### PR TITLE
[Windows] Fix remaining script annoyances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,15 @@ runtime_lib/xaiengine/src
 /iron_env.sh
 /.cache
 
+# Local wheel build inputs and outputs.
+/utils/mlir_aie_wheels/mlir-*.whl
+/utils/mlir_aie_wheels/mlir_no_rtti-*.whl
+/utils/mlir_aie_wheels/mlir/
+/utils/mlir_aie_wheels/mlir_no_rtti/
+/utils/mlir_aie_wheels/mlir-*.dist-info/
+/utils/mlir_aie_wheels/mlir_no_rtti-*.dist-info/
+/utils/mlir_aie_wheels/wheelhouse/
+
 # Local run/test artifacts under programming_examples/ and programming_guide/
 **/log/
 **/test_stx/

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,9 +11,11 @@
 [submodule "runtime_lib/xaiengine/aie-rt"]
 	path = third_party/aie-rt
 	url = https://github.com/Xilinx/aie-rt.git
+	ignore = dirty
 [submodule "third_party/bootgen"]
 	path = third_party/bootgen
 	url = https://github.com/Xilinx/bootgen.git
+	ignore = dirty
 [submodule "third_party/aie_api"]
 	path = third_party/aie_api
 	url = https://github.com/Xilinx/aie_api

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,10 @@ cmake_dependent_option(AIECC_LINK_WITH_XCHESSCC
 
 # If we need runtime libs, then statically link them.
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+if(MSVC AND OPENSSL_USE_STATIC_LIBS)
+  # Match OpenSSL's library suffix to the static MSVC runtime selected above.
+  set(OPENSSL_MSVC_STATIC_RT TRUE)
+endif()
 
 add_flag_if_supported("-Werror=sign-compare" WERROR_SIGN_COMPARE)
 add_flag_if_supported("-Werror=unused" WERROR_USED)

--- a/docs/buildHostWinNative.md
+++ b/docs/buildHostWinNative.md
@@ -3,11 +3,13 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 # Native Windows Setup and Build Instructions
 
-This guide covers the **native Windows** setup for **IRON/mlir-aie**, which is the recommended path on Windows 11. These instructions will guide you through installing and configuring everything required to both build and execute programs on the Ryzen™ AI NPU, entirely within Windows and without the need for a POSIX environment. If you prefer, you may instead use the [WSL2 setup](buildHostWin.md) to build and run IRON in a Linux environment on Windows.
+This guide covers the native Windows setup for **IRON/mlir-aie** and is the recommended path for Windows 11 users. It supports building and running programs on a Ryzen™ AI NPU entirely within Windows, without requiring a POSIX environment. The [WSL2 setup](buildHostWin.md) is available for users who prefer a POSIX-style development environment.
 
-Use an **x64 Native Tools Command Prompt for Visual Studio** in `cmd.exe` for the commands in this guide. It initializes MSVC, the linker, and the Windows SDK in one place. Visual Studio and Visual Studio Build Tools install this environment automatically and create a shortcut in the Start menu. PowerShell is also supported; see [Addendum A](#addendum-a-powershell).
+Use an **x64 Native Tools Command Prompt for Visual Studio** in `cmd.exe` for the commands in this guide. It provides MSVC, the linker, and the Windows SDK in one configured environment. Visual Studio and Visual Studio Build Tools both install that prompt, as well as adding a shortcut to the Start menu.
 
-> **Python note:** The Windows XRT SDK supplies `pyxrt` bindings for **CPython 3.13**. Use Python 3.13 with the SDK. Do not choose another Python version unless you already have an XRT distribution with matching bindings. Building and packaging XRT from source on Windows is an advanced task outside the scope of this guide.
+PowerShell is also supported. While the main instructions use `cmd.exe`, the corresponding PowerShell commands and shell-specific differences are collected in [Addendum A](#addendum-a-powershell).
+
+> **Python note:** The Windows XRT SDK supplies `pyxrt` bindings for **CPython 3.13**. Use Python 3.13 with this SDK. Another Python version requires an XRT distribution with matching bindings. Building and packaging XRT from source on Windows is possible, but it is an advanced task outside the scope of this guide.
 
 ## Contents
 
@@ -21,36 +23,34 @@ Use an **x64 Native Tools Command Prompt for Visual Studio** in `cmd.exe` for th
 
 ## 1. Install the Windows development environment
 
-Together, the items below form the expected native Windows development environment for this repository.
-
-You need:
+A fully usable native Windows checkout requires the following:
 
 - A Windows 11 system with a supported Ryzen™ AI / XDNA™ NPU.
-- **Visual Studio 2026** (preferred) or **Visual Studio 2022**. The full IDE and the matching Build Tools package are both supported.
-- **Python 3.13**. This may be through an ordinary install or a Conda / Miniforge environment. See [Addendum A](#addendum-a-powershell) for Conda / Miniforge usage.
-- **CMake**. The CMake supplied by a current Visual Studio installation should be fine; a current Kitware download is also suitable.
-- **Git for Windows**. Install it with Visual Studio or as a separate package.
+- **Visual Studio 2026** (preferred) or **Visual Studio 2022**. Either the full IDE or the matching **Build Tools** package may be used.
+- **Python 3.13**, installed directly or through Conda / Miniforge. Conda and Miniforge users should also read [Addendum A](#addendum-a-powershell).
+- **CMake**. The version included with a Visual Studio 2026 installation is normally sufficient; a current Kitware release is also suitable.
+- **Git for Windows**, installed with Visual Studio or separately.
 - The latest Ryzen™ AI / XDNA™ NPU driver and the Windows **XRT SDK**.
 
 ### 1.1 Visual Studio components
 
-When using the Visual Studio Installer (below), select **Desktop development with C++** and confirm that the following components are installed. Use the search box under the **Individual components** tab when needed:
+In the Visual Studio Installer, select **Desktop development with C++** and confirm that the following components are installed. The search box under **Individual components** is useful when checking an existing installation:
 
 - MSVC x64/x86 build tools
 - Windows SDK
 - C++ CMake tools for Windows
 - C++ Clang Compiler for Windows
-- MSBuild support for LLVM (`clang-cl`) toolset
-- Git for Windows, when Git is not installed separately
+- MSBuild support for the LLVM (`clang-cl`) toolset
+- Git for Windows, unless Git is installed separately
 
-The Clang and LLVM components support CMake configurations to build native C++ host applications.
+The Clang and LLVM components are used by CMake configurations that build native C++ host applications.
 
 ### 1.2 Install the tools
 
-Most tools may be installed via the Windows command-line package manager, `winget`:
+Most of the required tools are available through the Windows package manager, `winget`:
 
 ```bat
-REM Choose one: the full IDE or the matching Build Tools package.
+REM Choose one: the full IDE or the matching Build Tools package
 winget install -e --id Microsoft.VisualStudio.Community
 REM winget install -e --id Microsoft.VisualStudio.BuildTools
 
@@ -60,52 +60,54 @@ winget install -e --id Python.Python.3.13
 REM CMake
 winget install -e --id Kitware.CMake
 
-REM Git (optional unless not selected in VS installer)
+REM Git (optional unless not selected in the Visual Studio installer)
 winget install -e --id Git.Git
 ```
 
-Manual downloads are also available here:
+The same tools may be downloaded directly:
 
-```text
-Visual Studio: https://visualstudio.microsoft.com/downloads/
-Python:        https://www.python.org/downloads/windows/
-CMake:         https://cmake.org/download/
-Git:           https://git-scm.com/download/win
-```
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/)
+- [Python](https://www.python.org/downloads/windows/)
+- [CMake](https://cmake.org/download/)
+- [Git](https://git-scm.com/download/win)
+
 
 ## 2. Update and verify the NPU driver
 
-Chipset driver updates for Ryzen™ AI / XDNA™ APUs are regularly available through the AMD™ Software / Adrenalin™ application. Ensure you have the latest driver version for your system and verify your NPU is accessible by:
+Ryzen™ AI / XDNA™ chipset driver updates are distributed through the AMD™ Software / Adrenalin™ application. Install the latest driver available for the system, then verify that the NPU is accessible:
 
 ```bat
 "C:\Windows\System32\AMD\xrt-smi.exe" examine
 ```
 
-NPU Driver Version 32.0.20101.3760 (XRT Version 2.21.0) is the minimum supported by this repository on Windows. Older versions may function in some cases, but they are not recommended.
+NPU Driver Version **32.0.20101.3760** (XRT Version **2.21.0**) is the minimum supported by this repository on Windows. Older versions may work in many cases, but they are not recommended.
 
 ## 3. Install the Windows XRT SDK
 
-The XRT SDK provides the native Windows headers, import libraries, and tools used by C++ host applications. It also supplies the `pyxrt` binding used by Python JIT designs.
+The Windows XRT SDK provides the headers, import libraries, tools, and `pyxrt` bindings used by native host applications and Python JIT designs.
 
-Download:
+Download the SDK:
 
 ```text
 https://github.com/Xilinx/XRT/releases/download/2.21.75/xrt_windows_sdk.zip
 ```
 
-Extract the SDK such that `xrt_sdk\xrt` becomes:
+Extract the archive so that its `xrt_sdk\xrt` directory becomes:
 
 ```text
 C:\Xilinx\XRT
 ```
-> This is the canonical location. If you install the SDK elsewhere, pass that location to `iron_setup.py` in the next section. The activation helper it generates will record the selected XRT installation.
+
+> `C:\Xilinx\XRT` is the canonical location. A different location is also supported; pass it to `iron_setup.py` in the next section. The generated activation helpers retain the selected path, so it does not need to be supplied again in each shell.
 
 ## 4. Set up IRON
 
-Clone the `mlir-aie` repository, then create the local IRON environment:
+Clone the `mlir-aie` repository and create the checkout-local IRON environment:
 
 ```bat
-cd /d C:\dev
+REM Choose a working directory for the checkout. This example uses C:\dev
+mkdir C:\dev
+cd C:\dev
 
 git clone --recurse-submodules https://github.com/Xilinx/mlir-aie.git
 cd mlir-aie
@@ -114,57 +116,73 @@ python utils\iron_setup.py
 call .\iron_env.cmd
 ```
 
-The two commands have different jobs. `iron_setup.py` creates or updates the checkout-local `ironenv`, including all necessary dependencies; `iron_env.cmd` activates it in the current prompt and supplies the IRON and XRT paths. Call `iron_env.cmd` in every new Native Tools prompt. Rerun setup after updating the checkout or changing the XRT SDK location; it refreshes the existing environment and rewrites the helpers.
+The final two commands are separate because they perform different tasks. `iron_setup.py` creates or updates the checkout-local `ironenv` and installs the required dependencies. `iron_env.cmd` activates that environment in the current prompt and supplies the IRON and XRT paths.
 
-For normal use, no options are needed. Add `--dev` when preparing a contributor checkout: it installs the pinned development tools and the repository's pre-commit and pre-push hooks. Add `--extras` for the PyTorch-based material or Jupyter notebooks: it installs CPU PyTorch, Notebook, and an `ironenv` Jupyter kernel. These options work alone or in combination.
+`call` `iron_env.cmd` in each new `Native Tools` prompt. Rerun `iron_setup.py` after updating the checkout or changing the XRT SDK location; it refreshes the existing environment and rewrites the activation helpers.
 
-If you installed the XRT SDK to a different location, supply that location when creating the helper. It is saved in the generated helpers, so later shells still only need `iron_env.cmd`:
+No options are needed for normal use. Two optional setup modes are available:
+
+- `--dev` installs the pinned development tools and the repository's pre-commit and pre-push hooks. It also installs or upgrades `mlir_aie` to the latest rolling development wheel unless `--wheelhouse` is supplied. Use this option only when actively developing the repository.
+- `--extras` installs CPU PyTorch, Notebook, and an `ironenv` Jupyter kernel for the PyTorch-based examples and notebooks.
+
+The options may be used independently or together.
+
+If the XRT SDK is installed somewhere other than `C:\Xilinx\XRT`, provide that location during setup:
 
 ```bat
 python utils\iron_setup.py --xrt-root D:\tools\XRT
 call .\iron_env.cmd
 ```
 
+The selected path is written into the generated helpers. Later shells still need only `iron_env.cmd`.
+
 ## 5. Run a complete NPU program
 
-Many example programs are available in the `programming_examples` and `programming_guide` directories. Try running the SAXPY example to exercise the complete `mlir-aie` toolchain. The design computes `Z = 3X + Y` on one AI Engine tile. Its Python file describes the data movement and runtime sequence; the adjacent C++ file contains the vectorized AI Engine kernel. `@iron.jit` compiles them into an NPU program.
+The repository includes runnable examples under `programming_examples` and `programming_guide`. The SAXPY example is a useful first check because it exercises the complete `mlir-aie` toolchain.
+
+The design computes `Z = 3X + Y` on one AI Engine tile. Its Python file describes the data movement and runtime sequence, while the adjacent C++ file contains the vectorized AI Engine kernel. `@iron.jit` compiles them into an NPU program.
 
 ```bat
 cd programming_examples\getting_started\01_SAXPY
 python saxpy.py
 ```
 
-The script compiles the design, runs it on the attached NPU, and checks the result against a NumPy reference. If it prints `PASS!`, you have just successfully run your first IRON NPU program on Windows!
+The script compiles the design, runs it on the attached NPU, and checks the result against a NumPy reference. A final `PASS!` confirms that the native Windows toolchain, XRT installation, and NPU are working together correctly.
 
-Most existing learning material uses direct Python JIT scripts, so continue with the [mini tutorial](../programming_guide/mini_tutorial/) or feel free to try any other Python scripts in `programming_examples` or `programming_guide`.
-
+Most of the existing learning material uses direct Python JIT scripts. Continue with the [mini tutorial](../programming_guide/mini_tutorial/) or continue to explore by trying another Python example under `programming_examples` or `programming_guide`.
 
 ---
 
-## Addendum A: PowerShell
+<a id="addendum-a-powershell"></a>
+<details>
+<summary><strong>Addendum A: PowerShell</strong></summary>
 
-Visual Studio's Native Tools environment is also available in PowerShell by using the "Developer PowerShell for VS" shortcut in the Start menu. It is equivalent to the Native Tools `cmd.exe` prompt.
+Visual Studio also installs a **Developer PowerShell for VS** shortcut. It provides the same compiler environment as the Native Tools `cmd.exe` prompt.
 
-Alternatively, since PowerShell uses the same toolchain as `cmd.exe`, you may enter it at any time from the Native Tools `cmd.exe` prompt:
+PowerShell may also be started from an existing Native Tools prompt:
 
 ```bat
 pwsh
 ```
 
-The compiler environment will be inherited automatically. To set up from PowerShell, run the same setup command and dot-source the generated helper:
+The compiler environment is inherited automatically. Run setup and dot-source the generated activation helper:
 
 ```powershell
 python .\utils\iron_setup.py
 . .\iron_env.ps1
 ```
 
-In later PowerShell sessions, dot-source `iron_env.ps1` again. Dot-sourcing keeps the activated environment in the current shell.
+Dot-source `iron_env.ps1` again in each new PowerShell session. The leading dot is *required*: it keeps the activated environment in the current shell rather than as a child scope.
 
-However, if you are following this guide using PowerShell, please keep the syntactical differences between the two shells in mind. For instance, PowerShell environment variables use `$env:NAME` while `cmd.exe` uses `%NAME%`. Likewise, PS uses `&` to invoke programs while `cmd.exe` uses `call` for batch files. Etc.
+The toolchain is the same, but the shell syntax differs in the usual PowerShell ways. For example:
+
+- PowerShell environment variables use `$env:NAME`; `cmd.exe` uses `%NAME%`.
+- PowerShell uses `&` to invoke a command through an expression; `cmd.exe` uses `call` for batch files.
+- Path quoting and command composition are not always interchangeable between the two shells.
 
 ### Conda or Miniforge Python
 
-A dedicated Conda or Miniforge environment works with the SDK when it uses Python 3.13. Activate it before running `iron_setup.py`; the helper creates `ironenv` with that interpreter.
+A dedicated Conda or Miniforge environment works with the SDK when it uses Python 3.13. Activate it before running `iron_setup.py`; the helper uses the active interpreter when it creates `ironenv`.
 
 ```powershell
 conda create -n iron python=3.13
@@ -173,21 +191,27 @@ python .\utils\iron_setup.py
 . .\iron_env.ps1
 ```
 
-`iron_setup.py` uses its running interpreter only when it creates `ironenv`. Remove and recreate `ironenv` before switching the interpreter used by an existing environment.
+`iron_setup.py` will select the named interpreter when `ironenv` is created. Remove and recreate `ironenv` before changing the interpreter used by an existing checkout.
 
-## Addendum B: Build `mlir-aie` wheels locally
+</details>
 
-Build local wheels when altering core `mlir-aie` files, testing a local commit, or working on packaging.
+<a id="addendum-b-build-mlir-aie-wheels-locally"></a>
+<details>
+<summary><strong>Addendum B: Build <code>mlir-aie</code> wheels locally</strong></summary>
+
+Build local wheels when changing core `mlir-aie` files, testing a local commit, or working on packaging. This is not part of the normal setup path. **Normal users should not need to build local wheels**!
 
 ### B.1 Install OpenSSL
 
-Local wheel builds compile components that link against OpenSSL. Install the full **Win64 OpenSSL** package from Shining Light Productions; it supplies the headers and libraries required by the build and is much faster and easier than compiling from source. **Do not** use the "Light" package.
+Local wheel builds compile components that link against OpenSSL. Install the full **Win64 OpenSSL** package from Shining Light Productions. It provides the required headers and libraries and is considerably simpler than building OpenSSL from source.
+
+**Do not use the "Light" package.** It does not contain the development files required by this build.
 
 ```text
 https://slproweb.com/products/Win32OpenSSL.html
 ```
 
-From an x64 Native Tools prompt in a configured checkout, set the OpenSSL location and the CMake arguments for the build:
+From an x64 Native Tools prompt in a configured checkout, set the OpenSSL location and CMake arguments:
 
 ```bat
 set "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64"
@@ -197,7 +221,7 @@ set "CMAKE_ARGS=-DOPENSSL_ROOT_DIR=%OPENSSL_ROOT_DIR% -DOPENSSL_USE_STATIC_LIBS=
 
 ### B.2 Build the wheels
 
-Activate the IRON environment, install the local wheel-build tools, and build one Python version. This example uses Python 3.13:
+Activate the IRON environment, install the local wheel-build tools, and build one Python version. This example targets Python 3.13:
 
 ```bat
 cd /d C:\dev\mlir-aie
@@ -208,19 +232,26 @@ python -m pip install --require-hashes -r python\requirements_dev.lock
 python utils\mlir_aie_wheels\scripts\build_local.py --cp313
 ```
 
-The wheelhouse is:
+The completed wheels are written to:
 
 ```text
 utils\mlir_aie_wheels\wheelhouse
 ```
 
-Install the locally built wheels into IRON, then refresh the shell environment:
+Install the local wheels into IRON, then refresh the shell environment:
 
 ```bat
 python utils\iron_setup.py --wheelhouse utils\mlir_aie_wheels\wheelhouse
 call .\iron_env.cmd
 ```
 
-The local-wheel path force-reinstalls `mlir_aie` from the selected wheelhouse. The rest of setup still reconciles the repository's declared requirements.
+The local-wheel path force-reinstalls `mlir_aie` from the selected wheelhouse. The rest of setup continues to reconcile the repository's declared requirements.
 
-Use `--cp312` or `--cp314` only when the selected XRT distribution supplies matching `pyxrt` bindings. The local builder manages the staging directories. Remove `utils\mlir_aie_wheels\wheelhouse` and `C:\tmp` to clean up when you are done.
+Use `--cp312` or `--cp314` only when the selected XRT distribution supplies matching `pyxrt` bindings. The local builder manages its staging directories. Remove the following when the build artifacts are no longer needed:
+
+```text
+utils\mlir_aie_wheels\wheelhouse
+C:\tmp\aiewhls
+```
+
+</details>

--- a/tools/bootgen/CMakeLists.txt
+++ b/tools/bootgen/CMakeLists.txt
@@ -4,6 +4,14 @@
 
 set(BOOTGEN_SOURCE ${PROJECT_SOURCE_DIR}/third_party/bootgen)
 
+# Avoid retriggering compilation when configuration produces identical sources.
+function(write_bootgen_source_if_changed path contents)
+  file(READ "${path}" current_contents)
+  if(NOT current_contents STREQUAL contents)
+    file(WRITE "${path}" "${contents}")
+  endif()
+endfunction()
+
 # Upstream (xilinx_v2026.1) splits sources into per-architecture <dir>/src
 # trees; glob each one, matching upstream's own Makefile.
 set(bootgen_src_dirs
@@ -52,20 +60,20 @@ set(bootgen_include_dirs
 # If you want to use malloc, then include stdlib.h
 file(READ ${BOOTGEN_SOURCE}/utils/src/cdo-npi.c FILE_CONTENTS)
 string(REPLACE "#include <malloc.h>" "" FILE_CONTENTS "${FILE_CONTENTS}")
-file(WRITE ${BOOTGEN_SOURCE}/utils/src/cdo-npi.c "${FILE_CONTENTS}")
+write_bootgen_source_if_changed(${BOOTGEN_SOURCE}/utils/src/cdo-npi.c "${FILE_CONTENTS}")
 
 file(READ ${BOOTGEN_SOURCE}/utils/src/cdo-alloc.c FILE_CONTENTS)
 string(REPLACE "#include <malloc.h>" "" FILE_CONTENTS "${FILE_CONTENTS}")
-file(WRITE ${BOOTGEN_SOURCE}/utils/src/cdo-alloc.c "${FILE_CONTENTS}")
+write_bootgen_source_if_changed(${BOOTGEN_SOURCE}/utils/src/cdo-alloc.c "${FILE_CONTENTS}")
 
 # Strip the per-CDO-file "Generating: ..." printf: cdo_driver_mlir_aie is
-# called directly (not via the bootgen executable) 
+# called directly (not via the bootgen executable)
 file(READ ${BOOTGEN_SOURCE}/cdo-driver/cdo_driver.c FILE_CONTENTS)
 string(REGEX REPLACE "\n[ \t]*printf\\(\"Generating: %s\\\\n\", cdoFileName\\);"
   "" FILE_CONTENTS "${FILE_CONTENTS}")
-file(WRITE ${BOOTGEN_SOURCE}/cdo-driver/cdo_driver.c "${FILE_CONTENTS}")
+write_bootgen_source_if_changed(${BOOTGEN_SOURCE}/cdo-driver/cdo_driver.c "${FILE_CONTENTS}")
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL REQUIRED COMPONENTS SSL)
 if (OPENSSL_FOUND)
   message (STATUS "OpenSSL found")
   message (STATUS "OpenSSL include directories:" ${OPENSSL_INCLUDE_DIR})
@@ -78,7 +86,7 @@ find_package(Threads REQUIRED)
 # since we explicitly link OpenSSL::applink
 file(READ ${BOOTGEN_SOURCE}/common/src/main.cpp FILE_CONTENTS)
 string(REPLACE "#include \"openssl/ms/applink.c\"" "" FILE_CONTENTS "${FILE_CONTENTS}")
-file(WRITE ${BOOTGEN_SOURCE}/common/src/main.cpp "${FILE_CONTENTS}")
+write_bootgen_source_if_changed(${BOOTGEN_SOURCE}/common/src/main.cpp "${FILE_CONTENTS}")
 
 # Vendored LMS/HSS post-quantum signature library upstream added for newer
 # secure-boot support; built as a static lib instead of shelling out to its
@@ -135,7 +143,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
 endif()
 
 add_library(bootgen-lib STATIC ${libsources})
-# bootgen must be compiled with PIE/PIC, auditwheel repair's 
+# bootgen must be compiled with PIE/PIC, auditwheel repair's
 # patchelf-based RPATH rewrite corrupts the non-PIE binary.
 set_target_properties(bootgen-lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")

--- a/utils/iron_setup.py
+++ b/utils/iron_setup.py
@@ -6,8 +6,9 @@
 ##===------ iron_setup.py - Cross-platform IRON environment setup -----------===##
 #
 # Create or reconcile the wheel-backed Python environment used by this checkout.
-# Setup installs the release wheel at a tagged checkout or the current rolling
-# wheel on a development checkout, plus llvm-aie and any requested dependencies.
+# Tagged checkouts use their matching release wheel. --dev installs mlir_aie
+# from the latest rolling development channel with pip --upgrade --pre, plus
+# contributor dependencies.
 #
 #   python utils/iron_setup.py
 #   python utils/iron_setup.py --dev --extras
@@ -182,6 +183,7 @@ def pip_install_package(
     *,
     force_reinstall: bool,
     upgrade: bool = False,
+    allow_prereleases: bool = False,
     find_links: Optional[str] = None,
     wheelhouse: Optional[Path] = None,
     no_index: bool = False,
@@ -190,6 +192,8 @@ def pip_install_package(
     args = ["install"]
     if upgrade:
         args.append("--upgrade")
+    if allow_prereleases:
+        args.append("--pre")
     if force_reinstall:
         args.append("--force-reinstall")
     if no_deps:
@@ -250,6 +254,7 @@ class WheelSelection:
     wheelhouse: Optional[Path]
     description: str
     upgrade: bool = False
+    allow_prereleases: bool = False
 
 
 def release_tag_at_head(repo_root: Path) -> Optional[str]:
@@ -281,6 +286,21 @@ def resolve_mlir_aie_wheel(args: argparse.Namespace, repo_root: Path) -> WheelSe
             description=f"local wheelhouse: {wheelhouse}",
         )
 
+    if args.dev:
+        # Contributor environments must track the newest rolling prerelease.
+        # pip needs both --upgrade and --pre to make that guarantee.
+        return WheelSelection(
+            package="mlir_aie",
+            find_links=f"{WHEEL_ASSET_INDEX}/{ROLLING_WHEEL_CHANNEL}",
+            wheelhouse=None,
+            description=(
+                "latest rolling development wheel: "
+                f"{ROLLING_WHEEL_CHANNEL} (pip --upgrade --pre)"
+            ),
+            upgrade=True,
+            allow_prereleases=True,
+        )
+
     if tag := release_tag_at_head(repo_root):
         # A tagged checkout must use the wheel assets published for that tag.
         return WheelSelection(
@@ -290,7 +310,7 @@ def resolve_mlir_aie_wheel(args: argparse.Namespace, repo_root: Path) -> WheelSe
             description=f"release tag: {tag}",
         )
 
-    # Main and feature branches use the newest published rolling wheel.
+    # Untagged non-development checkouts use pip's normal rolling-channel selection.
     return WheelSelection(
         package="mlir_aie",
         find_links=f"{WHEEL_ASSET_INDEX}/{ROLLING_WHEEL_CHANNEL}",
@@ -324,6 +344,7 @@ def install_mlir_aie(
         selection.package,
         force_reinstall=force_reinstall,
         upgrade=selection.upgrade,
+        allow_prereleases=selection.allow_prereleases,
         find_links=selection.find_links,
     )
 
@@ -924,7 +945,11 @@ def add_install_args(parser: argparse.ArgumentParser) -> None:
         "--developer",
         dest="dev",
         action="store_true",
-        help="Install locked contributor tooling and the repository Git hooks.",
+        help=(
+            "Install locked contributor tooling and Git hooks, and install or "
+            "upgrade mlir_aie to the latest rolling development wheel using "
+            "pip --upgrade --pre unless --wheelhouse is supplied."
+        ),
     )
     parser.add_argument(
         "--extras",

--- a/utils/mlir_aie_wheels/scripts/build_local.py
+++ b/utils/mlir_aie_wheels/scripts/build_local.py
@@ -139,7 +139,8 @@ def _rename_main_wheel_python_tag(wheelhouse: Path) -> None:
             continue
         dst = whl.with_name(new_name)
         print(f"[rename] {whl.name} -> {dst.name}")
-        whl.rename(dst)
+        # Replace a wheel left by an earlier local build.
+        whl.replace(dst)
 
 
 def _copy_ccache_from_wheelhouse(wheelhouse: Path, host_ccache_dir: Path) -> None:

--- a/utils/mlir_aie_wheels/scripts/download_mlir.py
+++ b/utils/mlir_aie_wheels/scripts/download_mlir.py
@@ -7,6 +7,7 @@
 #
 ##===------------------------------------------------------------------------------===##
 # Python shim for scripts/download_mlir.sh (cross-platform, Windows-friendly).
+# Reuses matching downloads, native-tools installs, and extracted trees.
 #
 # Env:
 #   ENABLE_RTTI: ON/OFF (default: ON)
@@ -24,6 +25,7 @@ import shutil
 import subprocess
 import sys
 import zipfile
+from importlib import metadata
 from pathlib import Path
 
 
@@ -37,13 +39,11 @@ def _pip(args):
     _run([sys.executable, "-m", "pip", *args])
 
 
-def _try_rmtree(path):
+def _remove_tree(path):
     try:
         shutil.rmtree(path)
     except FileNotFoundError:
-        return
-    except Exception as exc:
-        print(f"[warn] failed to remove '{path}': {exc}")
+        pass
 
 
 def _find_clone_llvm(script_dir):
@@ -94,6 +94,126 @@ def _wheel_version():
         "LLVM_PROJECT_COMMIT": _sh_var(text, "LLVM_PROJECT_COMMIT"),
     }
     return _expand_sh(_sh_var(text, "WHEEL_VERSION"), vars).strip()
+
+
+def _installed_version(distribution):
+    try:
+        return metadata.version(distribution)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _install_native_tools(version):
+    if _installed_version("mlir-native-tools") == version:
+        print(f"[reuse] mlir-native-tools {version}")
+        return
+    _pip(["install", "--no-deps", "--upgrade", f"mlir-native-tools=={version}"])
+
+
+def _target_platform_args():
+    cibw_archs = (os.environ.get("CIBW_ARCHS") or "").strip()
+    matrix_os = (os.environ.get("MATRIX_OS") or "").strip()
+
+    if cibw_archs not in {"arm64", "aarch64"}:
+        return []
+    if matrix_os in {"macos-12", "macos-14"} and cibw_archs == "arm64":
+        return ["--platform", "macosx_12_0_arm64", "--only-binary=:all:"]
+    if matrix_os == "ubuntu-20.04" and cibw_archs == "aarch64":
+        return ["--platform", "linux_aarch64", "--only-binary=:all:"]
+    raise SystemExit(f"Unsupported CIBW_ARCHS/MATRIX_OS: {cibw_archs}/{matrix_os}")
+
+
+def _wheel_arch_marker():
+    cibw_archs = (os.environ.get("CIBW_ARCHS") or "").strip().lower()
+    return {
+        "amd64": "win_amd64",
+        "x86_64": "x86_64",
+        "arm64": "arm64",
+        "aarch64": "aarch64",
+    }.get(cibw_archs)
+
+
+def _matching_wheels(directory, distribution, version):
+    package_name = distribution.replace("-", "_")
+    prefix = f"{package_name}-{version}-".lower()
+    wheels = sorted(
+        wheel
+        for wheel in directory.glob("*.whl")
+        if wheel.name.lower().startswith(prefix)
+    )
+
+    # A shared wheel directory may contain the same version for several hosts.
+    if marker := _wheel_arch_marker():
+        wheels = [wheel for wheel in wheels if marker in wheel.name.lower()]
+    return wheels
+
+
+def _download_wheel(directory, distribution, version, platform_args):
+    wheels = _matching_wheels(directory, distribution, version)
+    if not wheels:
+        _pip(
+            [
+                "-q",
+                "download",
+                "--no-deps",
+                "--dest",
+                str(directory),
+                *platform_args,
+                f"{distribution}=={version}",
+            ]
+        )
+        wheels = _matching_wheels(directory, distribution, version)
+
+    if len(wheels) != 1:
+        raise RuntimeError(
+            f"Expected one cached {distribution} {version} wheel in {directory}, "
+            f"found {len(wheels)}"
+        )
+    print(f"[reuse] {wheels[0].name}")
+    return wheels[0]
+
+
+def _extraction_matches(wheel, dist_info):
+    # RECORD identifies the exact wheel without invalidating the Windows path fixup.
+    record = dist_info / "RECORD"
+    if not record.is_file():
+        return False
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            archived_record = archive.read(f"{dist_info.name}/RECORD")
+        return record.read_bytes() == archived_record
+    except (KeyError, OSError, zipfile.BadZipFile):
+        return False
+
+
+def _ensure_extracted(wheel, directory, distribution, version):
+    package_name = distribution.replace("-", "_")
+    package_dir = directory / package_name
+    dist_info = directory / f"{package_name}-{version}.dist-info"
+
+    if (
+        package_dir.is_dir()
+        and dist_info.is_dir()
+        and _extraction_matches(wheel, dist_info)
+    ):
+        print(f"[reuse] extracted {wheel.name}")
+        return package_dir
+
+    if package_dir.exists() or dist_info.exists():
+        print(f"[refresh] extracted {wheel.name}")
+    _remove_tree(package_dir)
+    for old_dist_info in directory.glob(f"{package_name}-*.dist-info"):
+        _remove_tree(old_dist_info)
+
+    print(f"[unzip] {wheel.name}")
+    with zipfile.ZipFile(wheel) as archive:
+        archive.extractall(directory)
+
+    if not package_dir.is_dir() or not dist_info.is_dir():
+        raise RuntimeError(
+            f"Wheel did not contain {package_dir.name} and {dist_info.name}"
+        )
+    return package_dir
 
 
 # --------------------------------------------------------------------------------------
@@ -198,49 +318,19 @@ def _fixup_llvm_diaguids(mlir_prefix):
 def main():
     enable_rtti = (os.environ.get("ENABLE_RTTI") or "ON").upper()
     no_rtti = enable_rtti == "OFF"
-
-    # Mirror: rm -rf mlir || true (also clear the sibling to avoid stale state).
-    _try_rmtree(Path("mlir"))
-    _try_rmtree(Path("mlir_no_rtti"))
+    distribution = "mlir-no-rtti" if no_rtti else "mlir"
+    directory = Path.cwd()
 
     version = _wheel_version()
     print(f"Using MLIR version: {version}")
+    _install_native_tools(version)
 
-    _pip(["install", "-U", "--force-reinstall", f"mlir-native-tools=={version}"])
+    wheel = _download_wheel(directory, distribution, version, _target_platform_args())
+    mlir_prefix = _ensure_extracted(wheel, directory, distribution, version)
+    _fixup_llvm_diaguids(mlir_prefix)
 
-    pkg = f"mlir{'-no-rtti' if no_rtti else ''}=={version}"
-    cibw_archs = (os.environ.get("CIBW_ARCHS") or "").strip()
-    matrix_os = (os.environ.get("MATRIX_OS") or "").strip()
-
-    if cibw_archs in {"arm64", "aarch64"}:
-        if matrix_os in {"macos-12", "macos-14"} and cibw_archs == "arm64":
-            plat = "macosx_12_0_arm64"
-        elif matrix_os == "ubuntu-20.04" and cibw_archs == "aarch64":
-            plat = "linux_aarch64"
-        else:
-            raise SystemExit(
-                f"Unsupported CIBW_ARCHS/MATRIX_OS: {cibw_archs}/{matrix_os}"
-            )
-
-        _pip(["-q", "download", pkg, "--platform", plat, "--only-binary=:all:"])
-    else:
-        _pip(["-q", "download", pkg])
-
-    wheels = sorted(Path.cwd().glob("mlir*whl"))
-    if not wheels:
-        raise FileNotFoundError("No wheels matched pattern: 'mlir*whl'")
-
-    for wheel in wheels:
-        print(f"[unzip] {wheel.name}")
-        with zipfile.ZipFile(wheel, "r") as zf:
-            zf.extractall(Path.cwd())
-
-    for d in (Path("mlir"), Path("mlir_no_rtti")):
-        if d.is_dir():
-            _fixup_llvm_diaguids(d)
-
-    print(Path.cwd())
-    for p in sorted(Path.cwd().glob("mlir*")):
+    print(directory)
+    for p in sorted(directory.glob("mlir*")):
         print(p.name)
 
     return 0

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -344,10 +344,23 @@ class CMakeBuild(build_ext):
         print("ENV", pprint(os.environ), file=sys.stderr)
         print("cmake", " ".join(cmake_args), file=sys.stderr)
 
+        configure_args = list(cmake_args)
+        if platform.system() == "Windows":
+            # cibuildwheel recreates its build venv on each run. Refresh cached
+            # Python and pybind11 paths while retaining the compiled build tree.
+            configure_args[:0] = [
+                "-UPython3_*",
+                "-U_Python3_*",
+                "-UPython_*",
+                "-U_Python_*",
+                "-Upybind11_*",
+                "-UPYBIND11_*",
+            ]
+
         build_succeeded = False
         try:
             subprocess.run(
-                ["cmake", _cmake_path(cmake_source_dir), *cmake_args],
+                ["cmake", _cmake_path(cmake_source_dir), *configure_args],
                 cwd=build_temp,
                 check=True,
             )

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import hashlib
 import os
 import platform
 import re
@@ -57,6 +58,22 @@ def _windows_short_dir(name: str, *, clean: bool = False) -> Path:
         _remove_tree(path)
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def _windows_path_key(path: Path) -> str:
+    # Junction and build-cache names must remain short but unique per checkout.
+    normalized = os.path.normcase(os.fspath(path.resolve()))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:10]
+
+
+def _windows_build_cache_name(
+    source_dir: Path, generator: str, python_tag: str, arch: str, rtti: str
+) -> str:
+    generator_key = re.sub(r"[^a-z0-9]+", "-", generator.lower()).strip("-")
+    return (
+        f"main-{_windows_path_key(source_dir)}-{generator_key or 'default'}-"
+        f"{python_tag}-{arch}-{rtti}"
+    )
 
 
 def _windows_short_alias(name: str, target: Path) -> Path:
@@ -183,12 +200,19 @@ class CMakeBuild(build_ext):
         cmake_module_root = MLIR_AIE_SOURCE_DIR
 
         if platform.system() == "Windows":
-            # Keep source and dependency paths short without moving the installed trees.
-            cmake_source_dir = _windows_short_alias("src", cmake_source_dir).absolute()
+            # Keep paths short without allowing one checkout to repoint
+            # another checkout's junctions.
+            source_alias = f"src-{_windows_path_key(cmake_source_dir)}"
+            cmake_source_dir = _windows_short_alias(
+                source_alias, cmake_source_dir
+            ).absolute()
             cmake_module_root = cmake_source_dir
+            dependency_alias = (
+                f"{_windows_tree_alias_name(MLIR_INSTALL_ABS_PATH.name)}-"
+                f"{_windows_path_key(MLIR_INSTALL_ABS_PATH)}"
+            )
             MLIR_INSTALL_ABS_PATH = _windows_short_alias(
-                _windows_tree_alias_name(MLIR_INSTALL_ABS_PATH.name),
-                MLIR_INSTALL_ABS_PATH,
+                dependency_alias, MLIR_INSTALL_ABS_PATH
             ).absolute()
 
         cmake_args = [
@@ -302,8 +326,18 @@ class CMakeBuild(build_ext):
         cleanup_build_temp = False
         build_temp = Path(self.build_temp) / ext.name
         if platform.system() == "Windows":
-            build_temp = _windows_short_dir("main", clean=True)
-            cleanup_build_temp = True
+            python_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+            arch = re.sub(
+                r"[^a-z0-9]+",
+                "-",
+                os.getenv("CIBW_ARCHS", "native").lower(),
+            )
+            rtti = "rtti" if check_env("ENABLE_RTTI", 1) else "no-rtti"
+            build_temp = _windows_short_dir(
+                _windows_build_cache_name(
+                    Path(ext.sourcedir), cmake_generator, python_tag, arch, rtti
+                )
+            )
         elif not build_temp.exists():
             build_temp.mkdir(parents=True)
 


### PR DESCRIPTION
Cleans up a few issues that might annoy Windows users (or could potentially cause a problem during CI). Shouldn't cause a problem for Linux.

* Make `iron_setup.py --dev` upgrade to the latest rolling development wheel (local `--wheelhouse` still selectable).
* Make `bootgen` build on Windows against the updated upstream source. This was just an /MD vs /MT mismatch, but potentially a big CI blocker.
* Reuse matching MLIR downloads, extracted trees, and native-tools installations. Hopefully safer and cleaner.
* Refresh the native Windows setup documentation.
* For the purposes of Git, ignore build-time mutations in the `aie-rt` and `bootgen` submodules.

