### PR TITLE
ci: opt-in compile/execute split for npu-xrt tests (pilot/RFC)

### DIFF
--- a/.github/workflows/scripts/cache_experiment.sh
+++ b/.github/workflows/scripts/cache_experiment.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# EXPERIMENT (TEMPORARY -- removed before any cache PR is finalized).
+#
+# SEPARATE ARM from split_experiment.sh (untouched, independently readable). Proves a
+# per-test, content-addressed xclbin cache on real Ryzen AI hardware.
+#
+# THIS ARM IS MEASUREMENT-ONLY (INTRA-RUN). It demonstrates reuse WITHIN one invocation
+# (cold->warm) and proves the cache is SAFE. Genuine cross-*job* persistence (actions/cache)
+# is deliberately deferred to a follow-up so the stripped, self-contained version is validated
+# on AMD's CI first -- see the commented-out cache steps in zz-experiment-split-validate.yml.
+#
+#   [A] cold vs warm (INTRA-RUN reuse) : cold = compile every converted npu-xrt test and
+#        POPULATE the cache; warm = wipe build artifacts, RESTORE from cache, compile only the
+#        misses (~0). NOTE: warm reuses what COLD just wrote in THIS run -- it quantifies the
+#        compile time a cache WOULD avoid; it is NOT cross-job persistence (see prehit below).
+#   [B] hit is CORRECT : after the warm restore, EXECUTE every test and require the SAME verdict
+#        set as cold. A cache hit must be a correct run, not merely a fast one.
+#   [C] invalidation self-test (row 4, the load-bearing guard): cache a good kernel -> mutate its
+#        source -> assert (1) key CHANGES, (2) cache MISSES, (3) the mutated build COMPILES cleanly
+#        then EXECUTES to FAIL (a broken kernel cannot ride a stale hit / mask a regression).
+#
+# Correctness is read from lit's `-o` JSON report, never `-s`-suppressed stdout. Guards FAIL LOUD
+# not only on TOTAL vacuity but on (a) PARTIAL coverage loss (an enumerated test silently missing
+# from the report -- lit only WARNS on an unresolved input) and (b) a missing positive PASS baseline
+# (comparing two uniformly-broken sides proves nothing).
+set -uo pipefail
+
+TREE="${TREE:-$PWD}"
+BUILD="${BUILD:-$TREE/build}"
+NPU_XRT_SRC="$TREE/test/npu-xrt"
+OUT="${OUT:-$TREE/cache-experiment-out}"
+# CACHE_DIR MUST live outside $OUT so the start-of-run `rm -rf $OUT` cannot wipe it.
+CACHE_DIR="${CACHE_DIR:-$TREE/xclbin-cache-exp}"
+JOBS="${JOBS_COMPILE:-10}"
+LIT="${LIT:-lit}"
+export PATH="$BUILD/bin:${AIEBU_DIR:+$AIEBU_DIR:}$PATH"
+
+[ -n "$OUT" ] && rm -rf "$OUT"; mkdir -p "$OUT" "$CACHE_DIR"   # fresh OUT: never parse a stale prior-run report
+find "$CACHE_DIR" -maxdepth 1 -name '*.tmp.*' -exec rm -rf {} + 2>/dev/null || true  # sweep orphaned atomic-save temps
+
+fail=0
+summary="$OUT/summary.txt"; : > "$summary"
+note(){ echo "::notice::$*"; echo "$*" >> "$summary"; }
+bad(){  echo "::error::$*";  echo "ASSERT-FAIL: $*" >> "$summary"; fail=1; }
+
+# Abort safety-net for the row-4 self-test. Revert via a byte-exact BACKUP, not `git checkout`
+# (which would also discard a developer's unrelated uncommitted edits to that file on a shared
+# local worktree). $_MUT/$_BAK track the in-flight mutated file + its backup.
+_MUT=""; _BAK=""
+restore_mut(){ [ -n "$_MUT" ] && [ -f "$_BAK" ] && cp -f "$_BAK" "$_MUT"; rm -f "$_BAK"; _MUT=""; _BAK=""; }
+trap 'restore_mut' EXIT
+
+# ---- verdicts from lit's JSON report (never from -s-suppressed stdout) ----
+codes(){ python3 - "$1" <<'PY'
+import sys, json, re
+try: d=json.load(open(sys.argv[1]))
+except Exception: sys.exit(0)
+for t in d.get('tests', []):
+    n=t['name'].split('::')[-1].strip()
+    m=re.match(r'npu-xrt/(.+?)/run\.lit', n)
+    if m: n=m.group(1)
+    print(n, t['code'])
+PY
+}
+count(){      codes "$1" | awk -v c="$2" '$2==c' | wc -l; }
+total(){      codes "$1" | wc -l; }
+verdict_of(){ codes "$1" | awk -v n="$2" '$1==n{print $2; exit}'; }  # verdict of the NAMED test
+elapsed(){    awk -v a="$1" -v b="$2" 'BEGIN{printf "%.3f", b-a}'; } # no bc dependency
+# Every enumerated test MUST appear in a phase's report, else that test's claim was silently
+# never exercised (lit only WARNS, not errors, on an input that resolves to no test).
+assert_coverage(){ # $1 report.json  $2 label
+  local present t missing=()
+  present="$(codes "$1" | awk '{print $1}')"
+  for t in "${T[@]}"; do grep -qxF "$t" <<<"$present" || missing+=("$t"); done
+  [ "${#missing[@]}" -eq 0 ] || bad "$2: ${#missing[@]}/${#T[@]} enumerated tests missing from report (silent coverage loss): ${missing[*]}"
+}
+
+# ---- content-addressed keying ----
+# GLOBAL fingerprint folded into EVERY per-test key. MUST change whenever codegen could change,
+# else a compiler change rides a stale xclbin (a broken pass masked -- worst case for a compiler
+# repo). CI sets TOOLCHAIN_KEY=<built commit> (sound SUPERSET; changes every commit). Cross-*commit*
+# reuse is intentionally absent (compiler rebuilt per commit); sound reuse is same-commit only.
+tc_key(){
+  { if [ -n "${TOOLCHAIN_KEY:-}" ]; then printf 'TK=%s\n' "$TOOLCHAIN_KEY"
+    else git -C "$TREE" rev-parse HEAD 2>/dev/null
+         command -v aiecc >/dev/null && sha256sum "$(command -v aiecc)" 2>/dev/null; fi
+    # runtime toolchain (Vitis/XRT) is OS-image state, NOT covered by the commit. Moot for the
+    # MEASUREMENT-ONLY (intra-run) experiment (same image within a run), but a FULL XRT/Vitis
+    # fingerprint is REQUIRED before re-enabling actions/cache -- fold the Vitis path as a start.
+    printf 'VITIS=%s\n' "${VITIS:-none}"
+    # shared codegen inputs outside per-test dirs
+    find "$TREE/runtime_lib/test_lib" -type f \
+         \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' -o -name '*.cc' \) -print0 2>/dev/null \
+      | sort -z | xargs -0 sha256sum 2>/dev/null
+  } | sha256sum | awk '{print $1}'
+}
+TCK="$(tc_key)"; note "global key (toolchain+shared): ${TCK:0:16}..."
+
+# Per-test key = hash(all source files under test/npu-xrt/<t> + global key).
+test_key(){ # $1 test
+  { find "$NPU_XRT_SRC/$1" -type f \
+        \( -name '*.cc' -o -name '*.cpp' -o -name '*.c' -o -name '*.h' -o -name '*.hpp' \
+           -o -name '*.mlir' -o -name '*.py' -o -name 'run.lit' -o -name '*.txt' \) -print0 \
+      | sort -z | xargs -0 sha256sum 2>/dev/null
+    printf 'TCK=%s\n' "$TCK"
+  } | sha256sum | awk '{print $1}'
+}
+slot(){ echo "$CACHE_DIR/$(test_key "$1")"; }
+
+wipe_artifacts(){ find "$BUILD/test/npu-xrt" \
+  \( -name '*.xclbin' -o -name 'test.exe' -o -name '*insts*.bin' -o -name '*.o' \
+     -o -name 'aie_arch.mlir' -o -name '*.prj' -o -name 'ctrlpkt*.bin' \) -prune -exec rm -rf {} + 2>/dev/null; }
+wipe_one(){ [ -d "$BUILD/test/npu-xrt/$1" ] && find "$BUILD/test/npu-xrt/$1" \
+  \( -name '*.xclbin' -o -name 'test.exe' -o -name '*insts*.bin' -o -name '*.o' \
+     -o -name 'aie_arch.mlir' -o -name '*.prj' -o -name 'ctrlpkt*.bin' \) -prune -exec rm -rf {} + 2>/dev/null; true; }
+
+# cache_save: ATOMIC (temp dir + rename) so an interrupted copy never leaves a partial slot.
+cache_save(){ local s tmp; s="$(slot "$1")"; tmp="${s}.tmp.$$"
+  rm -rf "$tmp"; mkdir -p "$tmp"
+  if cp -a "$BUILD/test/npu-xrt/$1/." "$tmp/"; then rm -rf "$s"; mv "$tmp" "$s"
+  else rm -rf "$tmp"; return 1; fi; }
+# cache_restore: a partial copy is wiped and treated as a MISS (recompile), never a stale ride.
+cache_restore(){ local s; s="$(slot "$1")"; [ -d "$s" ] || return 1
+  mkdir -p "$BUILD/test/npu-xrt/$1"
+  cp -a "$s/." "$BUILD/test/npu-xrt/$1/" || { wipe_one "$1"; return 1; }; }
+
+run_lit(){ # $1 mode(""/compile/execute)  $2 outfile  $3.. test build-paths
+  local mode="$1" of="$2"; shift 2
+  AIE_NPU_SPLIT="$mode" "$LIT" "$@" -j"$JOBS" -sv --time-tests -o "$of.json" > "$of" 2>&1
+}
+
+mapfile -t T < <(cd "$NPU_XRT_SRC" && grep -rl '%npu_run%' . --include=run.lit \
+                   | sed 's|^\./||;s|/run\.lit$||' | sort)
+note "converted npu-xrt tests: ${#T[@]}"
+[ "${#T[@]}" -gt 0 ] || { bad "0 converted tests discovered"; echo "::error::experiment aborted"; exit 1; }
+# every enumerated test must exist under $BUILD, else lit silently drops it and the count-based
+# guards below would pass on a smaller, unnoticed population.
+P=(); miss_build=()
+for t in "${T[@]}"; do
+  if [ -d "$BUILD/test/npu-xrt/$t" ]; then P+=("$BUILD/test/npu-xrt/$t"); else miss_build+=("$t"); fi
+done
+[ "${#miss_build[@]}" -eq 0 ] || bad "enumerated tests missing under \$BUILD (build lags source): ${miss_build[*]}"
+
+echo "##################### [A] cold vs warm (INTRA-RUN reuse) #####################"
+prehit=0; for t in "${T[@]}"; do [ -d "$(slot "$t")" ] && prehit=$((prehit+1)); done
+note "pre-existing cache slots before this run: ${prehit}/${#T[@]}  (0 expected -- actions/cache is stripped; this arm measures INTRA-run reuse only)"
+
+# COLD: clean root -> compile everything -> execute (reference verdicts) -> populate cache.
+wipe_artifacts
+t0=$(date +%s.%N); run_lit compile "$OUT/cold_compile.log" "${P[@]}"; t1=$(date +%s.%N)
+cold=$(elapsed "$t0" "$t1")
+assert_coverage "$OUT/cold_compile.log.json" "cold compile"
+run_lit execute "$OUT/cold_execute.log" "${P[@]}"
+assert_coverage "$OUT/cold_execute.log.json" "cold execute"
+[ "$(count "$OUT/cold_execute.log.json" PASS)" -gt 0 ] || bad "cold execute: 0 PASS -- device/toolchain broken; [A]/[B] would be vacuous"
+for t in "${T[@]}"; do cache_save "$t"; done
+note "cold: compile-all=${cold}s  ($(count "$OUT/cold_compile.log.json" PASS) pass / $(count "$OUT/cold_compile.log.json" UNSUPPORTED) unsupp)"
+
+# WARM: wipe -> restore from cache -> compile only misses (~0). realhits requires a real device
+# artifact so the 20 UNSUPPORTED no-op slots cannot inflate the reuse claim.
+wipe_artifacts
+hits=0; realhits=0; miss=()
+for t in "${T[@]}"; do
+  if cache_restore "$t"; then hits=$((hits+1))
+     find "$BUILD/test/npu-xrt/$t" \( -name '*.xclbin' -o -name '*insts*.bin' \) 2>/dev/null | grep -q . \
+       && realhits=$((realhits+1))
+  else miss+=("$t"); fi
+done
+mp=(); for t in "${miss[@]}"; do mp+=("$BUILD/test/npu-xrt/$t"); done
+t0=$(date +%s.%N)
+if [ "${#mp[@]}" -gt 0 ]; then run_lit compile "$OUT/warm_compile.log" "${mp[@]}"; else : > "$OUT/warm_compile.log"; fi
+t1=$(date +%s.%N); warm=$(elapsed "$t0" "$t1")
+note "warm (intra-run): hits=${hits}/${#T[@]} (real compiled-artifact hits=${realhits}; rest unsupported/no-op)  misses=${#miss[@]}  compile-misses=${warm}s"
+[ "$realhits" -gt 0 ] || bad "cache: 0 REAL compiled-artifact hits on an unchanged tree -- reuse not working"
+
+echo "##################### [B] cache hit is CORRECT (execute restored) ############"
+run_lit execute "$OUT/warm_execute.log" "${P[@]}"
+assert_coverage "$OUT/warm_execute.log.json" "warm execute"
+[ "$(count "$OUT/warm_execute.log.json" PASS)" -gt 0 ] || bad "warm execute: 0 PASS -- baseline broken; [B] would be vacuous"
+python3 - "$OUT" >> "$summary" 2>&1 <<'PY'
+import sys, os, json, re
+out=sys.argv[1]
+def parse(f):
+    d={}
+    try: j=json.load(open(os.path.join(out,f)))
+    except Exception: return d
+    for t in j.get('tests',[]):
+        n=t['name'].split('::')[-1].strip()
+        m=re.match(r'npu-xrt/(.+?)/run\.lit', n)
+        if m: n=m.group(1)
+        d[n]=t['code']
+    return d
+cold=parse('cold_execute.log.json'); warm=parse('warm_execute.log.json')
+tests=sorted(set(cold)|set(warm)); mm=[t for t in tests if cold.get(t,'-')!=warm.get(t,'-')]
+if not tests:
+    print("[cache-correct] ERROR: 0 tests parsed -- cannot compare cold vs warm execute (vacuous)"); sys.exit(2)
+print(f"[cache-correct] {len(tests)} tests, cold-execute vs warm(restored)-execute mismatches: {len(mm)}")
+for t in mm: print(f"  MISMATCH {t}: cold={cold.get(t,'-')} warm={warm.get(t,'-')}")
+sys.exit(1 if mm else 0)
+PY
+[ $? -eq 0 ] || bad "cache hit changed a verdict: restored artifacts do not run identically to a fresh compile"
+
+echo "##################### [C] invalidation self-test (row 4) #####################"
+INV_T="add_one_func_link_with_peano"; KF="$NPU_XRT_SRC/$INV_T/add_one_kernel.cc"; BP="$BUILD/test/npu-xrt/$INV_T"
+[ -d "$BP" ] || bad "row4: $INV_T not present under \$BUILD"
+# GOOD baseline: compile cleanly + cache + execute PASS.
+wipe_one "$INV_T"; run_lit compile "$OUT/inv_good_c.log" "$BP"
+[ "$(verdict_of "$OUT/inv_good_c.log.json" "$INV_T")" = PASS ] || bad "row4: good $INV_T did not COMPILE"
+cache_save "$INV_T"
+run_lit execute "$OUT/inv_good_e.log" "$BP"
+[ "$(verdict_of "$OUT/inv_good_e.log.json" "$INV_T")" = PASS ] || bad "row4 precondition: good $INV_T did not EXECUTE-PASS"
+k_good="$(test_key "$INV_T")"
+# mutate (wrong output). Back up the exact bytes + arm the trap BEFORE touching the file.
+_MUT="$KF"; _BAK="$OUT/.kf_backup"; cp -f "$KF" "$_BAK"
+sed -i "s|in\[i\] + 1|in\[i\] + 2|g" "$KF"
+grep -qF 'in[i] + 2' "$KF" || bad "row4: sed did not match $KF (source reformatted?) -- mutation is a no-op"
+k_bad="$(test_key "$INV_T")"
+# (1) key must change on mutation
+if [ "$k_good" != "$k_bad" ]; then note "row4: key changed on mutation (${k_good:0:12} -> ${k_bad:0:12})"
+else bad "row4: content key UNCHANGED after kernel mutation -> cache would ride stale"; fi
+# (2) mutated source must MISS the cache
+[ -d "$CACHE_DIR/$k_bad" ] && bad "row4: mutated key already present in cache -> stale hit"
+# (3) cache-aware build of the mutated test: MISS -> COMPILE cleanly -> EXECUTE to FAIL.
+wipe_one "$INV_T"
+if cache_restore "$INV_T"; then rode=1; cc="(rode)"
+else rode=0; run_lit compile "$OUT/inv_bad_c.log" "$BP"; cc="$(verdict_of "$OUT/inv_bad_c.log.json" "$INV_T")"; fi
+run_lit execute "$OUT/inv_bad_e.log" "$BP"
+bad_v="$(verdict_of "$OUT/inv_bad_e.log.json" "$INV_T")"
+restore_mut   # revert from byte-backup now; EXIT trap is the abort safety-net
+[ "$rode" -eq 0 ] || bad "row4: mutated source RESTORED a cached slot (stale ride) -- key did not discriminate"
+[ "$cc" = PASS ] || bad "row4: mutated kernel did not COMPILE cleanly (compile=$cc) -- cannot attribute the FAIL to the execute layer"
+if [ "$bad_v" = FAIL ]; then note "row4 OK: mutated kernel MISSED cache, compiled, and FAILED on device (no stale ride, no masking)"
+else bad "row4: mutated kernel verdict=$bad_v (expected FAIL) -- cache masked a regression"; fi
+
+echo "##################### summary #####################"
+{ echo "=== cache reuse (s), INTRA-RUN ==="
+  echo "cold compile-all    = $cold"
+  echo "warm compile-misses = $warm   (real hits=${realhits}/${#T[@]})"
+  echo "cross-JOB reuse (actions/cache): DISABLED this run (stripped); pre-existing slots=${prehit}/${#T[@]}"
+} | tee -a "$summary"
+echo "===== RESULT ====="; cat "$summary"
+[ "$fail" -eq 0 ] && { note "ALL CACHE ASSERTIONS PASSED (incl. invalidation self-test)"; exit 0; } \
+                  || { echo "::error::cache experiment assertions FAILED"; exit 1; }

