### PR TITLE
[python] Fix resident-tensor stale-write bug in HostRuntime.run()

### DIFF
--- a/python/utils/callabledesign.py
+++ b/python/utils/callabledesign.py
@@ -221,6 +221,7 @@ class CallableDesign:
             kernel_name="MLIR_AIE",
             trace_config=trace_config,
             num_host_bos=num_host_bos,
+            output_flags=compilable.tensor_output_flags(),
         )
         if compilable.use_cache:
             self._kernel_cache[cache_key] = kernel

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -475,6 +475,23 @@ class CompilableDesign:
 
         return tensor_args, scalar_kwargs
 
+    def tensor_output_flags(self) -> list[bool]:
+        """Whether each tensor argument is device -> host (``Out``/``InOut``).
+
+        Aligned with ``tensor_params`` order, and thus with the ``tensor_args``
+        order ``split_runtime_args()`` produces for a callable generator. Used
+        by the host runtime to know which dispatched arguments the device just
+        wrote fresh data into, so their host-residency can be reasserted after
+        a successful run (see ``HostRuntime._repin_outputs``).
+
+        Returns:
+            list[bool]: Empty for a static ``.mlir`` file generator (no
+            ``In``/``Out``/``InOut`` annotations to introspect).
+        """
+        if not callable(self.mlir_generator):
+            return []
+        return [self._hints.get(name) in (Out, InOut) for name in self.tensor_params]
+
     def generate_mlir(self):
         """Generate and return the MLIR module without compiling to xclbin.
 

--- a/python/utils/hostruntime/hostruntime.py
+++ b/python/utils/hostruntime/hostruntime.py
@@ -166,6 +166,7 @@ class HostRuntime(ABC):
         trace_config: TraceConfig | None = None,
         fail_on_error: bool = True,
         only_if_loaded=False,
+        output_flags: list[bool] | None = None,
         **kwargs,
     ) -> KernelResult:
         """
@@ -177,12 +178,39 @@ class HostRuntime(ABC):
             trace_config (TraceConfig | None, optional): Configuration for tracing. Defaults to None.
             fail_on_error (bool, optional): Whether to raise an exception on kernel failure. Defaults to True.
             only_if_loaded (bool, optional): If True, only run if already loaded. Defaults to False.
+            output_flags (list[bool] | None, optional): Per-argument
+                ``Out``/``InOut`` flags aligned with ``args`` (see
+                ``NPUKernel.output_flags``). Implementations should reassert
+                ``"npu"`` residency (``_repin_outputs``) on these positions
+                after a successful dispatch. Defaults to None.
             **kwargs: Additional arguments.
 
         Returns:
             KernelResult: The result of the kernel execution.
         """
         pass
+
+    @staticmethod
+    def _repin_outputs(args, output_flags: list[bool] | None) -> None:
+        """Reassert "npu" residency on the Out/InOut positions in *args*.
+
+        A successful dispatch just made the device the authoritative copy for
+        these arguments. Tensor.data marks a tensor host-dirty on every access
+        (see tensor_class.py) so that in-place writes (e.g. `t.data[:] = x`)
+        are never missed -- but that also fires on a plain read (`t.numpy()`),
+        since numpy gives no separate write hook. Without this reassertion, a
+        caller reading a resident output between dispatches (e.g. to extract a
+        result in a decode loop) would mark it dirty, and the next dispatch's
+        pre-run `.to("npu")` would then wrongly push that stale host copy back
+        onto the device instead of leaving the fresh device-computed state
+        alone. Positions beyond the end of output_flags (e.g. an appended
+        trace buffer) are left untouched.
+        """
+        if not output_flags:
+            return
+        for a, is_output in zip(args, output_flags):
+            if is_output:
+                a.device = "npu"
 
     def load_and_run(
         self,
@@ -227,7 +255,12 @@ class HostRuntime(ABC):
                     f"land."
                 )
 
-        ret = self.run(handle, list(run_args), trace_config=trace_config)
+        ret = self.run(
+            handle,
+            list(run_args),
+            trace_config=trace_config,
+            output_flags=npu_kernel.output_flags,
+        )
 
         if trace_config:
             trace_buffer, ctrl_buffer = self.extract_trace_from_args(

--- a/python/utils/hostruntime/tensor_class.py
+++ b/python/utils/hostruntime/tensor_class.py
@@ -113,6 +113,16 @@ class Tensor(ABC):
         """
         Subclasses must implement a data property.
 
+        Implementations should mark the tensor host-dirty (``self.device =
+        "cpu"``) on every access, not only on writes: numpy gives no separate
+        write hook (`np.copyto(t.data, x)` bypasses `__setitem__`), so a
+        write-only hook would miss exactly those writes and let a resident
+        argument re-authored in place between dispatches run stale on the
+        device. A redundant re-sync on a subsequent `.to("npu")` after a pure
+        read is cheap; a silently skipped one after a write is a correctness
+        bug. See ``HostRuntime._repin_outputs`` for how output arguments avoid
+        being penalized by this on read.
+
         Returns:
             np.ndarray: The underlying data of the tensor.
         """
@@ -135,10 +145,14 @@ class Tensor(ABC):
 
         Note: This method may implicitly trigger data synchronization to devices.
         """
