### PR TITLE
aie2p: add a correct f32 per-row layer_norm; drop wrong-axis welford

### DIFF
--- a/aie_kernels/aie2p/layer_norm.cc
+++ b/aie_kernels/aie2p/layer_norm.cc
@@ -55,48 +55,52 @@ void layer_norm(const T *restrict input, T *restrict output, int32_t cols) {
   event1();
 }
 
+// f32 per-row LayerNorm. The bf16 layer_norm above centers with a single
+// E[x^2] - mean^2 reduction, which is fine because the bf16 input contract
+// keeps the mean/std ratio small (a bf16 value near a large mean has an ulp
+// wider than the std, so that regime is unrepresentable). On f32 input the mean
+// can be large relative to the std and E[x^2] - mean^2 then catastrophically
+// cancels, so this variant reduces over the feature axis (cols) per row with a
+// numerically stable two-pass centered variance: center first, then square.
 template <typename T, int N>
-void layer_norm_welford(const T *restrict input, T *restrict output,
-                        int32_t rows, int32_t cols) {
+void layer_norm_f32(const T *restrict input, T *restrict output, int32_t cols) {
   event0();
   constexpr float epsilon = 1e-5f;
   const float gamma = 1.0f;
   const float beta = 0.0f;
-  ::aie::vector<T, N> reg_a, delta, delta2, mean_v, m2_v, variance_v, just_div,
-      just_prod;
 
-  ::aie::vector<T, N> beta_v = ::aie::broadcast<T, N>(beta);
   ::aie::vector<T, N> gamma_v = ::aie::broadcast<T, N>(gamma);
-  ::aie::vector<T, N> epsilon_v = ::aie::broadcast<T, N>(epsilon);
-  // Welford's algorithm for mean and variance, vectorized over columns
-  float inv_count = 0.0f;
-  mean_v = ::aie::zeros<T, N>();
-  m2_v = ::aie::zeros<T, N>();
-  for (int c = 0; c < cols; c += N) {
-    for (int r = 0; r < rows; r++) {
-      reg_a = ::aie::load_v<N>(input + r * cols + c);
-      delta = ::aie::sub(reg_a, mean_v);
-      inv_count = 1.0f / (r + 1);
-      just_div = ::aie::mul(delta, inv_count);
-      mean_v = ::aie::add(mean_v, just_div);
-      delta2 = ::aie::sub(reg_a, mean_v);
-      just_prod = ::aie::mul(delta, delta2);
-      m2_v = ::aie::add(m2_v, just_prod);
-    }
-  }
+  ::aie::vector<T, N> beta_v = ::aie::broadcast<T, N>(beta);
 
-  variance_v = ::aie::mul(m2_v, inv_count);
-  ::aie::vector<T, N> var_eps_v = ::aie::add(variance_v, epsilon_v);
-  ::aie::vector<T, N> inv_std_v = ::aie::invsqrt(var_eps_v);
-  for (int r = 0; r < rows; r++) {
-    for (int c = 0; c < cols; c += N) {
-      ::aie::vector<T, N> v0 = ::aie::load_v<N>(input + r * cols + c);
-      ::aie::vector<T, N> diff_v = ::aie::sub(v0, mean_v);
-      ::aie::vector<T, N> norm_v = ::aie::mul(diff_v, inv_std_v);
-      ::aie::vector<T, N> scaled_v = ::aie::mul(norm_v, gamma_v);
-      ::aie::vector<T, N> out_v = ::aie::add(scaled_v, beta_v);
-      ::aie::store_v(output + r * cols + c, out_v);
-    }
+  int vector_chunks = cols / N;
+
+  // Pass 1: mean = sum(x) / cols.
+  ::aie::vector<T, N> sum_v = ::aie::zeros<T, N>();
+  for (int i = 0; i < vector_chunks; i++) {
+    sum_v = ::aie::add(sum_v, ::aie::load_v<N>(input + i * N));
+  }
+  float mean = ::aie::reduce_add(sum_v) / float(cols);
+  ::aie::vector<T, N> mean_v = ::aie::broadcast<T, N>(mean);
+
+  // Pass 2: variance = sum((x - mean)^2) / cols (centered two-pass).
+  ::aie::vector<T, N> var_v = ::aie::zeros<T, N>();
+  for (int i = 0; i < vector_chunks; i++) {
+    ::aie::vector<T, N> diff_v =
+        ::aie::sub(::aie::load_v<N>(input + i * N), mean_v);
+    ::aie::vector<T, N> sq = ::aie::mul(diff_v, diff_v);
+    var_v = ::aie::add(var_v, sq);
+  }
+  float variance = ::aie::reduce_add(var_v) / float(cols);
+  float inv_std = aie::invsqrt(variance + epsilon);
+  ::aie::vector<T, N> inv_std_v = ::aie::broadcast<T, N>(inv_std);
+
+  for (int i = 0; i < vector_chunks; i++) {
+    ::aie::vector<T, N> diff_v =
+        ::aie::sub(::aie::load_v<N>(input + i * N), mean_v);
+    ::aie::vector<T, N> norm_v = ::aie::mul(diff_v, inv_std_v);
+    ::aie::vector<T, N> scaled_v = ::aie::mul(norm_v, gamma_v);
+    ::aie::vector<T, N> out_v = ::aie::add(scaled_v, beta_v);
+    ::aie::store_v(output + i * N, out_v);
   }
   event1();
 }
@@ -106,8 +110,7 @@ void layer_norm(bfloat16 *input, bfloat16 *output, int32_t cols) {
   layer_norm<bfloat16, 16>(input, output, cols);
 }
 
-void layer_norm_welford(float *input, float *output, int32_t rows,
-                        int32_t cols) {
-  layer_norm_welford<float, 16>(input, output, rows, cols);
+void layer_norm_f32(float *input, float *output, int32_t cols) {
+  layer_norm_f32<float, 16>(input, output, cols);
 }
 }

--- a/programming_examples/ml/norm/README.md
+++ b/programming_examples/ml/norm/README.md
@@ -7,21 +7,22 @@
 
 # Row-wise Norm (RMS | Layer)
 
-This design implements a `bfloat16` row-wise norm — either **RMSNorm** or **LayerNorm** — across an 8-core sequence. The op is selected at compile time via the `op` parameter; the structural design and host harness are shared. NPU2-only (the underlying kernels live under `aie_kernels/aie2p/`).
+This design implements a row-wise norm — **RMSNorm** or **LayerNorm** — across an 8-core sequence. The op is selected at compile time via the `op` parameter; the structural design and host harness are shared. NPU2-only (the underlying kernels live under `aie_kernels/aie2p/`).
 
 Per row:
 
-* `op=rms` &nbsp;&nbsp;`out = (x * gamma) / sqrt(mean(x^2) + eps)`  &nbsp;&nbsp;(gamma=1, eps=1e-5)
-* `op=layer` &nbsp;&nbsp;`out = (x - mean(x)) / sqrt(var(x) + eps) * gamma + beta`  &nbsp;&nbsp;(gamma=1, beta=0, eps=1e-5)
+* `op=rms` &nbsp;&nbsp;`out = (x * gamma) / sqrt(mean(x^2) + eps)`  &nbsp;&nbsp;(bf16; gamma=1, eps=1e-5)
+* `op=layer` &nbsp;&nbsp;`out = (x - mean(x)) / sqrt(var(x) + eps) * gamma + beta`  &nbsp;&nbsp;(bf16; gamma=1, beta=0, eps=1e-5)
+* `op=layer_f32` &nbsp;&nbsp;the same LayerNorm in f32 in/out, with a numerically stable centered two-pass variance. bf16 keeps the mean/std ratio small (a bf16 value near a large mean has an ulp wider than the std), so `E[x^2] - mean^2` is safe there; f32 can represent a large mean, where that form cancels, so the f32 path centers first.
 
 
 ## Source Files Overview
 
-1. `norm.py`: IRON design. `op` is a `CompileTime[str]` parameter that selects `rms_norm.cc` or `layer_norm.cc`. Per-op reference and tolerance live in a small dispatch table.
+1. `norm.py`: IRON design. `op` is a `CompileTime[str]` parameter that selects the kernel (`rms_norm.cc` or `layer_norm.cc`) and the tensor dtype (bf16, or f32 for `layer_f32`). Per-op reference and tolerance live in a small dispatch table.
 
 1. `rms_norm.cc` / `layer_norm.cc`: AIE2P kernels pulled from [`aie_kernels/aie2p/`](../../../aie_kernels/aie2p/).
 
-1. `test.cpp`: C++ testbench that loads the compiled XCLBIN + `insts.bin` via `setup_and_run_aie`, computes the per-row reference, and reports pass/fail with a per-op tolerance. The op is selected via the `NORM_OP` env var (set by the Makefile's `run` target).
+1. `test.cpp`: C++ testbench for the bf16 ops (`rms`, `layer`). It loads the compiled XCLBIN + `insts.bin` via `setup_and_run_aie`, computes the per-row reference, and reports pass/fail with a per-op tolerance. The op is selected via the `NORM_OP` env var (set by the Makefile's `run` target). The f32 `layer_f32` op is verified through the standalone Python path instead (`norm.py`'s dispatch table, driven by `run_strix.lit`), against an f64 gold reference.
 
 
 ## Usage
@@ -31,7 +32,10 @@ Per row:
 ```shell
 python3 norm.py --dev npu2 --op rms
 python3 norm.py --dev npu2 --op layer
+python3 norm.py --dev npu2 --op layer_f32 --embedding_dim 2048
 ```
+
+`layer_f32` uses `embedding_dim=2048` because an f32 row is twice the bytes of a bf16 row and a 4096-wide f32 row does not fit the tile's local memory double-buffered.
 
 ### C++ Testbench
 

--- a/programming_examples/ml/norm/norm.py
+++ b/programming_examples/ml/norm/norm.py
@@ -3,19 +3,23 @@
 # Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-"""Row-wise bf16 norm (RMSNorm | LayerNorm) — IRON API + ``@iron.jit``.
+"""Row-wise norm (RMSNorm | LayerNorm) — IRON API + ``@iron.jit``.
 
 NPU2-only: the underlying ``{rms,layer}_norm.cc`` kernels live under
 ``aie_kernels/aie2p/`` and have no aie2 counterpart.
 
 Eight cores process ``sequence_length // 8`` rows each; one row =
-``embedding_dim`` bf16 values. Per row:
+``embedding_dim`` values. Per row:
 
-  * rms (gamma=1, eps=1e-5):
+  * rms (bf16, gamma=1, eps=1e-5):
       out = (x * gamma) / sqrt(mean(x^2) + eps)
 
-  * layer (gamma=1, beta=0, eps=1e-5):
+  * layer (bf16, gamma=1, beta=0, eps=1e-5):
       out = (x - mean(x)) / sqrt(var(x) + eps) * gamma + beta
+
+  * layer_f32: the same LayerNorm in f32 in/out, with a numerically stable
+      centered two-pass variance (for the non-zero-mean inputs that f32 can
+      represent and bf16 cannot).
 """
 
 import argparse
@@ -39,7 +43,11 @@ _KERNEL_DIR = Path(__file__).resolve().parents[3] / "aie_kernels/aie2p"
 _KERNEL_SPEC = {
     "rms": ("rms_norm", _KERNEL_DIR / "rms_norm.cc"),
     "layer": ("layer_norm", _KERNEL_DIR / "layer_norm.cc"),
+    "layer_f32": ("layer_norm_f32", _KERNEL_DIR / "layer_norm.cc"),
 }
+
+# rms / layer are bf16; layer_f32 is the f32-in/f32-out per-row LayerNorm.
+_OP_DTYPE = {"rms": bfloat16, "layer": bfloat16, "layer_f32": np.float32}
 
 
 def _norm_extern(op, chunk_type):
@@ -63,16 +71,22 @@ def norm(
 ):
     device = iron.get_current_device()
     n_cores = 8
+    vec = 16  # kernels reduce/store one aie::vector<T, 16> at a time
 
     if sequence_length % n_cores != 0:
         raise ValueError(
             f"sequence_length ({sequence_length}) must be a multiple of {n_cores}"
         )
+    if embedding_dim % vec != 0:
+        # The layer / layer_f32 kernels process full vec-wide chunks with no
+        # scalar tail, so a non-multiple would silently drop the last columns.
+        raise ValueError(f"embedding_dim ({embedding_dim}) must be a multiple of {vec}")
 
     rows_per_core = sequence_length // n_cores
 
-    tensor_ty = np.ndarray[(sequence_length, embedding_dim), np.dtype[bfloat16]]
-    chunk_ty = np.ndarray[(embedding_dim,), np.dtype[bfloat16]]
+    dtype = _OP_DTYPE[op]
+    tensor_ty = np.ndarray[(sequence_length, embedding_dim), np.dtype[dtype]]
+    chunk_ty = np.ndarray[(embedding_dim,), np.dtype[dtype]]
 
     of_ins = [ObjectFifo(chunk_ty, name=f"in_{i}") for i in range(n_cores)]
     of_outs = [ObjectFifo(chunk_ty, name=f"out_{i}") for i in range(n_cores)]
@@ -113,7 +127,11 @@ def _make_argparser():
     p.add_argument("-s", "--sequence_length", type=int, default=64, help="rows")
     p.add_argument("-e", "--embedding_dim", type=int, default=4096, help="cols per row")
     p.add_argument(
-        "-o", "--op", choices=("rms", "layer"), default="rms", help="norm flavor"
+        "-o",
+        "--op",
+        choices=("rms", "layer", "layer_f32"),
+        default="rms",
+        help="norm flavor",
     )
     return p
 
@@ -142,26 +160,56 @@ def _layer_norm_reference(x_np):
     return ((x32 - mean) * inv_std * gamma + beta).astype(bfloat16)
 
 
-# per op: (reference fn, elementwise atol, mean per-row rel-L2 ceiling or None)
+def _layer_norm_f32_reference(x_np):
+    # Gold reference for the f32 kernel: centered two-pass variance in f64, f32
+    # output. Centered (not E[x^2]-mean^2) so it stays exact on the non-zero-mean
+    # input the kernel is exercised with.
+    eps, gamma, beta = 1e-5, 1.0, 0.0
+    x64 = x_np.astype(np.float64)
+    mean = x64.mean(axis=1, keepdims=True)
+    var = ((x64 - mean) ** 2).mean(axis=1, keepdims=True)
+    inv_std = 1.0 / np.sqrt(var + eps)
+    return ((x64 - mean) * inv_std * gamma + beta).astype(np.float32)
+
+
+# per op: (reference fn, elementwise atol, rtol, mean per-row rel-L2 ceiling).
+# rtol: assert_pass defaults to 0.128 (the bf16/LUT-tuned relative tolerance)
+# when only atol is given, which would dominate an O(1) LayerNorm output and mask
+# the f32 kernel's real error, so layer_f32 pins rtol=0 to let its tight absolute
+# atol actually govern. The bf16 ops keep the default (None).
+# rel-L2: aggregate accumulation guard, bf16 ops only; the f32 path is checked
+# directly by its atol.
 _VERIFY_CFG = {
-    "rms": (_rms_norm_reference, 0.05, None),
-    "layer": (_layer_norm_reference, 0.05, 0.01),
+    "rms": (_rms_norm_reference, 0.05, None, None),
+    "layer": (_layer_norm_reference, 0.05, None, 0.01),
+    "layer_f32": (_layer_norm_f32_reference, 1e-3, 0.0, None),
 }
 
 
 def _run_and_verify(opts):
     rng = np.random.default_rng(0)
     rows, cols = opts.sequence_length, opts.embedding_dim
-    a_np = rng.uniform(-1.0, 1.0, size=(rows, cols)).astype(bfloat16)
-    a_t = iron.tensor(a_np, dtype=bfloat16, device="npu")
+    dtype = _OP_DTYPE[opts.op]
+
+    if opts.op == "layer_f32":
+        # Non-zero row mean (~100): representable in f32 but not bf16, and large
+        # enough that E[x^2]-mean^2 loses the variance to f32 cancellation while
+        # the centered two-pass stays exact. Exercises what the f32 path is for.
+        a_np = (rng.uniform(-1.0, 1.0, size=(rows, cols)) + 100.0).astype(dtype)
+    else:
+        a_np = rng.uniform(-1.0, 1.0, size=(rows, cols)).astype(dtype)
+
+    a_t = iron.tensor(a_np, dtype=dtype, device="npu")
     c_t = iron.zeros_like(a_t)
 
     norm(a_t, c_t, **_compile_kwargs(opts))
 
-    ref_fn, atol, rel_l2_max = _VERIFY_CFG[opts.op]
+    ref_fn, atol, rtol, rel_l2_max = _VERIFY_CFG[opts.op]
     out = c_t.numpy().reshape(rows, cols)
     ref = ref_fn(a_np)
-    assert_pass(out, ref, atol=atol, fail_msg=f"{opts.op}norm output mismatch")
+    assert_pass(
+        out, ref, atol=atol, rtol=rtol, fail_msg=f"{opts.op}norm output mismatch"
+    )
 
     # Aggregate regression guard. The elementwise atol above is bounded by bf16
     # output quantization and barely moves when the reduction loses precision,

--- a/programming_examples/ml/norm/run_strix.lit
+++ b/programming_examples/ml/norm/run_strix.lit
@@ -5,3 +5,4 @@
 //
 // RUN: %run_on_npu2% %python %S/norm.py -d npu2 -o rms
 // RUN: %run_on_npu2% %python %S/norm.py -d npu2 -o layer
+// RUN: %run_on_npu2% %python %S/norm.py -d npu2 -o layer_f32 -e 2048


### PR DESCRIPTION
## What

Add a correct f32 per-row `layer_norm` to `aie_kernels/aie2p/layer_norm.cc`, replacing the wrong-axis, unlinked `layer_norm_welford`, and wire it into the `ml/norm` example as `op=layer_f32`.

## Why

`layer_norm_welford` was the file's only f32 LayerNorm, but its Welford reduction runs down the **rows** axis, accumulating per-**column** statistics. LayerNorm normalizes each row over its feature axis (cols), so it computed the wrong thing, and nothing linked it (the example only builds the bf16 `layer_norm`). There is currently no working f32 per-row LayerNorm here.

## How

`layer_norm_f32`: f32 in/out, reduces over `cols` per row, with a numerically stable centered two-pass variance (`sum((x-mean)^2)/cols`) instead of `E[x^2] - mean^2`.

The dtype is the point. The bf16 `layer_norm` uses `E[x^2] - mean^2`, which is safe under a bf16 input contract: a bf16 value near a large mean has an ulp wider than the std, so the large-mean / small-std regime where that form cancels is unrepresentable. f32 **can** represent that regime, so the f32 path centers first.

Wired into `ml/norm` as `op=layer_f32`: f32 tensors, an f64 gold reference, and a non-zero-mean input (row mean ~100) that exercises the centering. Verified through the standalone Python path (`run_strix.lit`, the same `%python %S/norm.py -o ...` form the rms/layer JIT checks already use), not the bf16 `test.cpp`. Two guards fall out of the dtype switch:

- The verify pins `rtol=0` so the f32 kernel's tight `atol=1e-3` actually governs (`assert_pass` otherwise defaults `rtol=0.128`, which would swamp an O(1) LayerNorm output and mask the error).
- `embedding_dim` is required to be a multiple of the 16-wide vector, since the kernels process full vector chunks with no scalar tail.

## Test

`programming_examples/ml/norm op=layer_f32` on NPU2 at `embedding_dim=2048` (an f32 row is twice the bytes of bf16, and a 4096-wide f32 row does not fit the tile's local memory double-buffered):

| embedding_dim | max-abs vs f64 reference |
|---------------|--------------------------|
| 1024          | 1.5e-5                   |
| 2048          | 2.4e-5                   |

Passes at `atol=1e-3, rtol=0`; a reintroduced `E[x^2] - mean^2` kernel fails that gate on device. The bf16 `rms` and `layer` paths are unchanged and still pass.

## Notes

Touches the same file as #3410, but a disjoint region of the kernel (that PR changes the bf16 `layer_norm`; this changes the f32 kernel), so those auto-merge. The two do overlap in `norm.py`'s `_VERIFY_CFG` dispatch table; whichever lands first, the other is a one-line rebase.