--- a/.github/workflows/scripts/cache_experiment.sh
+++ b/.github/workflows/scripts/cache_experiment.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
 # EXPERIMENT (TEMPORARY -- removed before any cache PR is finalized).
 #
 # SEPARATE ARM from split_experiment.sh (untouched, independently readable). Proves a
@@ -115,7 +119,10 @@ wipe_one(){ [ -d "$BUILD/test/npu-xrt/$1" ] && find "$BUILD/test/npu-xrt/$1" \
      -o -name 'aie_arch.mlir' -o -name '*.prj' -o -name 'ctrlpkt*.bin' \) -prune -exec rm -rf {} + 2>/dev/null; true; }
 
 # cache_save: ATOMIC (temp dir + rename) so an interrupted copy never leaves a partial slot.
-cache_save(){ local s tmp; s="$(slot "$1")"; tmp="${s}.tmp.$$"
+# An UNSUPPORTED test never executes, so lit never creates its exec dir -- nothing to cache, not an
+# error (realhits, not hits, is what the reuse claim is gated on).
+cache_save(){ local s tmp; [ -d "$BUILD/test/npu-xrt/$1" ] || return 1
+  s="$(slot "$1")"; tmp="${s}.tmp.$$"
   rm -rf "$tmp"; mkdir -p "$tmp"
   if cp -a "$BUILD/test/npu-xrt/$1/." "$tmp/"; then rm -rf "$s"; mv "$tmp" "$s"
   else rm -rf "$tmp"; return 1; fi; }
@@ -133,13 +140,13 @@ mapfile -t T < <(cd "$NPU_XRT_SRC" && grep -rl '%npu_run%' . --include=run.lit \
                    | sed 's|^\./||;s|/run\.lit$||' | sort)
 note "converted npu-xrt tests: ${#T[@]}"
 [ "${#T[@]}" -gt 0 ] || { bad "0 converted tests discovered"; echo "::error::experiment aborted"; exit 1; }
-# every enumerated test must exist under $BUILD, else lit silently drops it and the count-based
-# guards below would pass on a smaller, unnoticed population.
-P=(); miss_build=()
-for t in "${T[@]}"; do
-  if [ -d "$BUILD/test/npu-xrt/$t" ]; then P+=("$BUILD/test/npu-xrt/$t"); else miss_build+=("$t"); fi
-done
-[ "${#miss_build[@]}" -eq 0 ] || bad "enumerated tests missing under \$BUILD (build lags source): ${miss_build[*]}"
+# Feed lit BUILD-tree paths: it resolves each one through test_exec_root back to the source tree,
+# so the per-test build dir need NOT exist first (CMake never creates test/npu-xrt/<t>; lit makes it
+# on the test's first run). Only a CONFIGURED build is a real precondition; a test that silently
+# resolves to nothing is caught downstream by assert_coverage against the JSON report.
+[ -f "$BUILD/test/lit.site.cfg.py" ] \
+  || { bad "no configured build at \$BUILD ($BUILD/test/lit.site.cfg.py missing)"; echo "::error::experiment aborted"; exit 1; }
+P=(); for t in "${T[@]}"; do P+=("$BUILD/test/npu-xrt/$t"); done
 
 echo "##################### [A] cold vs warm (INTRA-RUN reuse) #####################"
 prehit=0; for t in "${T[@]}"; do [ -d "$(slot "$t")" ] && prehit=$((prehit+1)); done
@@ -202,7 +209,7 @@ PY
 
 echo "##################### [C] invalidation self-test (row 4) #####################"
 INV_T="add_one_func_link_with_peano"; KF="$NPU_XRT_SRC/$INV_T/add_one_kernel.cc"; BP="$BUILD/test/npu-xrt/$INV_T"
-[ -d "$BP" ] || bad "row4: $INV_T not present under \$BUILD"
+[ -f "$KF" ] || bad "row4: kernel $KF not found (test renamed/moved?)"
 # GOOD baseline: compile cleanly + cache + execute PASS.
 wipe_one "$INV_T"; run_lit compile "$OUT/inv_good_c.log" "$BP"
 [ "$(verdict_of "$OUT/inv_good_c.log.json" "$INV_T")" = PASS ] || bad "row4: good $INV_T did not COMPILE"

--- a/.github/workflows/scripts/split_experiment.sh
+++ b/.github/workflows/scripts/split_experiment.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
 # EXPERIMENT (TEMPORARY -- removed before the split PR is finalized).
 #
 # Proves the compile/execute split on real Ryzen AI hardware and collects the numbers for the
@@ -79,12 +83,14 @@ assert_coverage(){ # $1 report.json  $2 label
   [ "${#missing[@]}" -eq 0 ] || bad "$2: ${#missing[@]}/${#T[@]} enumerated tests missing from report (silent coverage loss): ${missing[*]}"
 }
 
-# every enumerated test must exist under $BUILD, else lit silently drops it.
-P=(); miss_build=()
-for t in "${T[@]}"; do
-  if [ -d "$BUILD/test/npu-xrt/$t" ]; then P+=("$BUILD/test/npu-xrt/$t"); else miss_build+=("$t"); fi
-done
-[ "${#miss_build[@]}" -eq 0 ] || bad "enumerated tests missing under \$BUILD (build lags source): ${miss_build[*]}"
+# Feed lit BUILD-tree paths: it resolves each one through test_exec_root back to the source tree.
+# The per-test build dir need NOT exist first -- CMake never creates test/npu-xrt/<t> (test/
+# CMakeLists.txt only configures build/test/lit.site.cfg.py); lit makes it on the test's first run.
+# So the only real precondition is a CONFIGURED build. A test that silently resolves to nothing is
+# caught downstream by assert_coverage against the JSON report, which is the guard that matters.
+[ -f "$BUILD/test/lit.site.cfg.py" ] \
+  || { bad "no configured build at \$BUILD ($BUILD/test/lit.site.cfg.py missing)"; echo "::error::experiment aborted"; exit 1; }
+P=(); for t in "${T[@]}"; do P+=("$BUILD/test/npu-xrt/$t"); done
 
 run_mode(){ # $1 label  $2 AIE_NPU_SPLIT  $3 jobs  $4 outfile
   local t0 t1; t0=$(date +%s.%N)
@@ -159,7 +165,7 @@ else note "canary OK: 0/$ct converted tests passed execute-only on a wiped root 
 echo "##################### [3/4] no-masking fault injection ########"
 inject(){ # $1 test  $2 kernel  $3 sed-good  $4 sed-bad
   local KF="$NPU_XRT_SRC/$1/$2" BP="$BUILD/test/npu-xrt/$1"
-  [ -d "$BP" ] || { bad "inject $1: $BP not present under \$BUILD"; return; }
+  [ -f "$KF" ] || { bad "inject $1: kernel $KF not found (test renamed/moved?)"; return; }
   _MUT="$KF"; _BAK="$OUT/.inj_backup"; cp -f "$KF" "$_BAK"
   sed -i "s|$3|$4|g" "$KF"
   cmp -s "$_BAK" "$KF" && { bad "inject $1: mutation was a no-op (sed matched nothing -- source reformatted?)"; restore_mut; return; }

--- a/.github/workflows/scripts/split_experiment.sh
+++ b/.github/workflows/scripts/split_experiment.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# EXPERIMENT (TEMPORARY -- removed before the split PR is finalized).
+#
+# Proves the compile/execute split on real Ryzen AI hardware and collects the numbers for the
+# #3198 CI/CD discussion. It tests correctness INCLUDING the deliberate-failure paths:
+#
+#   1. whole == split       : every converted npu-xrt test gives the same verdict whole-test vs
+#                             split (compile phase + execute phase).
+#   2. fresh-root canary     : after wiping compiled artifacts, execute-only must produce NO positive
+#                             outcome for any converted test. A PASS/XPASS here = the execute phase
+#                             rode a stale artifact -> hard error.
+#   3. no-masking injection  : a mutated kernel (still valid C++, wrong output) must COMPILE cleanly
+#                             yet FAIL at EXECUTE in BOTH whole and split -> the split cannot mask a
+#                             regression. Reverted afterward.
+#   4. timing                : whole (serial capacity-1) vs split (parallel compile + serial execute).
+#
+# Verdicts are read from lit's `-o` JSON report, never `-s`-suppressed stdout (which prints a line
+# only for FAILING tests). Guards FAIL LOUD not only on TOTAL vacuity but on (a) PARTIAL coverage loss
+# (an enumerated test silently absent from the report -- lit only WARNS on an unresolved input) and
+# (b) a missing positive PASS baseline (comparing two uniformly-broken sides proves nothing).
+set -uo pipefail
+
+TREE="${TREE:-$PWD}"
+BUILD="${BUILD:-$TREE/build}"
+NPU_XRT_SRC="$TREE/test/npu-xrt"
+OUT="${OUT:-$TREE/split-experiment-out}"
+JOBS_COMPILE="${JOBS_COMPILE:-10}"
+JOBS_WHOLE="${JOBS_WHOLE:-12}"
+LIT="${LIT:-lit}"
+export PATH="$BUILD/bin:${AIEBU_DIR:+$AIEBU_DIR:}$PATH"
+
+[ -n "$OUT" ] && rm -rf "$OUT"; mkdir -p "$OUT"   # fresh OUT: never parse a stale prior-run report
+
+fail=0
+summary="$OUT/summary.txt"; : > "$summary"
+note(){ echo "::notice::$*"; echo "$*" >> "$summary"; }
+bad(){  echo "::error::$*";  echo "ASSERT-FAIL: $*" >> "$summary"; fail=1; }
+
+# Abort safety-net for the fault-injection. Revert via a byte-exact BACKUP, not `git checkout`
+# (which would also discard a developer's unrelated uncommitted edits to that file on a shared
+# local worktree). $_MUT/$_BAK track the in-flight mutated file + its backup.
+_MUT=""; _BAK=""
+restore_mut(){ [ -n "$_MUT" ] && [ -f "$_BAK" ] && cp -f "$_BAK" "$_MUT"; rm -f "$_BAK"; _MUT=""; _BAK=""; }
+trap 'restore_mut' EXIT
+
+# "<testname> <CODE>" per test from a lit JSON report (-o). Empty if unreadable.
+codes(){ python3 - "$1" <<'PY'
+import sys, json, re
+try: d = json.load(open(sys.argv[1]))
+except Exception: sys.exit(0)
+for t in d.get('tests', []):
+    n = t['name'].split('::')[-1].strip()
+    m = re.match(r'npu-xrt/(.+?)/run\.lit', n)
+    if m: n = m.group(1)
+    print(n, t['code'])
+PY
+}
+count(){      codes "$1" | awk -v c="$2" '$2==c' | wc -l; }
+total(){      codes "$1" | wc -l; }
+verdict_of(){ codes "$1" | awk -v n="$2" '$1==n{print $2; exit}'; }  # verdict of the NAMED test
+elapsed(){    awk -v a="$1" -v b="$2" 'BEGIN{printf "%.3f", b-a}'; } # no bc dependency
+
+mapfile -t T < <(cd "$NPU_XRT_SRC" && grep -rl '%npu_run%' . --include=run.lit \
+                   | sed 's|^\./||;s|/run\.lit$||' | sort)
+note "converted npu-xrt tests: ${#T[@]}"
+[ "${#T[@]}" -gt 0 ] || { bad "0 converted tests discovered"; echo "::error::experiment aborted"; exit 1; }
+TLIST="$OUT/.tlist"; printf '%s\n' "${T[@]}" > "$TLIST"
+# codes_enum/count_enum/total_enum: restrict to the CONVERTED tests only, so a non-converted "bonus"
+# test that happens to share a dir (lit may discover more tests than we enumerated) cannot inflate a
+# count or produce a false canary PASS.
+codes_enum(){ awk 'NR==FNR{keep[$1]=1;next} keep[$1]' "$TLIST" <(codes "$1"); }
+count_enum(){ codes_enum "$1" | awk -v c="$2" '$2==c' | wc -l; }
+total_enum(){ codes_enum "$1" | wc -l; }
+# every enumerated test MUST appear in a phase's report, else its claim was silently never exercised.
+assert_coverage(){ # $1 report.json  $2 label
+  local present t missing=()
+  present="$(codes "$1" | awk '{print $1}')"
+  for t in "${T[@]}"; do grep -qxF "$t" <<<"$present" || missing+=("$t"); done
+  [ "${#missing[@]}" -eq 0 ] || bad "$2: ${#missing[@]}/${#T[@]} enumerated tests missing from report (silent coverage loss): ${missing[*]}"
+}
+
+# every enumerated test must exist under $BUILD, else lit silently drops it.
+P=(); miss_build=()
+for t in "${T[@]}"; do
+  if [ -d "$BUILD/test/npu-xrt/$t" ]; then P+=("$BUILD/test/npu-xrt/$t"); else miss_build+=("$t"); fi
+done
+[ "${#miss_build[@]}" -eq 0 ] || bad "enumerated tests missing under \$BUILD (build lags source): ${miss_build[*]}"
+
+run_mode(){ # $1 label  $2 AIE_NPU_SPLIT  $3 jobs  $4 outfile
+  local t0 t1; t0=$(date +%s.%N)
+  AIE_NPU_SPLIT="$2" "$LIT" "${P[@]}" -j"$3" -sv --time-tests -o "$4.json" > "$4" 2>&1
+  t1=$(date +%s.%N); elapsed "$t0" "$t1" > "$4.wall"
+  note "$1: wall=$(cat "$4.wall")s  $(count "$4.json" PASS) pass / $(count "$4.json" FAIL) fail / $(count "$4.json" UNSUPPORTED) unsupp"
+}
+
+wipe_artifacts(){ find "$BUILD/test/npu-xrt" \
+  \( -name '*.xclbin' -o -name 'test.exe' -o -name '*insts*.bin' -o -name '*.o' \
+     -o -name 'aie_arch.mlir' -o -name '*.prj' -o -name 'ctrlpkt*.bin' \) -prune -exec rm -rf {} + 2>/dev/null; }
+
+echo "##################### [1/4] whole vs split ####################"
+run_mode WHOLE   ""        "$JOBS_WHOLE"   "$OUT/whole.log"
+run_mode COMPILE compile   "$JOBS_COMPILE" "$OUT/compile.log"
+run_mode EXECUTE execute   "$JOBS_WHOLE"   "$OUT/execute.log"
+assert_coverage "$OUT/whole.log.json"   "whole"
+assert_coverage "$OUT/compile.log.json" "compile"
+assert_coverage "$OUT/execute.log.json" "execute"
+[ "$(count_enum "$OUT/whole.log.json" PASS)" -gt 0 ] || bad "whole: 0 PASS among converted tests -- device/toolchain broken; parity/canary/injection would be vacuous"
+
+python3 - "$OUT" "$TLIST" >> "$summary" 2>&1 <<'PY'
+import sys, re, os, json
+out, tlist = sys.argv[1], sys.argv[2]
+keep = set(l.strip() for l in open(tlist) if l.strip())
+def parse(f):
+    d={}
+    try: j=json.load(open(os.path.join(out,f)))
+    except Exception: return d
+    for t in j.get('tests',[]):
+        n=t['name'].split('::')[-1].strip()
+        m=re.match(r'npu-xrt/(.+?)/run\.lit', n)
+        if m: n=m.group(1)
+        if n in keep: d[n]=t['code']
+    return d
+# normalize any code into 3 buckets so a shared TIMEOUT/UNRESOLVED isn't a false MISMATCH,
+# while PASS-vs-not-PASS (the distinction that matters) is preserved.
+def norm(code):
+    if code == 'PASS': return 'PASS'
+    if code in ('UNSUPPORTED','-'): return 'UNSUPPORTED'
+    return 'NONPASS'
+w,c,e=parse('whole.log.json'),parse('compile.log.json'),parse('execute.log.json')
+tests=sorted(set(w)|set(c)|set(e)); mm=[]
+if not tests:
+    print("[compare] ERROR: 0 converted tests parsed -- cannot validate whole==split (vacuous)")
+    sys.exit(2)
+for t in tests:
+    W=w.get(t,'-'); C=c.get(t,'-'); E=e.get(t,'-')
+    if 'UNSUPPORTED' in (C,E): S='UNSUPPORTED'
+    elif C=='PASS' and E=='PASS': S='PASS'
+    else: S='NONPASS'
+    if norm(W) != S:
+        mm.append((t,W,C,E,S))
+print(f"[compare] {len(tests)} converted tests, mismatches whole-vs-split: {len(mm)}")
+for t,W,C,E,S in mm: print(f"  MISMATCH {t}: whole={W} compile={C} execute={E} -> split={S}")
+sys.exit(1 if mm else 0)
+PY
+[ $? -eq 0 ] || bad "whole != split for one or more converted tests (see compare above)"
+
+echo "##################### [2/4] fresh-root canary #################"
+wipe_artifacts
+run_mode CANARY-EXECUTE-ONLY execute "$JOBS_WHOLE" "$OUT/canary.log"
+assert_coverage "$OUT/canary.log.json" "canary"
+ct=$(total_enum "$OUT/canary.log.json")
+[ "$ct" -gt 0 ] || bad "canary: 0 converted tests in report (would be vacuous)"
+neg=$(( $(count_enum "$OUT/canary.log.json" FAIL) + $(count_enum "$OUT/canary.log.json" UNSUPPORTED) \
+       + $(count_enum "$OUT/canary.log.json" UNRESOLVED) + $(count_enum "$OUT/canary.log.json" TIMEOUT) ))
+pos=$(( ct - neg ))
+if [ "$pos" -ne 0 ]; then bad "canary: $pos converted test(s) produced a POSITIVE outcome execute-only on a wiped root (stale-artifact ride)"
+else note "canary OK: 0/$ct converted tests passed execute-only on a wiped root (no stale ride)"; fi
+
+echo "##################### [3/4] no-masking fault injection ########"
+inject(){ # $1 test  $2 kernel  $3 sed-good  $4 sed-bad
+  local KF="$NPU_XRT_SRC/$1/$2" BP="$BUILD/test/npu-xrt/$1"
+  [ -d "$BP" ] || { bad "inject $1: $BP not present under \$BUILD"; return; }
+  _MUT="$KF"; _BAK="$OUT/.inj_backup"; cp -f "$KF" "$_BAK"
+  sed -i "s|$3|$4|g" "$KF"
+  cmp -s "$_BAK" "$KF" && { bad "inject $1: mutation was a no-op (sed matched nothing -- source reformatted?)"; restore_mut; return; }
+  local wl="$OUT/inj_${1}_whole.log" sc="$OUT/inj_${1}_split_c.log" se="$OUT/inj_${1}_split_e.log"
+  AIE_NPU_SPLIT=""        "$LIT" "$BP" -j1 -sv -o "$wl.json" > "$wl" 2>&1
+  AIE_NPU_SPLIT=compile   "$LIT" "$BP" -j1 -sv -o "$sc.json" > "$sc" 2>&1
+  AIE_NPU_SPLIT=execute   "$LIT" "$BP" -j1 -sv -o "$se.json" > "$se" 2>&1
+  restore_mut
+  local wv cv ev; wv=$(verdict_of "$wl.json" "$1"); cv=$(verdict_of "$sc.json" "$1"); ev=$(verdict_of "$se.json" "$1")
+  [ -n "$wv" ] && [ -n "$cv" ] && [ -n "$ev" ] || { bad "inject $1: a verdict is missing (0 tests parsed -- would be vacuous)"; return; }
+  note "inject $1: whole=$wv split(compile=$cv,execute=$ev)"
+  # STRONG: mutated kernel must COMPILE cleanly (cv=PASS) yet FAIL at EXECUTE (ev=FAIL) in both paths,
+  # so a FAIL can't be a compile-error masquerading as an execute-layer catch.
+  { [ "$cv" = PASS ] && [ "$ev" = FAIL ] && [ "$wv" = FAIL ]; } \
+    || bad "inject $1: expected compile=PASS execute=FAIL whole=FAIL (got cv=$cv ev=$ev wv=$wv) -- fault not caught at execute layer, or compile-errored"
+}
+inject add_one_func_link_with_peano       add_one_kernel.cc "in\[i\] + 1" "in\[i\] + 2"
+inject add_one_scale_func_link_with_peano add_one_kernel.cc "in\[i\] + 1" "in\[i\] + 2"
+
+echo "##################### [4/4] timings + summary #################"
+{ echo "=== timing (s) ==="
+  echo "whole   = $(cat "$OUT/whole.log.wall" 2>/dev/null)"
+  echo "compile = $(cat "$OUT/compile.log.wall" 2>/dev/null)  (parallel -j$JOBS_COMPILE)"
+  echo "execute = $(cat "$OUT/execute.log.wall" 2>/dev/null)  (serial device)"
+} | tee -a "$summary"
+
+echo "===== RESULT ====="; cat "$summary"
+[ "$fail" -eq 0 ] && { note "ALL ASSERTIONS PASSED (incl. deliberate fails)"; exit 0; } \
+                   || { echo "::error::experiment assertions FAILED"; exit 1; }

--- a/.github/workflows/zz-experiment-split-validate.yml
+++ b/.github/workflows/zz-experiment-split-validate.yml
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
 # TEMPORARY EXPERIMENT WORKFLOW -- DO NOT MERGE. Removed before any split/cache PR
 # is finalized. Two INDEPENDENT arms on real Ryzen AI hardware, each proving
 # correctness INCLUDING its deliberate-failure paths so a silent regression is loud:

--- a/.github/workflows/zz-experiment-split-validate.yml
+++ b/.github/workflows/zz-experiment-split-validate.yml
@@ -1,0 +1,150 @@
+# TEMPORARY EXPERIMENT WORKFLOW -- DO NOT MERGE. Removed before any split/cache PR
+# is finalized. Two INDEPENDENT arms on real Ryzen AI hardware, each proving
+# correctness INCLUDING its deliberate-failure paths so a silent regression is loud:
+#   arm 1 (split_experiment.sh)  -- compile/execute split: whole==split parity,
+#          fresh-root canary, no-masking fault injection, whole-vs-split timing.
+#   arm 2 (cache_experiment.sh)  -- per-test content-addressed xclbin cache, MEASUREMENT-ONLY
+#          (intra-run cold->warm reuse + hit-is-correct + row-4 invalidation self-test). Genuine
+#          cross-JOB persistence (actions/cache) is DEFERRED: those steps are commented out below so
+#          the stripped, self-contained version is validated on CI FIRST, then re-enabled as a
+#          second test.
+# The arms run as separate steps sharing one build; results stay separately
+# attributable. This gathers the #3198 numbers (incl. Chess) without touching the
+# real workflow's default behaviour.
+name: EXPERIMENT split+cache validate (TEMPORARY)
+
+permissions:
+  contents: read
+
+# TEMPORARY / DO-NOT-MERGE. `pull_request` so a maintainer can run it on a Chess-capable runner by
+# approving the check (fork PRs on self-hosted runners are approval-gated); `workflow_dispatch` as a
+# fallback. The merge-hazard (a permanent 2nd per-PR device build if ever merged) is guarded ONLY by the
+# DO-NOT-MERGE marker + draft status + removal before the split PR is finalized -- so this file must never
+# reach a mergeable PR.
+on:
+  pull_request:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: exp-split-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
+  VITIS: /opt/ryzen_ai-1.3.0.1/vitis_aie_essentials
+  CMAKE_ARGS: |
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DXRT_ROOT=/opt/xilinx/xrt \
+            -DAIE_VITIS_COMPONENTS=AIE2;AIE2P \
+            -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON
+  LIT_OPTS: -sv --time-tests --timeout 600 --show-unsupported --show-excluded
+
+jobs:
+  experiment:
+    name: EXPERIMENT split validate
+    runs-on: ${{ matrix.runner_type }}
+    # Bound the hold on AMD's capacity-1 self-hosted device runner: a device-open
+    # hang or a wedged build must NOT sit until GitHub's 6h default. Covers build
+    # (~20m) + split arm + cache arm with headroom. (LIT_OPTS --timeout bounds only
+    # per-test lit hangs, not the build.)
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        runner_type: [ aie2-4col, aie2p-8col ]
+    env:
+      NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-exp-${{ matrix.runner_type }}-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          submodules: "true"
+
+      - name: Setup virtual environment / prerequisites
+        run: source ./utils/env_install.sh aie-venv --dev --extras
+
+      - name: Build mlir-aie from source (matched to this commit)
+        run: |
+          source aie-venv/bin/activate
+          OPENCV_CMAKE="-DOpenCV_DIR=$(pkg-config --variable=prefix opencv4)/lib/cmake/opencv4"
+          export EXTRA_CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python) $CMAKE_ARGS $OPENCV_CMAKE"
+          ./utils/build-mlir-aie-from-wheels.sh "" build mlir_aie
+
+      - name: Run split experiment (correctness incl. deliberate fails + timing)
+        run: |
+          sudo prlimit -lunlimited --pid $$
+          [ -f /opt/xilinx/xrt/setup.sh ] && source /opt/xilinx/xrt/setup.sh
+          source aie-venv/bin/activate
+          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
+          rm -rf "$NPU_CACHE_HOME"; mkdir -p "$NPU_CACHE_HOME"
+          export XRT_CONTEXT_CACHE_SIZE=2
+          TOTAL_MEM_GB=$(free -g | awk '/^Mem:/ {print $2}')
+          if [ "$TOTAL_MEM_GB" -lt 48 ]; then export JOBS_COMPILE=4 JOBS_WHOLE=4; else export JOBS_COMPILE=12 JOBS_WHOLE=12; fi
+          export TREE="$PWD" BUILD="$PWD/build" OUT="$PWD/split-experiment-out"
+          bash .github/workflows/scripts/split_experiment.sh
+
+      # ---- SEPARATE ARM: per-test content-addressed xclbin cache (MEASUREMENT-ONLY) ----
+      # actions/cache is DEFERRED. Validate the stripped, self-contained version (intra-run
+      # cold->warm reuse + row-4 safety) on AMD's CI FIRST, THEN re-enable cross-JOB persistence
+      # as a SECOND test. Before uncommenting, address the red-team findings:
+      #   (1) save step -> `if: success()` so a run whose hit-is-correct check FAILED can't persist
+      #       a known-bad slot that re-hits on a same-commit retry;
+      #   (2) SHA-pin actions/cache/{restore,save} (self-hosted device runners, house style);
+      #   (3) fold a full XRT/Vitis fingerprint into tc_key (git commit doesn't cover the OS-image
+      #       toolchain -> a runner-image upgrade between same-commit runs could serve a cross-ABI hit);
+      #   (4) add `id:` + surface `cache-hit` so a no-op cache service is visible, not silent.
+      #
+      # - name: Restore xclbin cache (cross-JOB, best-effort)   # DEFERRED -- second test
+      #   continue-on-error: true
+      #   uses: actions/cache/restore@v4                        # SHA-pin before enabling
+      #   with:
+      #     path: ${{ github.workspace }}/xclbin-cache-exp
+      #     key: xclbin-cache-${{ matrix.runner_type }}-${{ github.run_id }}
+      #     restore-keys: |
+      #       xclbin-cache-${{ matrix.runner_type }}-
+
+      - name: Run cache experiment (intra-run reuse + invalidation self-test)
+        run: |
+          sudo prlimit -lunlimited --pid $$
+          [ -f /opt/xilinx/xrt/setup.sh ] && source /opt/xilinx/xrt/setup.sh
+          source aie-venv/bin/activate
+          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
+          rm -rf "$NPU_CACHE_HOME"; mkdir -p "$NPU_CACHE_HOME"
+          export XRT_CONTEXT_CACHE_SIZE=2
+          TOTAL_MEM_GB=$(free -g | awk '/^Mem:/ {print $2}')
+          if [ "$TOTAL_MEM_GB" -lt 48 ]; then export JOBS_COMPILE=4; else export JOBS_COMPILE=12; fi
+          export TREE="$PWD" BUILD="$PWD/build" OUT="$PWD/cache-experiment-out"
+          export CACHE_DIR="$GITHUB_WORKSPACE/xclbin-cache-exp"
+          # toolchain fingerprint = built commit (invalidates every per-test key on a bump)
+          export TOOLCHAIN_KEY="${{ github.sha }}-${{ matrix.runner_type }}"
+          bash .github/workflows/scripts/cache_experiment.sh
+
+      # - name: Save xclbin cache (cross-JOB, best-effort)     # DEFERRED -- second test
+      #   if: success()   # NOT always(): never persist a slot from a run whose hit-is-correct check failed
+      #   continue-on-error: true
+      #   uses: actions/cache/save@v4                          # SHA-pin before enabling
+      #   with:
+      #     path: ${{ github.workspace }}/xclbin-cache-exp
+      #     key: xclbin-cache-${{ matrix.runner_type }}-${{ github.run_id }}
+
+      - name: Upload experiment data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: split-experiment-${{ matrix.runner_type }}
+          path: |
+            split-experiment-out/
+            cache-experiment-out/
+
+      - name: Cleanup NPU_CACHE_HOME
+        if: always()
+        run: rm -rf "$NPU_CACHE_HOME"

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -895,3 +895,24 @@ class LitConfigHelper:
         """
         for component in vitis_components:
             config_obj.available_features.add(f"aietools_{component.lower()}")
+
+
+def npu_split_parallelism_group(test):
+    """Per-test parallelism group for the compile/execute split.
+
+    Importable (module-level) so lit can pickle it to its parallel workers.
+    In AIE_NPU_SPLIT=compile a CONVERTED test (its RUN lines carry the %npu_run%
+    device marker, so it does no device work in the compile phase) runs
+    ungrouped/parallel; every other test -- including all unconverted ones --
+    keeps the capacity-1 ``npu-xrt`` group so its device execution stays
+    serialized. In any other mode all tests use ``npu-xrt``.
+    """
+    import os
+
+    if os.environ.get("AIE_NPU_SPLIT", "") != "compile":
+        return "npu-xrt"
+    try:
+        src = open(test.getSourcePath()).read()
+    except Exception:
+        return "npu-xrt"
+    return None if "%npu_run%" in src else "npu-xrt"

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -901,18 +901,39 @@ def npu_split_parallelism_group(test):
     """Per-test parallelism group for the compile/execute split.
 
     Importable (module-level) so lit can pickle it to its parallel workers.
-    In AIE_NPU_SPLIT=compile a CONVERTED test (its RUN lines carry the %npu_run%
-    device marker, so it does no device work in the compile phase) runs
-    ungrouped/parallel; every other test -- including all unconverted ones --
-    keeps the capacity-1 ``npu-xrt`` group so its device execution stays
-    serialized. In any other mode all tests use ``npu-xrt``.
+
+    In AIE_NPU_SPLIT=compile a CONVERTED test (a RUN line carries the %npu_run%
+    device marker, so it does no device work in the compile phase) leaves the
+    capacity-1 ``npu-xrt`` group.  A chess build joins the capacity-1
+    ``npu-split-chess-compile`` group instead of running ungrouped: chess peak
+    RSS is large enough to OOM the runner under parallel compiles, the same
+    reason programming_examples/lit.cfg.py serializes ``atb_chess``.  Every
+    other converted test runs ungrouped/parallel.
+
+    Every unconverted test -- and any test whose source cannot be read -- keeps
+    ``npu-xrt`` so its device execution stays serialized.  In any other mode all
+    tests use ``npu-xrt``.
     """
     import os
 
     if os.environ.get("AIE_NPU_SPLIT", "") != "compile":
         return "npu-xrt"
     try:
-        src = open(test.getSourcePath()).read()
+        with open(test.getSourcePath()) as f:
+            src = f.read()
     except Exception:
         return "npu-xrt"
-    return None if "%npu_run%" in src else "npu-xrt"
+
+    # Only a gating RUN line converts a test.  Matching the whole file would let
+    # a bare mention in a comment -- or a half-converted test whose device line
+    # lost its prefix -- leave the serialized lane while still driving the NPU.
+    converted = any(
+        "%npu_run%" in line for line in src.splitlines() if "RUN:" in line
+    )
+    if not converted:
+        return "npu-xrt"
+
+    for line in src.splitlines():
+        if "REQUIRES:" in line and "chess" in line:
+            return "npu-split-chess-compile"
+    return None

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -217,14 +217,31 @@ lit_config.parallelism_groups["npu-split-chess-compile"] = 1
 # compile phase runs them in parallel (see test/npu-xrt/lit.local.cfg); only the
 # device run stays in the capacity-1 npu-xrt group, which serializes the global
 # XRT hw_context pool that #2737 added the group to protect.
-# CONSTRAINT for converting a test: a line tagged with %npu_build%/%npu_run%
-# must be a single simple command with NO redirect (>), pipe (|), &&/;, or a
-# trailing FileCheck -- the ":" skip only neutralises a plain command; a redirect
-# would still truncate its target and a pipe would still run the downstream stage
-# on empty input. Redirect/pipe/FileCheck tests must stay whole-test (unconverted).
+# CONSTRAINT 1 (line shape) for converting a test: a line tagged with
+# %npu_build%/%npu_run% must be a single simple command with NO redirect (>), pipe
+# (|), &&/;, or a trailing FileCheck -- the ":" skip only neutralises a plain
+# command; a redirect would still truncate its target and a pipe would still run the
+# downstream stage on empty input. Redirect/pipe/FileCheck tests must stay
+# whole-test (unconverted).
+# CONSTRAINT 2 (artifact ownership): a converted test must not write a bare relative
+# artifact name that any OTHER test in its directory also writes. lit's cwd is the
+# directory (dirname(test.getExecPath())) but %t is per test FILE
+# (<execdir>/Output/<name>.tmp), so bare names like aie.xclbin are directory-scoped
+# while test identity is file-scoped. A whole-test run survives that because build
+# and run are adjacent lines and this group is capacity-1; the split is not -- it
+# moves produce->consume into a separate lit invocation and compiles ungrouped, so
+# two tests sharing a name would race in the compile phase and the execute phase
+# could run one test against the other's xclbin. Sibling tests count even when
+# unconverted: with no markers they run whole in BOTH passes. Directories whose
+# tests share names (xrt_handle_lifetime, reconfigure_loadpdi{,_persistent_memtile},
+# matmul_whole_array_dynamic) are therefore left unconverted; scoping their
+# artifacts to %t, as matmul_whole_array_dynamic already does for its xclbin/prj,
+# would make them convertible.
 _npu_split = os.environ.get("AIE_NPU_SPLIT", "")
 _npu_skip = ":"  # shell no-op; consumes the rest of a redirect/pipe-free line
-config.substitutions.append(("%npu_build%", _npu_skip if _npu_split == "execute" else ""))
+config.substitutions.append(
+    ("%npu_build%", _npu_skip if _npu_split == "execute" else "")
+)
 config.substitutions.append(("%npu_run%", _npu_skip if _npu_split == "compile" else ""))
 
 # shutil.which picks up the platform's executable suffix (.exe on Windows

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -200,6 +200,21 @@ lit_config.parallelism_groups["concurrency"] = 1
 # NPU XRT tests should run serially to avoid resource contention
 lit_config.parallelism_groups["npu-xrt"] = 1
 
+# Compile/execute split (opt-in, OFF by default). AIE_NPU_SPLIT selects which
+# half of a *converted* npu-xrt test runs:
+#   "compile" -> run the build lines (%npu_build%), skip the device run (%npu_run%)
+#   "execute" -> skip the build, run only the device lines against the compile
+#                phase's persisted artifacts
+#   unset     -> whole test, unchanged (both prefixes expand to nothing)
+# Build lines touch no device (aiecc/clang only generate MLIR/objects), so the
+# compile phase runs them in parallel (see test/npu-xrt/lit.local.cfg); only the
+# device run stays in the capacity-1 npu-xrt group, which serializes the global
+# XRT hw_context pool that #2737 added the group to protect.
+_npu_split = os.environ.get("AIE_NPU_SPLIT", "")
+_npu_skip = ":"  # shell no-op; consumes the (redirect-free) rest of the line
+config.substitutions.append(("%npu_build%", _npu_skip if _npu_split == "execute" else ""))
+config.substitutions.append(("%npu_run%", _npu_skip if _npu_split == "compile" else ""))
+
 # shutil.which picks up the platform's executable suffix (.exe on Windows
 # via PATHEXT) so the feature gate fires correctly on every OS.
 if shutil.which("aie-lsp-server", path=config.llvm_tools_dir) is not None:

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -200,6 +200,13 @@ lit_config.parallelism_groups["concurrency"] = 1
 # NPU XRT tests should run serially to avoid resource contention
 lit_config.parallelism_groups["npu-xrt"] = 1
 
+# A converted chess test leaves the capacity-1 npu-xrt group in the compile
+# phase, so it needs its own bound: chess peak RSS OOMs the runner under
+# parallel compiles. Capacity 1 matches the atb_chess precedent in
+# programming_examples/lit.cfg.py, so chess compiles stay exactly as serialized
+# as they are today; the split only stops them waiting behind the device lock.
+lit_config.parallelism_groups["npu-split-chess-compile"] = 1
+
 # Compile/execute split (opt-in, OFF by default). AIE_NPU_SPLIT selects which
 # half of a *converted* npu-xrt test runs:
 #   "compile" -> run the build lines (%npu_build%), skip the device run (%npu_run%)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -210,8 +210,13 @@ lit_config.parallelism_groups["npu-xrt"] = 1
 # compile phase runs them in parallel (see test/npu-xrt/lit.local.cfg); only the
 # device run stays in the capacity-1 npu-xrt group, which serializes the global
 # XRT hw_context pool that #2737 added the group to protect.
+# CONSTRAINT for converting a test: a line tagged with %npu_build%/%npu_run%
+# must be a single simple command with NO redirect (>), pipe (|), &&/;, or a
+# trailing FileCheck -- the ":" skip only neutralises a plain command; a redirect
+# would still truncate its target and a pipe would still run the downstream stage
+# on empty input. Redirect/pipe/FileCheck tests must stay whole-test (unconverted).
 _npu_split = os.environ.get("AIE_NPU_SPLIT", "")
-_npu_skip = ":"  # shell no-op; consumes the (redirect-free) rest of the line
+_npu_skip = ":"  # shell no-op; consumes the rest of a redirect/pipe-free line
 config.substitutions.append(("%npu_build%", _npu_skip if _npu_split == "execute" else ""))
 config.substitutions.append(("%npu_run%", _npu_skip if _npu_split == "compile" else ""))
 

--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin
 //

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin

--- a/test/npu-xrt/add_256_using_dma_op_no_double_buffering/run.lit
+++ b/test/npu-xrt/add_256_using_dma_op_no_double_buffering/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin

--- a/test/npu-xrt/add_314_using_dma_op/run.lit
+++ b/test/npu-xrt/add_314_using_dma_op/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/add_blockwrite/run.lit
+++ b/test/npu-xrt/add_blockwrite/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/add_maskwrite/run.lit
+++ b/test/npu-xrt/add_maskwrite/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/add_multi_arg_runlist/run.lit
+++ b/test/npu-xrt/add_multi_arg_runlist/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai_npu2
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --device-name=aie_add_1 --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %aiecc %backend_flags --device-name=aie_add_2 --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --get-xclbin --get-npu-insts --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=aie_add_1 --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=aie_add_2 --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --get-xclbin --get-npu-insts --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin

--- a/test/npu-xrt/add_one_cpp_aiecc/run.lit
+++ b/test/npu-xrt/add_one_cpp_aiecc/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_cpp_aiecc_xchesscc/run.lit
+++ b/test/npu-xrt/add_one_cpp_aiecc_xchesscc/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai, chess
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_ctrl_packet/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %host_link_flags %xrt_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %host_link_flags %xrt_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_func_link_with_chess/run.lit
+++ b/test/npu-xrt/add_one_func_link_with_chess/run.lit
@@ -11,12 +11,12 @@
 // core and populates link_files on the CoreOp, which the BCF emitter turns into
 // _include _file directives consumed by xbridge.
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu1% xchesscc_wrapper aie2  -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %run_on_npu2% xchesscc_wrapper aie2p -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% xchesscc_wrapper aie2  -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %run_on_npu2% xchesscc_wrapper aie2p -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_func_link_with_peano/run.lit
+++ b/test/npu-xrt/add_one_func_link_with_peano/run.lit
@@ -12,12 +12,15 @@
 // which the ldscript emitter turns into an INPUT() directive.  The Peano
 // copy loop copies the .o to the .prj tmpdir so lld can find it.
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu1% %PEANO_INSTALL_DIR/bin/clang --target=aie2-none-unknown-elf -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %run_on_npu2% %PEANO_INSTALL_DIR/bin/clang --target=aie2p-none-unknown-elf -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %aiecc --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// Build lines (%npu_build%) touch no device and run in the compile phase; the
+// device runs (%npu_run%) stay in the capacity-1 npu-xrt lane. Both prefixes are
+// empty in a normal (unsplit) run, so behaviour is unchanged by default.
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% %PEANO_INSTALL_DIR/bin/clang --target=aie2-none-unknown-elf -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %run_on_npu2% %PEANO_INSTALL_DIR/bin/clang --target=aie2p-none-unknown-elf -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %aiecc --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_objFifo/run.lit
+++ b/test/npu-xrt/add_one_objFifo/run.lit
@@ -3,12 +3,12 @@
 //
 // REQUIRES: ryzen_ai, xrt_python_bindings
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu1% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.bin
-// RUN: %run_on_npu2% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu1% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.bin
+// RUN: %npu_run% %run_on_npu2% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.bin

--- a/test/npu-xrt/add_one_objFifo_elf/run.lit
+++ b/test/npu-xrt/add_one_objFifo_elf/run.lit
@@ -3,12 +3,12 @@
 //
 // REQUIRES: ryzen_ai, xrt_python_bindings
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --xclbin-name=aie.xclbin --get-elf --elf-name=insts.elf ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf
-// RUN: %run_on_npu1% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.elf
-// RUN: %run_on_npu2% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.elf
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --xclbin-name=aie.xclbin --get-elf --elf-name=insts.elf ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf
+// RUN: %npu_run% %run_on_npu1% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.elf
+// RUN: %npu_run% %run_on_npu2% %python %S/test.py --xclbin aie.xclbin -k MLIR_AIE --instr insts.elf

--- a/test/npu-xrt/add_one_scale_func_link_with_chess/run.lit
+++ b/test/npu-xrt/add_one_scale_func_link_with_chess/run.lit
@@ -18,14 +18,14 @@
 //   2. scale_by_two(out, out, n)  — out[i] *= 2  (in-place, same buf for in and out)
 // Expected output: (input + 1) * 2.
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu1% xchesscc_wrapper aie2  -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %run_on_npu2% xchesscc_wrapper aie2p -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %run_on_npu1% xchesscc_wrapper aie2  -I %aietools/include -c %S/scale_kernel.cc -o ./scale_kernel.o
-// RUN: %run_on_npu2% xchesscc_wrapper aie2p -I %aietools/include -c %S/scale_kernel.cc -o ./scale_kernel.o
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% xchesscc_wrapper aie2  -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %run_on_npu2% xchesscc_wrapper aie2p -I %aietools/include -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %run_on_npu1% xchesscc_wrapper aie2  -I %aietools/include -c %S/scale_kernel.cc -o ./scale_kernel.o
+// RUN: %npu_build% %run_on_npu2% xchesscc_wrapper aie2p -I %aietools/include -c %S/scale_kernel.cc -o ./scale_kernel.o
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_scale_func_link_with_peano/run.lit
+++ b/test/npu-xrt/add_one_scale_func_link_with_peano/run.lit
@@ -18,14 +18,14 @@
 //   2. scale_by_two(out, out, n)  — out[i] *= 2  (in-place: same buffer for in and out)
 // Expected output: (input + 1) * 2.
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu1% %PEANO_INSTALL_DIR/bin/clang --target=aie2-none-unknown-elf  -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %run_on_npu2% %PEANO_INSTALL_DIR/bin/clang --target=aie2p-none-unknown-elf -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
-// RUN: %run_on_npu1% %PEANO_INSTALL_DIR/bin/clang --target=aie2-none-unknown-elf  -O2 -c %S/scale_kernel.cc -o ./scale_kernel.o
-// RUN: %run_on_npu2% %PEANO_INSTALL_DIR/bin/clang --target=aie2p-none-unknown-elf -O2 -c %S/scale_kernel.cc -o ./scale_kernel.o
-// RUN: %aiecc --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% %PEANO_INSTALL_DIR/bin/clang --target=aie2-none-unknown-elf  -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %run_on_npu2% %PEANO_INSTALL_DIR/bin/clang --target=aie2p-none-unknown-elf -O2 -c %S/add_one_kernel.cc -o ./add_one_kernel.o
+// RUN: %npu_build% %run_on_npu1% %PEANO_INSTALL_DIR/bin/clang --target=aie2-none-unknown-elf  -O2 -c %S/scale_kernel.cc -o ./scale_kernel.o
+// RUN: %npu_build% %run_on_npu2% %PEANO_INSTALL_DIR/bin/clang --target=aie2p-none-unknown-elf -O2 -c %S/scale_kernel.cc -o ./scale_kernel.o
+// RUN: %npu_build% %aiecc --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=aie.xclbin --get-npu-insts --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_two/run.lit
+++ b/test/npu-xrt/add_one_two/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai_npu2
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --xclbin-kernel-name=ADDONE --device-name=design1 --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %aiecc %backend_flags --xclbin-kernel-name=ADDTWO --device-name=design2 --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --get-xclbin --get-npu-insts --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --xclbin-kernel-name=ADDONE --device-name=design1 --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --xclbin-kernel-name=ADDTWO --device-name=design2 --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --get-xclbin --get-npu-insts --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin

--- a/test/npu-xrt/add_one_two_runlist/run.lit
+++ b/test/npu-xrt/add_one_two_runlist/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai_npu2
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --device-name=aie_add_1 --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %aiecc %backend_flags --device-name=aie_add_2 --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --get-xclbin --get-npu-insts --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=aie_add_1 --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=aie_add_2 --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --get-xclbin --get-npu-insts --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -3,12 +3,12 @@
 //
 // REQUIRES: ryzen_ai_npu2
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %aiecc %backend_flags --tmpdir=project1 --device-name=add_one --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.bin aie_arch.mlir
-// RUN: %aiecc %backend_flags --tmpdir=project2 --device-name=add_two --get-txn --txn-name=transaction.mlir --get-npu-insts --npu-insts-name=add_two_insts.bin aie_arch.mlir
-// RUN: aie-translate --aie-device-name=add_two -aie-npu-to-binary -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin
-// RUN: %run_on_npu1% ./test.exe -x add_one.xclbin --instr0 add_one_insts.bin -c add_two_cfg.bin --instr1 add_two_insts.bin
-// RUN: %run_on_npu2% ./test.exe -x add_one.xclbin --instr0 add_one_insts.bin -c add_two_cfg.bin --instr1 add_two_insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_build% %aiecc %backend_flags --tmpdir=project1 --device-name=add_one --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --get-xclbin --get-npu-insts --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.bin aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --tmpdir=project2 --device-name=add_two --get-txn --txn-name=transaction.mlir --get-npu-insts --npu-insts-name=add_two_insts.bin aie_arch.mlir
+// RUN: %npu_build% aie-translate --aie-device-name=add_two -aie-npu-to-binary -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x add_one.xclbin --instr0 add_one_insts.bin -c add_two_cfg.bin --instr1 add_two_insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x add_one.xclbin --instr0 add_one_insts.bin -c add_two_cfg.bin --instr1 add_two_insts.bin

--- a/test/npu-xrt/add_one_using_dma/run.lit
+++ b/test/npu-xrt/add_one_using_dma/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/cascade_flows/run.lit
+++ b/test/npu-xrt/cascade_flows/run.lit
@@ -3,9 +3,9 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel1.cc -o ./kernel1.o
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel2.cc -o ./kernel2.o
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel3.cc -o ./kernel3.o
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel1.cc -o ./kernel1.o
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel2.cc -o ./kernel2.o
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel3.cc -o ./kernel3.o
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/core_dmas/dma_configure_task_lock/run.lit
+++ b/test/npu-xrt/core_dmas/dma_configure_task_lock/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/core_dmas/dma_configure_task_token/run.lit
+++ b/test/npu-xrt/core_dmas/dma_configure_task_token/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/ctrl_packet_reconfig/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig/run.lit
@@ -3,16 +3,16 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
 //
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 //
-// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
-// RUN: %aiecc %backend_flags --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
-// RUN: %aiecc %backend_flags --device-name=main --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=aie_run_seq.bin aie_overlay.mlir
+// RUN: %npu_build% aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=main --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=aie_run_seq.bin aie_overlay.mlir
 //
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
 //
-// RUN: %run_on_npu1% ./test.exe
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_run% %run_on_npu1% ./test.exe
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -3,15 +3,15 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
 //
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 //
-// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
-// RUN: %aiecc %backend_flags --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
-// RUN: %aiecc %backend_flags --device-name=main --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=aie_run_seq.bin aie_overlay.mlir
+// RUN: %npu_build% aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=main --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=aie_run_seq.bin aie_overlay.mlir
 //
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -3,15 +3,15 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
 //
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2/g' -i aie_arch.mlir
 //
-// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
-// RUN: %aiecc %backend_flags --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
-// RUN: %aiecc %backend_flags --device-name=main --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=aie_run_seq.bin aie_overlay.mlir
+// RUN: %npu_build% aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --device-name=main --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=aie_run_seq.bin aie_overlay.mlir
 //
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/run.lit
@@ -3,15 +3,15 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
 //
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 //
-// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
-// RUN: %aiecc %backend_flags --tmpdir=project1 --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
-// RUN: %aiecc %backend_flags --tmpdir=project2 --device-name=main --get-ctrlpkt --get-elf --elf-name=aie.elf aie_overlay.mlir
+// RUN: %npu_build% aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie_arch.mlir -o aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --tmpdir=project1 --device-name=base --get-xclbin --xclbin-name=aie.xclbin aie_overlay.mlir
+// RUN: %npu_build% %aiecc %backend_flags --tmpdir=project2 --device-name=main --get-ctrlpkt --get-elf --elf-name=aie.elf aie_overlay.mlir
 //
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/dmabd_task_queue/run.lit
+++ b/test/npu-xrt/dmabd_task_queue/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/lit.local.cfg
+++ b/test/npu-xrt/lit.local.cfg
@@ -13,4 +13,12 @@ config.excludes.add("util.py")
 # Design script driven by matmul_whole_array_dynamic/run.lit, not a test itself.
 config.excludes.add("whole_array_dynamic.py")
 
-config.parallelism_group = "npu-xrt"
+import os
+
+# Compile/execute split: in the compile phase the build work touches no device,
+# so run it in parallel (ungrouped); the execute phase and the normal whole-test
+# run keep the capacity-1 npu-xrt group that serializes device access.
+if os.environ.get("AIE_NPU_SPLIT", "") == "compile":
+    config.parallelism_group = None
+else:
+    config.parallelism_group = "npu-xrt"

--- a/test/npu-xrt/lit.local.cfg
+++ b/test/npu-xrt/lit.local.cfg
@@ -13,12 +13,16 @@ config.excludes.add("util.py")
 # Design script driven by matmul_whole_array_dynamic/run.lit, not a test itself.
 config.excludes.add("whole_array_dynamic.py")
 
-import os
+# Compile/execute split. Gate the parallelism group PER-TEST via an importable
+# callable (so lit can pickle it to its parallel workers -- a function defined
+# here in the exec'd config cannot be pickled). In AIE_NPU_SPLIT=compile a
+# CONVERTED test (RUN lines carry %npu_run%) runs ungrouped/parallel; every other
+# test -- including all unconverted ones -- keeps the capacity-1 npu-xrt group so
+# its device execution stays serialized (the XRT hw_context pool #2737 protects).
+# Per-test gating means running the whole directory in compile mode is still safe.
+# NOTE: the split assumes both lit passes share one clean filesystem/exec-root;
+# a stale artifact from a prior run could otherwise let execute pass on a stale
+# xclbin.
+from aie_lit_utils.lit_config_helpers import npu_split_parallelism_group
 
-# Compile/execute split: in the compile phase the build work touches no device,
-# so run it in parallel (ungrouped); the execute phase and the normal whole-test
-# run keep the capacity-1 npu-xrt group that serializes device access.
-if os.environ.get("AIE_NPU_SPLIT", "") == "compile":
-    config.parallelism_group = None
-else:
-    config.parallelism_group = "npu-xrt"
+config.parallelism_group = npu_split_parallelism_group

--- a/test/npu-xrt/loadpdi/run.lit
+++ b/test/npu-xrt/loadpdi/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: %aiecc -v --get-full-elf --no-xchesscc --no-xbridge %S/aie.mlir
-// RUN: %host_clang -o test.exe %S/test_elf.cpp -std=c++17 %host_link_flags %xrt_flags
-// RUN: ./test.exe
+// RUN: %npu_build% %aiecc -v --get-full-elf --no-xchesscc --no-xbridge %S/aie.mlir
+// RUN: %npu_build% %host_clang -o test.exe %S/test_elf.cpp -std=c++17 %host_link_flags %xrt_flags
+// RUN: %npu_run% ./test.exe

--- a/test/npu-xrt/many_buffers/run.lit
+++ b/test/npu-xrt/many_buffers/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/matrix_multiplication_using_cascade/run.lit
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/run.lit
@@ -3,14 +3,14 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/mm.cc -o ./mm.o
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -c %S/mm.cc -o ./mm.o
+// RUN: %npu_build% g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags %host_link_flags %test_utils_flags
 //
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie2_plain.xclbin --npu-insts-name=insts2_plain.txt %S/aie_plainx4.mlir
-// RUN: %run_on_npu1% ./test.exe -x aie2_plain.xclbin -k MLIR_AIE -i insts2_plain.txt --trace_sz 32768
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie2_plain.xclbin --npu-insts-name=insts2_plain.txt %S/aie_plainx4.mlir
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie2_plain.xclbin -k MLIR_AIE -i insts2_plain.txt --trace_sz 32768
 //
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie2_buffer.xclbin --npu-insts-name=insts2_buffer.txt %S/aie_bufferx4.mlir
-// RUN: %run_on_npu1% ./test.exe -x aie2_buffer.xclbin -k MLIR_AIE -i insts2_buffer.txt --trace_sz 32768
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie2_buffer.xclbin --npu-insts-name=insts2_buffer.txt %S/aie_bufferx4.mlir
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie2_buffer.xclbin -k MLIR_AIE -i insts2_buffer.txt --trace_sz 32768
 //
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie2_cascade.xclbin --npu-insts-name=insts2_cascade.txt %S/aie_cascadex4.mlir
-// RUN: %run_on_npu1% ./test.exe -x aie2_cascade.xclbin -k MLIR_AIE -i insts2_cascade.txt --trace_sz 32768
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie2_cascade.xclbin --npu-insts-name=insts2_cascade.txt %S/aie_cascadex4.mlir
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie2_cascade.xclbin -k MLIR_AIE -i insts2_cascade.txt --trace_sz 32768

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/run.lit
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/memtile_dmas/dma_configure_task_lock/run.lit
+++ b/test/npu-xrt/memtile_dmas/dma_configure_task_lock/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/memtile_dmas/dma_configure_task_token/run.lit
+++ b/test/npu-xrt/memtile_dmas/dma_configure_task_token/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/memtile_dmas/writebd/run.lit
+++ b/test/npu-xrt/memtile_dmas/writebd/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/run.lit
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/multi_source_packet_flow/run.lit
+++ b/test/npu-xrt/multi_source_packet_flow/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/packet_flow/run.lit
+++ b/test/npu-xrt/packet_flow/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow_fanin/run.lit
+++ b/test/npu-xrt/packet_flow_fanin/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow_fanout/run.lit
+++ b/test/npu-xrt/packet_flow_fanout/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe aie.xclbin
-// RUN: %run_on_npu2% ./test.exe aie.xclbin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %npu_run% %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/runtime_cumsum/run.lit
+++ b/test/npu-xrt/runtime_cumsum/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/sum.cc -o ./sum.o
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/sum.cc -o ./sum.o
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/scratchpad_addr_offset/run.lit
+++ b/test/npu-xrt/scratchpad_addr_offset/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: %aiecc -v --get-full-elf --no-xchesscc --no-xbridge --dynamic-objFifos --get-scratchpad-parameters %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_build% %aiecc -v --get-full-elf --no-xchesscc --no-xbridge --dynamic-objFifos --get-scratchpad-parameters %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/scratchpad_params/run.lit
+++ b/test/npu-xrt/scratchpad_params/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: %aiecc -v --get-full-elf --no-xchesscc --no-xbridge --dynamic-objFifos --get-scratchpad-parameters %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_build% %aiecc -v --get-full-elf --no-xchesscc --no-xbridge --dynamic-objFifos --get-scratchpad-parameters %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/scratchpad_regwrite/run.lit
+++ b/test/npu-xrt/scratchpad_regwrite/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: %aiecc -v --get-full-elf --no-xchesscc --no-xbridge %S/aie.mlir
-// RUN: %host_clang -o test.exe %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
-// RUN: %run_on_npu2% ./test.exe
+// RUN: %npu_build% %aiecc -v --get-full-elf --no-xchesscc --no-xbridge %S/aie.mlir
+// RUN: %npu_build% %host_clang -o test.exe %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
+// RUN: %npu_run% %run_on_npu2% ./test.exe

--- a/test/npu-xrt/shim_dma_bd_reuse/run.lit
+++ b/test/npu-xrt/shim_dma_bd_reuse/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/static_L1_init/run.lit
+++ b/test/npu-xrt/static_L1_init/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/tile_dmas/blockwrite_using_locks/run.lit
+++ b/test/npu-xrt/tile_dmas/blockwrite_using_locks/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/tile_dmas/writebd/run.lit
+++ b/test/npu-xrt/tile_dmas/writebd/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/tile_dmas/writebd_tokens/run.lit
+++ b/test/npu-xrt/tile_dmas/writebd_tokens/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/tile_mapped_read/run.lit
+++ b/test/npu-xrt/tile_mapped_read/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cpp -o kernel.o
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cpp -o kernel.o
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/two_col/run.lit
+++ b/test/npu-xrt/two_col/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/threshold.cc -o ./threshold.o
-// RUN: %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/threshold.cc -o ./threshold.o
+// RUN: %npu_build% %aiecc --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/vec_vec_add_memtile_init/run.lit
+++ b/test/npu-xrt/vec_vec_add_memtile_init/run.lit
@@ -3,11 +3,11 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/vec_vec_add_tile_init/run.lit
+++ b/test/npu-xrt/vec_vec_add_tile_init/run.lit
@@ -3,10 +3,10 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: cp %S/aie.mlir aie_arch.mlir
-// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
-// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% cp %S/aie.mlir aie_arch.mlir
+// RUN: %npu_build% %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %npu_build% %aiecc %backend_flags --get-xclbin --get-npu-insts --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_run% %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/vector_scalar_using_dma/run.lit
+++ b/test/npu-xrt/vector_scalar_using_dma/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai_npu1, chess
 //
-// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/scale.cc -o ./scale.o
-// RUN: %aiecc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %npu_build% xchesscc_wrapper aie2 -I %aietools/include -c %S/scale.cc -o ./scale.o
+// RUN: %npu_build% %aiecc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %npu_build% %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %npu_run% %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE AS-IS.** This draft carries a *temporary* validation harness
> (`.github/workflows/zz-experiment-split-validate.yml` + `.github/workflows/scripts/{split,cache}_experiment.sh`)
> whose only job is to gather Chess correctness/timing on a Chess-capable runner. It triggers on
> `pull_request` and runs on the self-hosted device runners, so if this PR were merged unremoved it would
> become a **permanent second per-PR device build on the capacity-1 runners** -- the exact opposite of this
> PR's aim. It must be deleted before the split is finalized. Only the lit split below is proposed for review;
> the harness is evidence-gathering scaffolding.

## Problem

The on-device `check-aie` phase is the biggest CI sink, and it is almost entirely compilation. On a
serialized `npu-xrt` test I measured device-side work at ~20 ms (device open dominates; pure NPU dispatch
0.39 ms) versus ~2.1 s of Peano compile for a one-kernel test and 26-77 s for Chess tests. So the
capacity-1 `npu-xrt` lane spends ~99% of its wall time compiling, which never touches the device.

## Change (opt-in, off by default)

Let a converted `npu-xrt` test run its compilation in a parallel, no-device phase and keep only the device
execution in the capacity-1 `npu-xrt` group. `AIE_NPU_SPLIT` selects the phase:

- unset (default): both substitutions expand to nothing, so behaviour is unchanged.
- `compile`: run the build lines (`%npu_build%`), skip the device run (`%npu_run%` becomes `:`); the test
  is ungrouped so builds run at `-jN`.
- `execute`: skip the build, run only the device lines against the compile phase's persisted `%t`
  artifacts; the test stays in the capacity-1 `npu-xrt` group.

CI would run the split subset as two passes: `AIE_NPU_SPLIT=compile lit ...` then
`AIE_NPU_SPLIT=execute lit ...`. Converting a test is a per-line prefix (`%npu_build%` on build lines,
`%npu_run%` on the `./test.exe` line).

This preserves #2737's invariant: the capacity-1 group serializes the global per-device XRT `hw_context`
pool, which is consumed only at device-execution time; compilation never opens the device. Per-test
parallelism gating keeps every unconverted device test in the capacity-1 group during the compile phase,
so running the whole directory in compile mode never parallelises unserialized device work.

## Coverage

57 `npu-xrt` tests converted by a classifier with a `--validate` pass (0 invariant violations). 14 are
left whole-test on purpose: JIT (`@iron.jit`, no separable compile/execute boundary), multi-line
continuations, and redirect/pipe/FileCheck lines that the `:` skip token cannot neutralise safely. The
dangerous classifier error is tagging a device run as `%npu_build%`; `--validate` guards exactly that.

## Evidence (Ryzen AI 9 / AIE2P)

- Behaviour-identical across the full runnable set: on a commit-matched from-source build, all 39 runnable
  Peano `npu-xrt` tests give the same verdict whole vs split. A fresh-root two-arm control is the
  load-bearing proof: execute-only from a wiped root is 0/39 PASS (no stale artifact can ride),
  compile+execute from the same wiped root is 39/39 PASS (genuine split).
- No masking, no stale ride (fault injection): for representative tests I mutate the kernel so its output
  is wrong. whole and split both FAIL identically, and split FAILs even when a prior good split has left
  good artifacts in the exec root, so the compile phase overwrites them and the execute phase never rides a
  stale-good xclbin. Reverting the mutation restores PASS.
- ~4x on this Peano subset: whole 54.2 s serial vs split 13.4 s (9.66 s parallel compile at `-j10` plus
  3.75 s serial device execute).

## What I have not measured (honest caveats)

- The Chess tests are converted and codemod-validated, but their whole-vs-split behaviour and timing are
  projected, not measured: my box is npu2/Peano and skips Chess. The compile/execute seam
  (`%run_on_npuN% ./test.exe`) is backend-agnostic, so Chess correctness is expected to hold, but I have
  not run it. The `check-aie` win is largest exactly on the Chess compiles (26-77 s), so that is the
  measurement I most want from a Chess-capable runner.
- Timing is n=1 per phase, and whole runs first, warming the aiecc on-disk JIT cache the compile phase then
  reuses, so the ratio is biased favourable; a cold or repeated-median run would tighten it.

## Scope / not in this PR

- No workflow YAML change: how and whether to wire the two passes into CI is the maintainers' call. Related
  to the CI overhaul in #3198.
- No cross-run xclbin cache: that needs a content-addressed input + toolchain key and is separate, higher
  risk.

Opening as a draft / RFC to show the mechanism and the measured win concretely. Happy to adjust the scope,
the marker names, or the phase model.


## Tracking / next

Discussion and maintainer thread: #3405. Per hunhoffe's note there that Chess compiles are memory-intensive
(they were OOM-killing runners without a Chess-specific concurrency limit), the compile phase would carry
its own memory-sized parallelism group, so Chess compiles stay as bounded as today while leaving the
capacity-1 device lane. I have a temporary, self-guarding validation job (whole==split assert plus a
fresh-root canary and no-masking fault injection, all encoded as CI assertions) ready to run on a
Chess-capable runner, to turn the projected Chess correctness/timing and the compile memory footprint into
measured numbers.