-        if self.device == "npu":
+        # Capture the residency label before touching `.data` -- accessing it
+        # marks the tensor host-dirty (see the `data` property), which would
+        # otherwise make repr() itself flip the label it's about to print.
+        device = self.device
+        if device == "npu":
             self._sync_from_device()
         array_str = np.array2string(self.data, separator=",")
-        return f"{self.__class__.__name__}({array_str}, device='{self.device}')"
+        return f"{self.__class__.__name__}({array_str}, device='{device}')"
 
     def __array__(self, dtype=None):
         """
@@ -191,10 +205,14 @@ class Tensor(ABC):
         before modification and back to device after modification to ensure
         data consistency across device and host memory.
         """
-        if self.device == "npu":
+        # Capture residency once: `.data` marks the tensor host-dirty on access
+        # (see the `data` property), so re-reading `self.device` after the
+        # write below would always see "cpu" and skip the resync-to-device.
+        was_npu = self.device == "npu"
+        if was_npu:
             self._sync_from_device()
         self.data[index] = value
-        if self.device == "npu":
+        if was_npu:
             self._sync_to_device()
 
     def __len__(self):
@@ -404,8 +422,12 @@ class Tensor(ABC):
 
         Note: For NPU tensors, this method syncs the filled data to device after modification.
         """
+        # Capture residency before the write: `.data` marks the tensor
+        # host-dirty on access, so checking `self.device` afterward would
+        # always see "cpu" and skip the resync-to-device.
+        was_npu = self.device == "npu"
         self.data.fill(value)
-        if self.device == "npu":
+        if was_npu:
             self._sync_to_device()
 
     def numel(self):

--- a/python/utils/hostruntime/xrtruntime/hostruntime.py
+++ b/python/utils/hostruntime/xrtruntime/hostruntime.py
@@ -233,6 +233,7 @@ class XRTHostRuntime(HostRuntime):
         trace_config=None,
         fail_on_error: bool = True,
         only_if_loaded: bool = False,
+        output_flags: list[bool] | None = None,
         **kwargs,
     ) -> XRTKernelResult:
         """
@@ -244,6 +245,9 @@ class XRTHostRuntime(HostRuntime):
             trace_config (optional): Configuration for tracing. Defaults to None.
             fail_on_error (bool, optional): Whether to raise an exception on kernel failure. Defaults to True.
             only_if_loaded (bool, optional): Accepted for API compatibility with the runtime base class.
+            output_flags (list[bool] | None, optional): Per-argument
+                ``Out``/``InOut`` flags aligned with ``args``; see
+                ``HostRuntime._repin_outputs``. Defaults to None.
             **kwargs: Additional arguments.
 
         Returns:
@@ -320,6 +324,9 @@ class XRTHostRuntime(HostRuntime):
             # delete insts buffer if it was created locally
             if insts_bo and not kernel_handle.insts_bo:
                 del insts_bo
+
+        if r == pyxrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+            self._repin_outputs(args, output_flags)
 
         return XRTKernelResult(r, stop - start)
 

--- a/python/utils/hostruntime/xrtruntime/tensor.py
+++ b/python/utils/hostruntime/xrtruntime/tensor.py
@@ -93,9 +93,14 @@ class XRTTensor(Tensor):
         """
         Get the underlying numpy array.
 
+        Marks the tensor host-dirty on every access (see Tensor.data) so an
+        in-place write -- `t.data[:] = x` or `np.copyto(t.data, x)` -- is
+        never missed by the next `.to("npu")`.
+
         Returns:
             np.ndarray: The underlying data.
         """
+        self.device = "cpu"
         return self._data
 
     @property

--- a/python/utils/npukernel.py
+++ b/python/utils/npukernel.py
@@ -20,6 +20,7 @@ class NPUKernel:
         kernel_name="MLIR_AIE",
         trace_config: TraceConfig | None = None,
         num_host_bos: int | None = None,
+        output_flags: list[bool] | None = None,
     ):
         """
         Initialize the NPUKernel.
@@ -38,6 +39,14 @@ class NPUKernel:
                 command-chain minimum), so it is the correct value to validate
                 host buffer counts against. ``None`` when it could not be
                 determined (validation is then skipped).
+            output_flags (list[bool] | None, optional): Per-argument
+                ``Out``/``InOut`` flags, aligned with the run-time positional
+                tensor arguments (see
+                ``CompilableDesign.tensor_output_flags()``). ``None`` (or
+                empty) when the generator has no ``In``/``Out``/``InOut``
+                annotations to introspect (e.g. a static ``.mlir`` file), in
+                which case the host runtime cannot reassert output residency
+                after a dispatch. Defaults to None.
         """
         self._xclbin_path = xclbin_path
         self._insts_path = insts_path
@@ -45,6 +54,7 @@ class NPUKernel:
         self._trace_config = trace_config
         self._device_index = device_index
         self._num_host_bos = num_host_bos
+        self._output_flags = output_flags
 
     @property
     def trace_config(self) -> TraceConfig | None:
