### PR TITLE
ci: cache pre-commit and pip in Lint and Format

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: python/requirements_dev.lock
 
       - name: Install Python packages
         run: |
@@ -170,6 +172,8 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: python/requirements_dev.lock
 
       - name: Check Liquid Syntax
         run: python3 utils/check_liquid_syntax.py
@@ -179,8 +183,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --require-hashes -r python/requirements_dev.lock
 
-      - name: Check filename case conflicts
-        run: pre-commit run check-case-conflict --all-files --color never
+      # Cache the pre-commit hook environments (clang-format, black, ...) so they
+      # are not rebuilt from scratch on every run.
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-${{ runner.os }}-
 
       - name: Check filename case conflicts
         run: pre-commit run check-case-conflict --all-files --color never


### PR DESCRIPTION
## What

Cache the Python-side work in the Lint and Format workflow: the pip downloads
and the pre-commit hook environments. #3385 added C++ ccache to this workflow;
this covers the remaining un-cached cost, which is Python, not C++.

Today every run reinstalls the Python dependencies and rebuilds each pre-commit
hook environment (clang-format, black, ...) from scratch.

## How

- `cache: 'pip'` on both `setup-python` steps, keyed on
  `python/requirements_dev.lock`, so the wheel downloads are restored instead of
  re-fetched.
- `actions/cache` for `~/.cache/pre-commit`, keyed on `.pre-commit-config.yaml`
  with a `restore-keys` fallback, so the hook toolchains are reused across runs
  and only rebuilt when the config changes.
- Drop a duplicated `check-case-conflict` step: the workflow ran the exact same
  `pre-commit run check-case-conflict --all-files` twice back to back. One is
  removed; the other stays.

## Result

The lint job stops re-downloading pip wheels and re-building pre-commit
environments on every run, hitting the cache in steady state and rebuilding only
when the lock file or the pre-commit config changes. Complements the C++ ccache
from #3385; both pinned to commit SHAs, matching the workflow's existing action
pinning.