@@ -97,6 +107,18 @@ class NPUKernel:
             ``None`` if it could not be determined.
         """
         return self._num_host_bos
+
+    @property
+    def output_flags(self) -> list[bool] | None:
+        """
+        Get the per-argument ``Out``/``InOut`` flags.
+
+        Returns:
+            list[bool] | None: Aligned with the run-time positional tensor
+            arguments, or ``None`` if the generator had no annotations to
+            introspect.
+        """
+        return self._output_flags
 
     # Blocking call.
     def __call__(self, *args, **kwargs):

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -120,6 +120,27 @@ def test_path_generator_has_empty_param_lists():
 
 
 # ---------------------------------------------------------------------------
+# tensor_output_flags(): In/Out/InOut role per tensor_params position
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_output_flags_matches_annotation_order():
+    d = CompilableDesign(_gemm_gen())
+    assert d.tensor_params == ["a", "b", "c"]
+    assert d.tensor_output_flags() == [False, False, True]
+
+
+def test_tensor_output_flags_inout_counts_as_output():
+    d = CompilableDesign(_inout_gen())
+    assert d.tensor_output_flags() == [True]
+
+
+def test_tensor_output_flags_empty_for_path_generator():
+    d = CompilableDesign(Path("/nonexistent/design.mlir"))
+    assert d.tensor_output_flags() == []
+
+
+# ---------------------------------------------------------------------------
 # Construction: paths normalised to Path objects
 # ---------------------------------------------------------------------------
 

--- a/test/python/test_hostruntime_repin.py
+++ b/test/python/test_hostruntime_repin.py
@@ -1,0 +1,70 @@
+# test_hostruntime_repin.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# RUN: %pytest %s
+"""Unit tests for HostRuntime._repin_outputs -- no NPU required.
+
+Tensor.data marks a tensor host-dirty on every access (not just writes, since
+numpy gives no separate write hook), so a resident argument re-authored in
+place between dispatches is never missed. But that also fires on a plain read
+(e.g. peeking a dispatch's output via .numpy()), which would otherwise make
+the *next* dispatch's pre-run `.to("npu")` wrongly push the stale host copy
+back over fresh device-computed state. _repin_outputs is the compensating
+step: reassert "npu" residency on the Out/InOut argument positions right
+after a successful dispatch.
+"""
+
+from aie.utils.hostruntime.hostruntime import HostRuntime
+
+
+class _FakeTensor:
+    """Minimal stand-in exposing only the `.device` attribute _repin_outputs touches."""
+
+    def __init__(self, device):
+        self.device = device
+
+
+def test_repin_outputs_reasserts_npu_on_output_positions():
+    t = _FakeTensor("cpu")  # e.g. left dirty by a prior .numpy() read
+    HostRuntime._repin_outputs([t], [True])
+    assert t.device == "npu"
+
+
+def test_repin_outputs_leaves_non_output_positions_alone():
+    t = _FakeTensor("cpu")
+    HostRuntime._repin_outputs([t], [False])
+    assert t.device == "cpu"
+
+
+def test_repin_outputs_noop_when_output_flags_none():
+    """No role info (e.g. a static .mlir file with no In/Out annotations)."""
+    t = _FakeTensor("cpu")
+    HostRuntime._repin_outputs([t], None)
+    assert t.device == "cpu"
+
+
+def test_repin_outputs_noop_when_output_flags_empty():
+    t = _FakeTensor("cpu")
+    HostRuntime._repin_outputs([t], [])
+    assert t.device == "cpu"
+
+
+def test_repin_outputs_stops_at_shorter_output_flags():
+    """A trailing arg beyond output_flags (e.g. an appended trace buffer) is
+    left untouched rather than raising."""
+    t_out = _FakeTensor("cpu")
+    t_trace = _FakeTensor("cpu")
+    HostRuntime._repin_outputs([t_out, t_trace], [True])
+    assert t_out.device == "npu"
+    assert t_trace.device == "cpu"
+
+
+def test_repin_outputs_mixed_roles():
+    t_in = _FakeTensor("cpu")
+    t_out = _FakeTensor("cpu")
+    HostRuntime._repin_outputs([t_in, t_out], [False, True])
+    assert t_in.device == "cpu"
+    assert t_out.device == "npu"


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description
  
`Tensor.data` doesn't mark the tensor dirty, so writing a resident arg in place (`t.data[:] = x`, `np.copyto`) between dispatches is missed — the next `.to("npu")` no-ops and the kernel runs on stale bytes. Reported against #3354; same bug already fixed downstream in `amd/IRON#138`. 

  ## Fix

- `Tensor.data` now marks host-dirty on every access (read or write — numpy has no write-only hook).
- `HostRuntime._repin_outputs` reasserts `"npu"` residency on `Out`/`InOut` args after a successful dispatch, using the existing `In`/`Out`/`InOut` annotations, so reading a result between dispatches doesn't cause the *next* dispatch to push stale host data back over fresh device output.
- HRX backend needs no changes — it already syncs unconditionally both ways, sidestepping this class of bug entirely.

<!-- What does this PR change, and why? Link any related issue with "Fixes #123". -->

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
