### PR TITLE
Add route pinning to `aie.flow` with `via`

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -227,6 +227,21 @@ void printObjectFifoConsumerTiles(mlir::OpAsmPrinter &printer,
                                   mlir::Operation *op, mlir::OperandRange tiles,
                                   BDDimLayoutArrayArrayAttr dimsPerTileAttr);
 
+mlir::ParseResult
+parseFlowVias(mlir::OpAsmParser &parser,
+              llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &vias,
+              mlir::DenseI32ArrayAttr &ingressBundles,
+              mlir::DenseI32ArrayAttr &ingressChannels,
+              mlir::DenseI32ArrayAttr &egressBundles,
+              mlir::DenseI32ArrayAttr &egressChannels);
+
+void printFlowVias(mlir::OpAsmPrinter &printer, mlir::Operation *op,
+                   mlir::OperandRange vias,
+                   mlir::DenseI32ArrayAttr ingressBundles,
+                   mlir::DenseI32ArrayAttr ingressChannels,
+                   mlir::DenseI32ArrayAttr egressBundles,
+                   mlir::DenseI32ArrayAttr egressChannels);
+
 int32_t getBufferBaseAddress(mlir::Operation *bufOp);
 
 // Trace Event Value Parsing/Printing (handles both string and typed enums)

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -563,14 +563,15 @@ def AIE_ConnectOp: AIE_Op<"connect", [ParentOneOf<["SwitchboxOp", "ShimMuxOp"]> 
 }
 
 def AIE_FlowOp: AIE_Op<"flow", []> {
-  let arguments = (
-    ins Index:$source,
-        WireBundle:$source_bundle,
-        ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$source_channel,
-        Index:$dest,
-        WireBundle:$dest_bundle,
-        ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$dest_channel
-  );
+  let arguments = (ins Index:$source, WireBundle:$source_bundle,
+      ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$source_channel, Index:$dest,
+      WireBundle:$dest_bundle,
+      ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$dest_channel,
+      Variadic<Index>:$vias,
+      OptionalAttr<DenseI32ArrayAttr>:$via_ingress_bundles,
+      OptionalAttr<DenseI32ArrayAttr>:$via_ingress_channels,
+      OptionalAttr<DenseI32ArrayAttr>:$via_egress_bundles,
+      OptionalAttr<DenseI32ArrayAttr>:$via_egress_channels);
   let summary = "A logical circuit-switched connection between cores";
   let description = [{
     The `aie.flow` operation represents a circuit switched connection between two endpoints, usually
@@ -578,18 +579,41 @@ def AIE_FlowOp: AIE_Op<"flow", []> {
     the programmed connections inside a switchbox, along with `aie.wire` operations which represent
     physical connections between switchboxes and other components.
 
+    An optional `via` list pins the exact tiles and stream-switch ports the flow
+    must route through.  Each via is a tuple of a tile value together with the
+    ingress and egress port (bundle and channel) the stream uses at that tile,
+    so the intermediate switchbox configuration follows from the flow itself.  A
+    flow with vias is equivalent to the disaggregated flows that meet on the via
+    ports, and `--aie-split-flow-vias` rewrites it into those segments plus the
+    pinned switchbox connections.
+
     Example:
     ```
       %00 = aie.tile(0, 0)
       %11 = aie.tile(1, 1)
       %01 = aie.tile(0, 1)
       aie.flow(%00, "DMA" : 0, %11, "Core" : 1)
+      aie.flow(%00, "DMA" : 0, %11, "Core" : 1) via (%01 : South : 0 -> North : 0)
     ```
   }];
 
   let assemblyFormat = [{
-    `(` $source `,` $source_bundle `:` $source_channel `,` $dest `,` $dest_bundle `:` $dest_channel `)` attr-dict
+    `(` $source `,` $source_bundle `:` $source_channel `,` $dest `,` $dest_bundle `:` $dest_channel `)`
+    custom<FlowVias>($vias, $via_ingress_bundles, $via_ingress_channels, $via_egress_bundles, $via_egress_channels)
+    attr-dict
   }];
+
+  let hasVerifier = 1;
+
+  let builders = [OpBuilder<
+      (ins "mlir::Value":$source, "xilinx::AIE::WireBundle":$source_bundle,
+          "int":$source_channel, "mlir::Value":$dest,
+          "xilinx::AIE::WireBundle":$dest_bundle, "int":$dest_channel),
+      [{
+      build($_builder, $_state, source, source_bundle, source_channel, dest,
+            dest_bundle, dest_channel, mlir::ValueRange{}, nullptr, nullptr,
+            nullptr, nullptr);
+    }]>];
 
   let extraClassDeclaration = [{
     int sourceIndex() { return getSourceChannel(); }
@@ -800,25 +824,50 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
     so that they always get allocated with the same master, slave
     ports, arbiters and master selects (msel).
 
+    The optional attribute mask, written directly after the ID in the
+    parentheses, pins the packet-rule mask for the flow. A packet is
+    accepted at a slave port when (incoming ID & mask) == (ID & mask),
+    so the flow matches every ID sharing the unmasked bits of ID. When
+    omitted, the mask is derived automatically during routing.
+
     Example:
     ```
       %01 = aie.tile(0, 1)
-      aie.packet_flow(0x10) {
+      aie.packet_flow(0x10 mask 0x1f) {
         aie.packet_source<%01, "Core" : 0>
         aie.packet_dest<%01, "Core" : 0>
       }
     ```
   }];
 
-  let arguments = (
-    ins AIEI8Attr:$ID,
-        OptionalAttr<BoolAttr>:$keep_pkt_header,
-        OptionalAttr<BoolAttr>:$priority_route
-  );
+  let arguments = (ins AIEI8Attr:$ID, OptionalAttr<AIEI8Attr>:$mask,
+      OptionalAttr<BoolAttr>:$keep_pkt_header,
+      OptionalAttr<BoolAttr>:$priority_route, Variadic<Index>:$vias,
+      OptionalAttr<DenseI32ArrayAttr>:$via_ingress_bundles,
+      OptionalAttr<DenseI32ArrayAttr>:$via_ingress_channels,
+      OptionalAttr<DenseI32ArrayAttr>:$via_egress_bundles,
+      OptionalAttr<DenseI32ArrayAttr>:$via_egress_channels);
   let regions = (region AnyRegion:$ports);
 
-  let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
+  let assemblyFormat = [{ `(` $ID (`mask` $mask^)? `)` regions
+    custom<FlowVias>($vias, $via_ingress_bundles, $via_ingress_channels, $via_egress_bundles, $via_egress_channels)
+    attr-dict }];
   let hasVerifier = 1;
+
+  let builders = [OpBuilder<(ins "uint8_t":$ID,
+                                "mlir::BoolAttr":$keep_pkt_header,
+                                "mlir::BoolAttr":$priority_route),
+                            [{
+      build($_builder, $_state, ID, nullptr, keep_pkt_header, priority_route,
+            mlir::ValueRange{}, nullptr, nullptr, nullptr, nullptr);
+    }]>,
+                  OpBuilder<(ins "mlir::IntegerAttr":$ID,
+                                "mlir::BoolAttr":$keep_pkt_header,
+                                "mlir::BoolAttr":$priority_route),
+                            [{
+      build($_builder, $_state, ID, nullptr, keep_pkt_header, priority_route,
+            mlir::ValueRange{}, nullptr, nullptr, nullptr, nullptr);
+    }]>];
 
   let extraClassDeclaration = [{
     int IDInt() { return getID(); }

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -826,6 +826,17 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
     so that they always get allocated with the same master, slave
     ports, arbiters and master selects (msel).
 
+    The optional attribute mask, written after the ID in the parentheses,
+    states the packet-rule mask of the flow. A slave port accepts a packet
+    when `incoming & mask == ID`, so the flow claims every ID that agrees
+    with ID on the bits the mask selects. Routing derives a mask from the
+    IDs it knows when the attribute is absent. ID must have no bit outside
+    the mask, or no packet can match.
+
+    A design may compute a packet header at run time, so which IDs reach a
+    port is not decidable here. State the mask to claim a set of IDs that
+    routing cannot see.
+
     Example:
     ```
       %01 = aie.tile(0, 1)
@@ -833,18 +844,34 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
         aie.packet_source<%01, "Core" : 0>
         aie.packet_dest<%01, "Core" : 0>
       }
+      // Claims 0x10 through 0x13: the mask ignores the low two bits.
+      aie.packet_flow(0x10 mask 0x1c) {
+        aie.packet_source<%01, "Core" : 0>
+        aie.packet_dest<%01, "Core" : 0>
+      }
     ```
   }];
 
-  let arguments = (
-    ins AIEI8Attr:$ID,
-        OptionalAttr<BoolAttr>:$keep_pkt_header,
-        OptionalAttr<BoolAttr>:$priority_route
-  );
+  let arguments = (ins AIEI8Attr:$ID, OptionalAttr<AIEI8Attr>:$mask,
+      OptionalAttr<BoolAttr>:$keep_pkt_header,
+      OptionalAttr<BoolAttr>:$priority_route);
   let regions = (region AnyRegion:$ports);
 
-  let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
+  let assemblyFormat = [{ `(` $ID (`mask` $mask^)? `)` regions attr-dict }];
   let hasVerifier = 1;
+
+  let builders = [OpBuilder<(ins "uint8_t":$ID,
+                                "mlir::BoolAttr":$keep_pkt_header,
+                                "mlir::BoolAttr":$priority_route),
+                            [{
+      build($_builder, $_state, ID, nullptr, keep_pkt_header, priority_route);
+    }]>,
+                  OpBuilder<(ins "mlir::IntegerAttr":$ID,
+                                "mlir::BoolAttr":$keep_pkt_header,
+                                "mlir::BoolAttr":$priority_route),
+                            [{
+      build($_builder, $_state, ID, nullptr, keep_pkt_header, priority_route);
+    }]>];
 
   let extraClassDeclaration = [{
     int IDInt() { return getID(); }

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.h
@@ -48,6 +48,7 @@ createAIECoreToStandardPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createAIECoreToStandardPass(const AIECoreToStandardOptions &options);
 std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIEFindFlowsPass();
+std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIESplitFlowViasPass();
 std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIELocalizeLocksPass();
 std::unique_ptr<mlir::OperationPass<DeviceOp>>
 createAIENormalizeAddressSpacesPass();

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -274,14 +274,54 @@ def AIEFindFlows : Pass<"aie-find-flows", "DeviceOp"> {
     by aie.flow) or a packet-switched connection (represensted by
     aie.packetflow).  This pass is primarily used for testing automatic
     routing.
+
+    By default every configured connection is lifted, including partial flows
+    whose source or destination is a directional switchbox port rather than a
+    core or DMA (transit connections, PLIO/edge entries, and packet routes a
+    running design steers by packet id).  A physically routed design can
+    therefore drop its aie.switchbox configuration and recover it from the
+    lifted flows.  Set `keep-partial-flows=false` to restrict recovery to flows
+    that begin at a core/DMA and end on a core/DMA.
   }];
 
   let constructor = "xilinx::AIE::createAIEFindFlowsPass()";
   let dependentDialects = [
     "xilinx::AIE::AIEDialect",
   ];
+
+  let options =
+      [Option<"clKeepPartialFlows", "keep-partial-flows", "bool",
+              /*default=*/"true",
+              "Also recover partial flows whose source or destination is a "
+              "directional/edge switchbox port rather than a core or DMA.">,
+       Option<
+           "clEmitVias", "emit-vias", "bool", /*default=*/"false",
+           "Emit each recovered flow with a via list pinning every switchbox "
+           "hop, so the flow carries its own route and the router can skip "
+           "it.">,
+       Option<
+           "clRemoveLifted", "remove-lifted", "bool", /*default=*/"true",
+           "Remove the interconnect configuration (connects, packet rules, "
+           "mastersets, amsels, wires) that was lifted into recovered flows, "
+           "leaving only configuration that could not be lifted.">,
+  ];
 }
 
+def AIESplitFlowVias : Pass<"aie-split-flow-vias", "DeviceOp"> {
+  let summary = "Split aie.flow operations that pin via ports into segments";
+  let description = [{
+    Each `aie.flow` that carries a `via` list is rewritten into the
+    disaggregated flows that meet on the via ports, plus an `aie.switchbox`
+    connection at every via tile joining its pinned ingress and egress ports.
+    A flow `A via (B : in -> eg) to C` becomes `aie.flow(A, B:in)`,
+    `aie.switchbox(B) { aie.connect<in, eg> }`, and `aie.flow(B:eg, C)`.  The
+    pass elides a segment whose source and destination coincide, which happens
+    when the flow already begins or ends on a via port.
+  }];
+
+  let constructor = "xilinx::AIE::createAIESplitFlowViasPass()";
+  let dependentDialects = ["xilinx::AIE::AIEDialect", ];
+}
 
 def AIEVectorTransferLowering : Pass<"aie-vector-transfer-lowering", "DeviceOp"> {
   let summary = "Lower vector.transfer_read/write to vector.load/store for AIE";

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -325,14 +325,31 @@ def AIEFindFlows : Pass<"aie-find-flows", "DeviceOp"> {
     by aie.flow) or a packet-switched connection (represensted by
     aie.packetflow).  This pass is primarily used for testing automatic
     routing.
+
+    By default every configured connection is lifted, including partial flows
+    whose source or destination is a directional switchbox port rather than a
+    core or DMA (transit connections, PLIO/edge entries, and packet routes a
+    running design steers by packet id).  A physically routed design can
+    therefore drop its aie.switchbox configuration and recover it from the
+    lifted flows.  Set `keep-partial-flows=false` to restrict recovery to flows
+    that begin at a core/DMA and end on a core/DMA.
   }];
 
   let constructor = "xilinx::AIE::createAIEFindFlowsPass()";
-  let dependentDialects = [
-    "xilinx::AIE::AIEDialect",
+  let dependentDialects = ["xilinx::AIE::AIEDialect", ];
+
+  let options =
+      [Option<"clKeepPartialFlows", "keep-partial-flows", "bool",
+              /*default=*/"true",
+              "Also recover partial flows whose source or destination is a "
+              "directional/edge switchbox port rather than a core or DMA.">,
+       Option<
+           "clRemoveLifted", "remove-lifted", "bool", /*default=*/"true",
+           "Remove the interconnect configuration (connects, packet rules, "
+           "mastersets, amsels, wires) that was lifted into recovered flows, "
+           "leaving only configuration that could not be lifted.">,
   ];
 }
-
 
 def AIEVectorTransferLowering : Pass<"aie-vector-transfer-lowering", "DeviceOp"> {
   let summary = "Lower vector.transfer_read/write to vector.load/store for AIE";

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1225,6 +1225,84 @@ static void printObjectFifoConsumerElemType(OpAsmPrinter &p,
     p << " -> " << consumerElemType;
 }
 
+ParseResult xilinx::AIE::parseFlowVias(
+    OpAsmParser &parser, SmallVectorImpl<OpAsmParser::UnresolvedOperand> &vias,
+    DenseI32ArrayAttr &ingressBundles, DenseI32ArrayAttr &ingressChannels,
+    DenseI32ArrayAttr &egressBundles, DenseI32ArrayAttr &egressChannels) {
+  SmallVector<int32_t> inBundles, inChannels, egBundles, egChannels;
+  auto parseBundle = [&](SmallVectorImpl<int32_t> &out) -> ParseResult {
+    StringRef kw;
+    if (parser.parseKeyword(&kw))
+      return failure();
+    auto bundle = symbolizeWireBundle(kw);
+    if (!bundle)
+      return parser.emitError(parser.getCurrentLocation(),
+                              "invalid wire bundle '" + kw + "'");
+    out.push_back(static_cast<int32_t>(*bundle));
+    return success();
+  };
+  // via ( %tile : <ingress bundle> : <ch> -> <egress bundle> : <ch>, ... )
+  if (succeeded(parser.parseOptionalKeyword("via"))) {
+    auto parseOne = [&]() -> ParseResult {
+      int32_t inChan, egChan;
+      if (parser.parseOperand(vias.emplace_back()) || parser.parseColon() ||
+          parseBundle(inBundles) || parser.parseColon() ||
+          parser.parseInteger(inChan) || parser.parseArrow() ||
+          parseBundle(egBundles) || parser.parseColon() ||
+          parser.parseInteger(egChan))
+        return failure();
+      inChannels.push_back(inChan);
+      egChannels.push_back(egChan);
+      return success();
+    };
+    if (parser.parseCommaSeparatedList(AsmParser::Delimiter::Paren, parseOne))
+      return failure();
+  }
+  if (!vias.empty()) {
+    MLIRContext *ctx = parser.getContext();
+    ingressBundles = DenseI32ArrayAttr::get(ctx, inBundles);
+    ingressChannels = DenseI32ArrayAttr::get(ctx, inChannels);
+    egressBundles = DenseI32ArrayAttr::get(ctx, egBundles);
+    egressChannels = DenseI32ArrayAttr::get(ctx, egChannels);
+  }
+  return success();
+}
+
+void xilinx::AIE::printFlowVias(OpAsmPrinter &printer, Operation *op,
+                                OperandRange vias,
+                                DenseI32ArrayAttr ingressBundles,
+                                DenseI32ArrayAttr ingressChannels,
+                                DenseI32ArrayAttr egressBundles,
+                                DenseI32ArrayAttr egressChannels) {
+  if (vias.empty())
+    return;
+  printer << "via (";
+  for (size_t i = 0; i < vias.size(); i++) {
+    if (i)
+      printer << ", ";
+    printer << vias[i] << " : "
+            << stringifyWireBundle(static_cast<WireBundle>(ingressBundles[i]))
+            << " : " << ingressChannels[i] << " -> "
+            << stringifyWireBundle(static_cast<WireBundle>(egressBundles[i]))
+            << " : " << egressChannels[i];
+  }
+  printer << ")";
+}
+
+LogicalResult FlowOp::verify() {
+  size_t n = getVias().size();
+  DenseI32ArrayAttr arrays[] = {
+      getViaIngressBundlesAttr(), getViaIngressChannelsAttr(),
+      getViaEgressBundlesAttr(), getViaEgressChannelsAttr()};
+  for (DenseI32ArrayAttr a : arrays) {
+    size_t size = a ? a.size() : 0;
+    if (size != n)
+      return emitOpError("has ")
+             << n << " via tile(s) but a via port array of size " << size;
+  }
+  return success();
+}
+
 static ParseResult parseObjectFifoConsumerElemType(OpAsmParser &parser,
                                                    TypeAttr &consumerElemType) {
   if (failed(parser.parseOptionalArrow()))
@@ -2403,6 +2481,17 @@ LogicalResult PacketFlowOp::verify() {
     return emitOpError("must have at least one aie.packet_source");
   if (numDests < 1)
     return emitOpError("must have at least one aie.packet_dest");
+
+  size_t n = getVias().size();
+  DenseI32ArrayAttr arrays[] = {
+      getViaIngressBundlesAttr(), getViaIngressChannelsAttr(),
+      getViaEgressBundlesAttr(), getViaEgressChannelsAttr()};
+  for (DenseI32ArrayAttr a : arrays) {
+    size_t size = a ? a.size() : 0;
+    if (size != n)
+      return emitOpError("has ")
+             << n << " via tile(s) but a via port array of size " << size;
+  }
 
   return success();
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1974,12 +1974,18 @@ LogicalResult verifyNoDuplicateFlows(DeviceOp device) {
 }
 
 // Rejects two aie.packet_flow ops that carry the same ID between the same set
-// of sources and destinations. Declaring the flow twice makes the routing
-// problem look more congested than it is and gives the two copies conflicting
-// keep_pkt_header/priority_route settings when their attributes disagree.
+// of sources and destinations under the same mask. Declaring the flow twice
+// makes the routing problem look more congested than it is and gives the two
+// copies conflicting keep_pkt_header/priority_route settings when their
+// attributes disagree.
+//
+// The mask belongs in the key because it is half of what a flow claims: an ID
+// under two masks names two sets of packets, so the two flows carry different
+// traffic. A flow without the attribute claims its ID alone, which is what the
+// widest mask says, so both spellings key alike.
 LogicalResult verifyNoDuplicatePacketFlows(DeviceOp device) {
   using PacketFlowKey =
-      std::tuple<int, std::vector<PortKey>, std::vector<PortKey>>;
+      std::tuple<int, int, std::vector<PortKey>, std::vector<PortKey>>;
   std::map<PacketFlowKey, PacketFlowOp> packetFlowSeen;
   WalkResult result = device.walk([&](PacketFlowOp packetFlow) {
     Region &body = packetFlow.getPorts();
@@ -2011,12 +2017,17 @@ LogicalResult verifyNoDuplicatePacketFlows(DeviceOp device) {
       return WalkResult::advance();
     llvm::sort(sources);
     llvm::sort(dests);
+    int idBits =
+        llvm::Log2_32_Ceil(device.getTargetModel().getMaxPacketId() + 1);
+    int mask = packetFlow.getMask().value_or((1 << idBits) - 1);
     auto [it, inserted] = packetFlowSeen.try_emplace(
-        {packetFlow.IDInt(), std::move(sources), std::move(dests)}, packetFlow);
+        {packetFlow.IDInt(), mask, std::move(sources), std::move(dests)},
+        packetFlow);
     if (!inserted) {
       InFlightDiagnostic diag =
           packetFlow.emitOpError()
           << "duplicates an earlier packet flow; ID " << packetFlow.IDInt()
+          << " under mask 0x" << llvm::utohexstr(mask)
           << " is already declared between the same sources and destinations";
       diag.attachNote(it->second.getLoc()) << "the other packet flow is here";
       return WalkResult::interrupt();
@@ -2545,6 +2556,16 @@ LogicalResult PacketFlowOp::verify() {
     return emitOpError("must have at least one aie.packet_source");
   if (numDests < 1)
     return emitOpError("must have at least one aie.packet_dest");
+
+  // A slave port accepts a packet when `incoming & mask == ID`, so a bit set
+  // in ID and clear in the mask rejects every packet.
+  if (std::optional<uint8_t> mask = getMask()) {
+    uint8_t id = getID();
+    if ((id & *mask) != id)
+      return emitOpError("has ID 0x")
+             << llvm::utohexstr(id) << " outside mask 0x"
+             << llvm::utohexstr(*mask) << ", which no packet can match";
+  }
 
   return success();
 }

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -22,6 +23,8 @@
 #include "llvm/Support/MathExtras.h"
 
 #include <cstdint>
+
+#include <set>
 
 using namespace mlir;
 using namespace xilinx;
@@ -97,9 +100,16 @@ struct ConvertFlowsToInterconnect : OpConversionPattern<FlowOp> {
     TileID srcSbId = {srcCoords.col, srcCoords.row};
     PathEndPoint srcPoint = {srcSbId, srcPort};
     if (analyzer.processedFlows[srcPoint]) {
+      // This FlowOp is a broadcast sibling of a flow whose route was already
+      // materialized (the analyzer merges all destinations sharing a source
+      // into one net, so the first sibling emitted connections for every
+      // destination). Erase it and report success so the erase is committed;
+      // returning failure() here would roll the erase back and leave a stale
+      // aie.flow in the routed IR, breaking idempotency (re-running the pass
+      // would try to re-route an already-routed net and fail).
       LLVM_DEBUG(llvm::dbgs() << "Flow already processed!\n");
       rewriter.eraseOp(Op);
-      return failure();
+      return success();
     }
     // std::map<TileID, SwitchSetting>
     SwitchSettings settings = analyzer.flowSolutions[srcPoint];
@@ -251,6 +261,13 @@ bool AIEPathfinderPass::findPathToDest(const SwitchSettings &settings,
   }
 
   int neighbourSourceChannel = currDestChannel;
+  // The destination may itself be a fabric input port (e.g. a partial packet
+  // flow pinned to end at a switchbox port). Such a port is never the output of
+  // any switchbox setting, so it would otherwise never match; recognize arrival
+  // when the current output feeds the final tile's destination input directly.
+  if (neighbourTile == finalTile && neighbourSourceBundle == finalDestBundle &&
+      neighbourSourceChannel == finalDestChannel)
+    return true;
   for (const auto &[sbNode, setting] : settings) {
     TileID tile = {sbNode.col, sbNode.row};
     if (tile == neighbourTile) {
@@ -484,6 +501,11 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   std::map<std::pair<PhysPort, int>, SmallVector<PhysPort, 4>> ctrlPacketFlows;
   SmallVector<std::pair<PhysPort, int>, 4> slavePorts;
   DenseMap<std::pair<PhysPort, int>, int> slaveAMSels;
+  // Explicit packet-rule masks pinned by aie.packet_flow's mask attribute. The
+  // key is the slave port (switchbox ingress) together with the flow ID,
+  // because a design may reuse one ID across flows that declare different
+  // masks. A flow without an explicit mask has its mask derived from the ids.
+  std::map<std::pair<PhysPort, int>, int> explicitPortMasks;
   // Flag to keep packet header at packet flow destination
   DenseMap<PhysPort, BoolAttr> keepPktHeaderAttr;
   // Map from tileID and master ports to flags labelling control packet flows
@@ -503,6 +525,10 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     Region &r = pktFlowOp.getPorts();
     Block &b = r.front();
     int flowID = pktFlowOp.IDInt();
+    std::optional<int> flowMask =
+        pktFlowOp.getMask()
+            ? std::optional<int>(static_cast<int>(*pktFlowOp.getMask()))
+            : std::nullopt;
     SmallVector<std::pair<TileID, Port>, 4> sources;
 
     // Pass 1: collect all sources (order-independent; supports fan-in).
@@ -557,6 +583,12 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
                     switchboxes[currTile].begin(), switchboxes[currTile].end(),
                     std::pair{connect, flowID}) == switchboxes[currTile].end())
               switchboxes[currTile].push_back({connect, flowID});
+            // Pin this flow's declared mask to the slave port it enters here,
+            // so flows that share an ID but declare different masks stay
+            // distinct.
+            if (flowMask)
+              explicitPortMasks[{{currTile, {src.bundle, src.channel}},
+                                 flowID}] = *flowMask;
             // Assign "control packet flows" flag per switchbox, based on
             // packet flow op attribute
             auto ctrlPkt = pktFlowOp.getPriorityRoute();
@@ -619,6 +651,14 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   // master select.
   std::map<std::pair<TileID, int>, SmallVector<Port, 4>> masterAMSels;
 
+  // <arbiter, msel> slots (per tile) already occupied by packet-switch
+  // configuration present in the input IR (e.g. pinned via segments emitted by
+  // --aie-split-flow-vias). These are reserved so the allocator below does not
+  // hand them out again and create two flows that share one amsel. Kept
+  // separate from masterAMSels so the existing masterset ops are not
+  // re-emitted.
+  std::set<std::pair<TileID, int>> reservedAmsels;
+
   // Track which arbiter each port is assigned to (to prevent conflicts)
   std::map<PhysPort, int> portToArbiter;
 
@@ -641,17 +681,20 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       [&](const std::map<std::pair<TileID, int>, SmallVector<Port, 4>>
               &masterAMSels,
           TileOp tileOp, bool isCtrlPkt) {
+        auto slotFree = [&](int a, int i) {
+          auto key = std::make_pair(tileOp.getTileID(),
+                                    getAmselFromArbiterIDAndMsel(a, i));
+          return !masterAMSels.count(key) && !reservedAmsels.count(key);
+        };
         if (isCtrlPkt) { // Higher AMsel first
           for (int i = numMselsPerArbiter - 1; i >= 0; i--)
             for (int a = numArbiters - 1; a >= 0; a--)
-              if (!masterAMSels.count(
-                      {tileOp.getTileID(), getAmselFromArbiterIDAndMsel(a, i)}))
+              if (slotFree(a, i))
                 return getAmselFromArbiterIDAndMsel(a, i);
         } else { // Lower AMsel first
           for (int i = 0; i < numMselsPerArbiter; i++)
             for (int a = 0; a < numArbiters; a++)
-              if (!masterAMSels.count(
-                      {tileOp.getTileID(), getAmselFromArbiterIDAndMsel(a, i)}))
+              if (slotFree(a, i))
                 return getAmselFromArbiterIDAndMsel(a, i);
         }
         tileOp->emitOpError(
@@ -663,10 +706,12 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       [&](const std::map<std::pair<TileID, int>, SmallVector<Port, 4>>
               &masterAMSels,
           TileOp tileOp, int arbiter) {
-        for (int i = 0; i < numMselsPerArbiter; i++)
-          if (!masterAMSels.count({tileOp.getTileID(),
-                                   getAmselFromArbiterIDAndMsel(arbiter, i)}))
+        for (int i = 0; i < numMselsPerArbiter; i++) {
+          auto key = std::make_pair(tileOp.getTileID(),
+                                    getAmselFromArbiterIDAndMsel(arbiter, i));
+          if (!masterAMSels.count(key) && !reservedAmsels.count(key))
             return getAmselFromArbiterIDAndMsel(arbiter, i);
+        }
         tileOp->emitOpError("tile op arbiter ")
             << std::to_string(arbiter) << " has used up all its msels";
         return INVALID_AMSEL_VALUE;
@@ -734,6 +779,27 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
     return INVALID_ARBITER_VALUE;
   };
+
+  // Seed the reserved-amsel set with packet-switch configuration that is
+  // already present in the switchboxes (e.g. pinned via segments materialized
+  // by --aie-split-flow-vias, or any pre-lowered packet routing). Without this
+  // the allocator below starts from an empty state and can hand out an
+  // <arbiter, msel> pair that another master on the same tile already occupies,
+  // producing two independent flows that share one amsel and mis-multicast
+  // (deadlock).
+  for (auto swboxOp : device.getOps<SwitchboxOp>()) {
+    TileID tileId = swboxOp.getTileOp().getTileID();
+    for (auto mtset : swboxOp.getConnections().getOps<MasterSetOp>()) {
+      for (Value amselVal : mtset.getAmsels()) {
+        auto amselOp = amselVal.getDefiningOp<AMSelOp>();
+        if (!amselOp)
+          continue;
+        reservedAmsels.insert(
+            {tileId, getAmselFromArbiterIDAndMsel(amselOp.arbiterIndex(),
+                                                  amselOp.getMselValue())});
+      }
+    }
+  }
 
   // Check all multi-cast flows (same source, same ID). They should be
   // assigned the same arbiter and msel so that the flow can reach all the
@@ -1093,8 +1159,20 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       llvm::SmallSet<int, 8> avoidIds = idsOnPort[port];
       for (int id : matchIds)
         avoidIds.erase(id);
-      SmallVector<std::pair<int, int>> cover =
-          computeSubcubeCover(matchIds, avoidIds, idBits);
+
+      // A mask attribute on any flow of the group pins the group to a single
+      // rule; otherwise the rules follow from the ids alone.
+      std::optional<int> pinnedMask;
+      for (auto member : group)
+        if (auto it = explicitPortMasks.find(member);
+            it != explicitPortMasks.end())
+          pinnedMask = it->second;
+
+      SmallVector<std::pair<int, int>> cover;
+      if (pinnedMask)
+        cover.push_back({*pinnedMask, matchIds.front() & *pinnedMask});
+      else
+        cover = computeSubcubeCover(matchIds, avoidIds, idBits);
 
       LLVM_DEBUG({
         llvm::dbgs() << "packet cover " << stringifyWireBundle(bundle)
@@ -1110,18 +1188,21 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         llvm::dbgs() << '\n';
       });
 
-      for (int id : matchIds)
-        assert(llvm::any_of(cover,
-                            [&](std::pair<int, int> c) {
-                              return (id & c.first) == c.second;
-                            }) &&
-               "subcube cover misses a match id");
-      for (int id : avoidIds)
-        assert(llvm::none_of(cover,
-                             [&](std::pair<int, int> c) {
-                               return (id & c.first) == c.second;
-                             }) &&
-               "subcube cover over-claims an avoid id");
+      // A pinned mask is the user's choice, so only a derived cover is checked.
+      if (!pinnedMask) {
+        for (int id : matchIds)
+          assert(llvm::any_of(cover,
+                              [&](std::pair<int, int> c) {
+                                return (id & c.first) == c.second;
+                              }) &&
+                 "subcube cover misses a match id");
+        for (int id : avoidIds)
+          assert(llvm::none_of(cover,
+                               [&](std::pair<int, int> c) {
+                                 return (id & c.first) == c.second;
+                               }) &&
+                 "subcube cover over-claims an avoid id");
+      }
 
       Value amsel = amselOps[slaveAMSels[group.front()]];
 
@@ -1274,7 +1355,14 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
   }
 
+  // Remove the packet_flow ops now that they have been lowered into
+  // masterset/amsel/packet_rules on the switchboxes. Leaving them in the IR
+  // would break idempotency: re-running this pass on its own routed output
+  // would re-lower them and emit duplicate masterset/packet_rules (illegal
+  // double-drivers on ports already claimed by the first lowering).
+  target.addIllegalOp<PacketFlowOp>();
   RewritePatternSet patterns(&getContext());
+  patterns.insert<AIEOpRemoval<PacketFlowOp>>(device.getContext());
 
   if (failed(applyPartialConversion(device, target, std::move(patterns))))
     return failure();
@@ -1293,6 +1381,15 @@ void AIEPathfinderPass::runOnOperation() {
     signalPassFailure();
     return;
   }
+  for (auto flowOp : d.getOps<FlowOp>()) {
+    if (!flowOp.getVias().empty()) {
+      flowOp.emitOpError("cannot be routed while it carries via waypoints; run "
+                         "--aie-split-flow-vias first to lower the vias into "
+                         "switchbox connections");
+      signalPassFailure();
+      return;
+    }
+  }
   OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
 
   if (clRouteCircuit && failed(runOnFlow(d, analyzer))) {
@@ -1304,8 +1401,23 @@ void AIEPathfinderPass::runOnOperation() {
     return;
   }
 
-  // Populate wires between switchboxes and tiles.
+  // Populate wires between switchboxes and tiles. Re-running the pass on
+  // already-routed IR must not duplicate the wires a previous run emitted, so
+  // key the wires already present and emit only the missing ones.
   builder.setInsertionPoint(d.getBody()->getTerminator());
+  llvm::DenseSet<std::tuple<Value, int, Value, int>> existingWires;
+  for (auto wire : d.getOps<WireOp>())
+    existingWires.insert(
+        {wire.getSource(), static_cast<int>(wire.getSourceBundle()),
+         wire.getDest(), static_cast<int>(wire.getDestBundle())});
+  auto wire = [&](Location loc, Value source, WireBundle sourceBundle,
+                  Value dest, WireBundle destBundle) {
+    if (existingWires
+            .insert({source, static_cast<int>(sourceBundle), dest,
+                     static_cast<int>(destBundle)})
+            .second)
+      WireOp::create(builder, loc, source, sourceBundle, dest, destBundle);
+  };
   for (int col = 0; col <= analyzer.getMaxCol(); col++) {
     for (int row = 0; row <= analyzer.getMaxRow(); row++) {
       TileOp tile;
@@ -1323,50 +1435,42 @@ void AIEPathfinderPass::runOnOperation() {
         // connections east-west between stream switches
         if (analyzer.coordToSwitchbox.count({col - 1, row})) {
           auto westsw = analyzer.coordToSwitchbox[{col - 1, row}];
-          WireOp::create(builder, loc, westsw, WireBundle::East, sw,
-                         WireBundle::West);
+          wire(loc, westsw, WireBundle::East, sw, WireBundle::West);
         }
       }
       if (row > 0) {
         // connections between abstract 'core' of tile
-        WireOp::create(builder, loc, tile, WireBundle::Core, sw,
-                       WireBundle::Core);
+        wire(loc, tile, WireBundle::Core, sw, WireBundle::Core);
         // connections between abstract 'dma' of tile
-        WireOp::create(builder, loc, tile, WireBundle::DMA, sw,
-                       WireBundle::DMA);
+        wire(loc, tile, WireBundle::DMA, sw, WireBundle::DMA);
         // connections north-south inside array ( including connection to shim
         // row)
         if (analyzer.coordToSwitchbox.count({col, row - 1})) {
           auto southsw = analyzer.coordToSwitchbox[{col, row - 1}];
-          WireOp::create(builder, loc, southsw, WireBundle::North, sw,
-                         WireBundle::South);
+          wire(loc, southsw, WireBundle::North, sw, WireBundle::South);
         }
       } else if (row == 0) {
         if (tile.isShimNOCTile()) {
           if (analyzer.coordToShimMux.count({col, 0})) {
             auto shimsw = analyzer.coordToShimMux[{col, 0}];
-            WireOp::create(
-                builder, loc, shimsw,
-                WireBundle::North, // Changed to connect into the north
-                sw, WireBundle::South);
+            wire(loc, shimsw,
+                 WireBundle::North, // Changed to connect into the north
+                 sw, WireBundle::South);
             // PLIO is attached to shim mux
             if (analyzer.coordToPLIO.count(col)) {
               auto plio = analyzer.coordToPLIO[col];
-              WireOp::create(builder, loc, plio, WireBundle::North, shimsw,
-                             WireBundle::South);
+              wire(loc, plio, WireBundle::North, shimsw, WireBundle::South);
             }
 
             // abstract 'DMA' connection on tile is attached to shim mux ( in
             // row 0 )
-            WireOp::create(builder, loc, tile, WireBundle::DMA, shimsw,
-                           WireBundle::DMA);
+            wire(loc, tile, WireBundle::DMA, shimsw, WireBundle::DMA);
           }
         } else if (tile.isShimPLTile()) {
           // PLIO is attached directly to switch
           if (analyzer.coordToPLIO.count(col)) {
             auto plio = analyzer.coordToPLIO[col];
-            WireOp::create(builder, loc, plio, WireBundle::North, sw,
-                           WireBundle::South);
+            wire(loc, plio, WireBundle::North, sw, WireBundle::South);
           }
         }
       }

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <optional>
+#include <set>
 
 using namespace mlir;
 using namespace xilinx;
@@ -100,9 +101,16 @@ struct ConvertFlowsToInterconnect : OpConversionPattern<FlowOp> {
     TileID srcSbId = {srcCoords.col, srcCoords.row};
     PathEndPoint srcPoint = {srcSbId, srcPort};
     if (analyzer.processedFlows[srcPoint]) {
+      // This FlowOp is a broadcast sibling of a flow whose route was already
+      // materialized (the analyzer merges all destinations sharing a source
+      // into one net, so the first sibling emitted connections for every
+      // destination). Erase it and report success so the erase is committed;
+      // returning failure() here would roll the erase back and leave a stale
+      // aie.flow in the routed IR, breaking idempotency (re-running the pass
+      // would try to re-route an already-routed net and fail).
       LLVM_DEBUG(llvm::dbgs() << "Flow already processed!\n");
       rewriter.eraseOp(Op);
-      return failure();
+      return success();
     }
     // std::map<TileID, SwitchSetting>
     SwitchSettings settings = analyzer.flowSolutions[srcPoint];
@@ -254,6 +262,13 @@ bool AIEPathfinderPass::findPathToDest(const SwitchSettings &settings,
   }
 
   int neighbourSourceChannel = currDestChannel;
+  // The destination may itself be a fabric input port (e.g. a partial packet
+  // flow pinned to end at a switchbox port). Such a port is never the output of
+  // any switchbox setting, so it would otherwise never match; recognize arrival
+  // when the current output feeds the final tile's destination input directly.
+  if (neighbourTile == finalTile && neighbourSourceBundle == finalDestBundle &&
+      neighbourSourceChannel == finalDestChannel)
+    return true;
   for (const auto &[sbNode, setting] : settings) {
     TileID tile = {sbNode.col, sbNode.row};
     if (tile == neighbourTile) {
@@ -341,28 +356,42 @@ static void bnbMinCover(ArrayRef<CoverCube> cubes,
   }
 }
 
+// Two cubes share an id when they agree on every bit both of them check.
+// Testing the cubes answers that without walking the ids they match, which a
+// cube with several don't-care bits has too many of.
+static bool cubesIntersect(std::pair<int, int> a, std::pair<int, int> b) {
+  return ((a.second ^ b.second) & a.first & b.first) == 0;
+}
+
 // Cover `matchIds` (a group's packet ids) with the fewest (mask, value) rules
-// that match every specified id and no `avoidIds` (other ids on the same slave
-// port). A rule matches id x iff (x & mask) == value; ids in neither set are
-// don't-cares, free to over-claim.
+// that match every specified id and no cube in `avoidCubes` (what the other
+// groups on the same slave port claim). A rule matches id x iff
+// (x & mask) == value; ids no cube claims are don't-cares, free to over-claim.
+//
+// An avoid cube states a claim the cover must not touch. A group that derives
+// its rules contributes one cube per id. A group whose flows state a mask
+// contributes that one cube, which stands for every id the mask matches --
+// including ids no flow in this design mentions.
 //
 // Based on Quine-McCluskey:
 //   1. Enumerate prime implicants: maximal cubes (a cube is one (mask, value))
-//      that match >=1 matchIds and no avoidIds.
+//      that match >=1 matchIds and no avoid cube.
 //   2. Pick the fewest of those cubes that cover all match ids (bnbMinCover).
 //   3. Tighten each chosen cube to the smallest enclosing cube of the ids it
 //      took, so it claims no more don't-cares than necessary; the one-cube case
 //      reduces to the old common-bits mask.
 static SmallVector<std::pair<int, int>>
 computeSubcubeCover(const SmallVector<int, 4> &matchIds,
-                    const llvm::SmallSet<int, 8> &avoidIds, int idBits) {
+                    ArrayRef<std::pair<int, int>> avoidCubes, int idBits) {
 
   // id space and full mask, sized from the target's packet-id width.
   const int numIds = 1 << idBits;
   const int idMask = numIds - 1;
 
   auto hitsAvoid = [&](int mask, int value) {
-    return llvm::any_of(avoidIds, [&](int o) { return (o & mask) == value; });
+    return llvm::any_of(avoidCubes, [&](std::pair<int, int> c) {
+      return cubesIntersect({mask, value}, c);
+    });
   };
 
   llvm::SmallBitVector matchMask(numIds);
@@ -545,6 +574,11 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   DenseMap<std::pair<PhysPort, int>, DmaEndpoints> slaveFlowDmaEndpoints;
   // Aggregate of the above over all flows sharing a slave port.
   DenseMap<PhysPort, PortTraffic> slavePortTraffic;
+
+  // Packet-rule masks the flows state, keyed by the slave port the stream
+  // enters and the flow ID. One ID may reach a port under two masks, so the
+  // ID alone does not identify the claim.
+  std::map<std::pair<PhysPort, int>, int> pinnedMasks;
 
   for (auto tileOp : device.getOps<TileOp>()) {
     int col = tileOp.colIndex();
@@ -737,6 +771,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
                                       keep.value_or(false)))
                 traffic.spansConsumerBds = true;
             }
+            if (std::optional<uint8_t> mask = pktFlowOp.getMask())
+              pinnedMasks[{{currTile, {src.bundle, src.channel}}, flowID}] =
+                  *mask;
             // Assign "control packet flows" flag per switchbox, based on
             // packet flow op attribute
             auto ctrlPkt = pktFlowOp.getPriorityRoute();
@@ -808,6 +845,14 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   // A map from Tile and master selectValue to the ports targetted by that
   // master select.
   std::map<std::pair<TileID, int>, SmallVector<Port, 4>> masterAMSels;
+
+  // <arbiter, msel> slots (per tile) that packet-switch configuration already
+  // present in the input IR occupies: a control overlay this run must not
+  // disturb, or any packet routing a previous run lowered. The allocator below
+  // starts from an empty state, so without this it can hand out a slot another
+  // master on the same tile holds, giving two independent flows one amsel.
+  // Kept apart from masterAMSels so this run does not re-emit those ops.
+  std::set<std::pair<TileID, int>> reservedAmsels;
 
   // Track which arbiter each port is assigned to (to prevent conflicts)
   std::map<PhysPort, int> portToArbiter;
@@ -977,7 +1022,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         int hazardous = INVALID_AMSEL_VALUE;
         ArbiterHazard worst{0, 0};
         for (int amsel : candidates) {
-          if (masterAMSels.count({tileId, amsel}))
+          if (masterAMSels.count({tileId, amsel}) ||
+              reservedAmsels.count({tileId, amsel}))
             continue;
           std::optional<ArbiterHazard> hazard =
               arbiterHazard(tileId, getArbiterIDFromAmsel(amsel), flow);
@@ -1004,10 +1050,12 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       [&](const std::map<std::pair<TileID, int>, SmallVector<Port, 4>>
               &masterAMSels,
           TileOp tileOp, int arbiter) {
-        for (int i = 0; i < numMselsPerArbiter; i++)
-          if (!masterAMSels.count({tileOp.getTileID(),
-                                   getAmselFromArbiterIDAndMsel(arbiter, i)}))
+        for (int i = 0; i < numMselsPerArbiter; i++) {
+          auto key = std::make_pair(tileOp.getTileID(),
+                                    getAmselFromArbiterIDAndMsel(arbiter, i));
+          if (!masterAMSels.count(key) && !reservedAmsels.count(key))
             return getAmselFromArbiterIDAndMsel(arbiter, i);
+        }
         tileOp->emitOpError("tile op arbiter ")
             << std::to_string(arbiter) << " has used up all its msels";
         return INVALID_AMSEL_VALUE;
@@ -1075,6 +1123,18 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
     return INVALID_ARBITER_VALUE;
   };
+
+  // Seed the reserved set from the packet-switch configuration the switchboxes
+  // already carry, so this run allocates around it instead of over it.
+  for (auto swboxOp : device.getOps<SwitchboxOp>()) {
+    TileID tileId = swboxOp.getTileOp().getTileID();
+    for (auto mtset : swboxOp.getConnections().getOps<MasterSetOp>())
+      for (Value amselVal : mtset.getAmsels())
+        if (auto amselOp = amselVal.getDefiningOp<AMSelOp>())
+          reservedAmsels.insert(
+              {tileId, getAmselFromArbiterIDAndMsel(amselOp.arbiterIndex(),
+                                                    amselOp.getMselValue())});
+  }
 
   // Check all multi-cast flows (same source, same ID). They should be
   // assigned the same arbiter and msel so that the flow can reach all the
@@ -1338,11 +1398,40 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
   }
 
-  // Ids on each slave port; a group covers its own and avoids the rest.
-  std::map<PhysPort, llvm::SmallSet<int, 8>> idsOnPort;
-  for (const auto &group : slaveGroups)
-    for (auto member : group)
-      idsOnPort[member.first].insert(member.second);
+  // What each group claims on its slave port, as cubes, split into the rules
+  // its flows state and the ids left for the cover to describe. A group may
+  // carry several rules, all pointing at its one arbiter slot, so a stated
+  // rule sits beside the derived ones rather than replacing them.
+  const uint32_t maxPacketId = device.getTargetModel().getMaxPacketId();
+  const int idBits = llvm::Log2_32_Ceil(maxPacketId + 1);
+  const int idMask = (1 << idBits) - 1;
+
+  SmallVector<SmallVector<std::pair<int, int>, 4>, 4> statedRules(
+      slaveGroups.size());
+  SmallVector<SmallVector<int, 4>, 4> derivedIds(slaveGroups.size());
+  for (size_t gi = 0; gi < slaveGroups.size(); ++gi) {
+    for (auto member : slaveGroups[gi]) {
+      auto it = pinnedMasks.find(member);
+      // A full-width mask selects the id alone, which the cover states just as
+      // well, so only a wider claim becomes a rule of its own.
+      if (it == pinnedMasks.end() || it->second == idMask) {
+        derivedIds[gi].push_back(member.second);
+        continue;
+      }
+      std::pair<int, int> cube = {it->second, member.second};
+      if (!llvm::is_contained(statedRules[gi], cube))
+        statedRules[gi].push_back(cube);
+    }
+  }
+
+  // Everything a group claims, for the other groups on its port to avoid.
+  auto claimsOf = [&](size_t gi) {
+    SmallVector<std::pair<int, int>, 8> claims(statedRules[gi].begin(),
+                                               statedRules[gi].end());
+    for (int id : derivedIds[gi])
+      claims.push_back({idMask, id});
+    return claims;
+  };
 
   // Realize the routes in MLIR
 
@@ -1425,7 +1514,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
 
     // Generate the packet rules
     DenseMap<Port, PacketRulesOp> slaveRules;
-    for (auto group : slaveGroups) {
+    for (size_t gi = 0; gi < slaveGroups.size(); ++gi) {
+      const auto &group = slaveGroups[gi];
       builder.setInsertionPoint(b.getTerminator());
 
       auto port = group.front().first;
@@ -1440,7 +1530,6 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       for (auto member : group)
         matchIds.push_back(member.second);
 
-      uint32_t maxPacketId = device.getTargetModel().getMaxPacketId();
       for (int id : matchIds)
         if (id > static_cast<int>(maxPacketId)) {
           return mlir::emitError(tileLoc)
@@ -1448,39 +1537,74 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
                  << maxPacketId;
         }
 
-      int idBits = llvm::Log2_32_Ceil(maxPacketId + 1);
-      llvm::SmallSet<int, 8> avoidIds = idsOnPort[port];
-      for (int id : matchIds)
-        avoidIds.erase(id);
-      SmallVector<std::pair<int, int>> cover =
-          computeSubcubeCover(matchIds, avoidIds, idBits);
+      SmallVector<std::pair<int, int>> avoidCubes;
+      for (size_t oi = 0; oi < slaveGroups.size(); ++oi)
+        if (oi != gi && slaveGroups[oi].front().first == port) {
+          auto claims = claimsOf(oi);
+          avoidCubes.append(claims.begin(), claims.end());
+        }
+
+      // A stated rule claims ids beyond the ones this design routes. Two
+      // claims that share an id give the port two routes for that id, and the
+      // group that loses it has no rule left to state.
+      for (std::pair<int, int> own : claimsOf(gi))
+        for (std::pair<int, int> other : avoidCubes)
+          if (cubesIntersect(own, other)) {
+            int witness = (own.second & own.first) |
+                          (other.second & other.first & ~own.first);
+            return mlir::emitError(tileLoc)
+                   << "packet flows through " << stringifyWireBundle(bundle)
+                   << channel << " claim rule (mask 0x"
+                   << llvm::utohexstr(own.first) << ", id 0x"
+                   << llvm::utohexstr(own.second) << ") and rule (mask 0x"
+                   << llvm::utohexstr(other.first) << ", id 0x"
+                   << llvm::utohexstr(other.second)
+                   << "), which both match id 0x" << llvm::utohexstr(witness)
+                   << "; widen one mask to carry both, or route them apart";
+          }
+
+      // The group keeps the rules its flows state, and the cover describes the
+      // ids that state none. A stated rule also constrains that cover, so the
+      // two never claim one id twice.
+      SmallVector<std::pair<int, int>> cover(statedRules[gi].begin(),
+                                             statedRules[gi].end());
+      if (!derivedIds[gi].empty()) {
+        SmallVector<std::pair<int, int>> derivedAvoid = avoidCubes;
+        derivedAvoid.append(statedRules[gi].begin(), statedRules[gi].end());
+        SmallVector<int, 4> ids(derivedIds[gi].begin(), derivedIds[gi].end());
+        SmallVector<std::pair<int, int>> derived =
+            computeSubcubeCover(ids, derivedAvoid, idBits);
+        cover.append(derived.begin(), derived.end());
+      }
 
       LLVM_DEBUG({
         llvm::dbgs() << "packet cover " << stringifyWireBundle(bundle)
                      << channel << ": matchIds {";
         for (int id : matchIds)
           llvm::dbgs() << ' ' << id;
-        llvm::dbgs() << " } avoidIds {";
-        for (int id : avoidIds)
-          llvm::dbgs() << ' ' << id;
+        llvm::dbgs() << " } avoid {";
+        for (auto [m, v] : avoidCubes)
+          llvm::dbgs() << " (" << m << ", " << v << ")";
         llvm::dbgs() << " } ->";
         for (auto [m, v] : cover)
           llvm::dbgs() << " rule(" << m << ", " << v << ")";
         llvm::dbgs() << '\n';
       });
 
+      // A stated rule takes part in the same constraints as a derived one, so
+      // both checks cover every group.
       for ([[maybe_unused]] int id : matchIds)
         assert(llvm::any_of(cover,
                             [&](std::pair<int, int> c) {
                               return (id & c.first) == c.second;
                             }) &&
-               "subcube cover misses a match id");
-      for ([[maybe_unused]] int id : avoidIds)
+               "packet rule cover misses a match id");
+      for ([[maybe_unused]] std::pair<int, int> other : avoidCubes)
         assert(llvm::none_of(cover,
                              [&](std::pair<int, int> c) {
-                               return (id & c.first) == c.second;
+                               return cubesIntersect(c, other);
                              }) &&
-               "subcube cover over-claims an avoid id");
+               "packet rule cover claims another group's ids");
 
       Value amsel = amselOps[slaveAMSels[group.front()]];
 
@@ -1515,8 +1639,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         return failure();
       }
 
-      // The cover avoids this port's avoidIds by construction; this catches a
-      // conflict only against rules from another source (e.g. hand-authored).
+      // The cover avoids what the other groups claim by construction; this
+      // catches a conflict only against rules from another source (e.g.
+      // hand-authored).
       for (auto rule : rules.getOps<PacketRuleOp>()) {
         auto verifyMask = rule.maskInt();
         auto verifyValue = rule.valueInt();
@@ -1633,7 +1758,14 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
   }
 
+  // Remove the packet_flow ops now that they have been lowered into
+  // masterset/amsel/packet_rules on the switchboxes. Leaving them in the IR
+  // would break idempotency: re-running this pass on its own routed output
+  // would re-lower them and emit duplicate masterset/packet_rules (illegal
+  // double-drivers on ports already claimed by the first lowering).
+  target.addIllegalOp<PacketFlowOp>();
   RewritePatternSet patterns(&getContext());
+  patterns.insert<AIEOpRemoval<PacketFlowOp>>(device.getContext());
 
   if (failed(applyPartialConversion(device, target, std::move(patterns))))
     return failure();
@@ -1663,8 +1795,32 @@ void AIEPathfinderPass::runOnOperation() {
     return;
   }
 
-  // Populate wires between switchboxes and tiles.
+  // Populate wires between switchboxes and tiles. Re-running the pass on
+  // already-routed IR must not duplicate the wires a previous run emitted, so
+  // key the wires already present and emit only the missing ones.
   builder.setInsertionPoint(d.getBody()->getTerminator());
+  llvm::DenseSet<std::tuple<Value, int, Value, int>> existingWires;
+  // aie.wire is a physical connection, so the IR may spell one adjacency in
+  // either operand order. Key both orders, or a reverse-oriented wire already
+  // present goes unnoticed and this run adds a duplicate in canonical order.
+  auto recordWire = [&](Value source, int sourceBundle, Value dest,
+                        int destBundle) {
+    bool absent =
+        !existingWires.contains({source, sourceBundle, dest, destBundle}) &&
+        !existingWires.contains({dest, destBundle, source, sourceBundle});
+    existingWires.insert({source, sourceBundle, dest, destBundle});
+    existingWires.insert({dest, destBundle, source, sourceBundle});
+    return absent;
+  };
+  for (auto wire : d.getOps<WireOp>())
+    recordWire(wire.getSource(), static_cast<int>(wire.getSourceBundle()),
+               wire.getDest(), static_cast<int>(wire.getDestBundle()));
+  auto wire = [&](Location loc, Value source, WireBundle sourceBundle,
+                  Value dest, WireBundle destBundle) {
+    if (recordWire(source, static_cast<int>(sourceBundle), dest,
+                   static_cast<int>(destBundle)))
+      WireOp::create(builder, loc, source, sourceBundle, dest, destBundle);
+  };
   for (int col = 0; col <= analyzer.getMaxCol(); col++) {
     for (int row = 0; row <= analyzer.getMaxRow(); row++) {
       TileOp tile;
@@ -1682,50 +1838,42 @@ void AIEPathfinderPass::runOnOperation() {
         // connections east-west between stream switches
         if (analyzer.coordToSwitchbox.count({col - 1, row})) {
           auto westsw = analyzer.coordToSwitchbox[{col - 1, row}];
-          WireOp::create(builder, loc, westsw, WireBundle::East, sw,
-                         WireBundle::West);
+          wire(loc, westsw, WireBundle::East, sw, WireBundle::West);
         }
       }
       if (row > 0) {
         // connections between abstract 'core' of tile
-        WireOp::create(builder, loc, tile, WireBundle::Core, sw,
-                       WireBundle::Core);
+        wire(loc, tile, WireBundle::Core, sw, WireBundle::Core);
         // connections between abstract 'dma' of tile
-        WireOp::create(builder, loc, tile, WireBundle::DMA, sw,
-                       WireBundle::DMA);
+        wire(loc, tile, WireBundle::DMA, sw, WireBundle::DMA);
         // connections north-south inside array ( including connection to shim
         // row)
         if (analyzer.coordToSwitchbox.count({col, row - 1})) {
           auto southsw = analyzer.coordToSwitchbox[{col, row - 1}];
-          WireOp::create(builder, loc, southsw, WireBundle::North, sw,
-                         WireBundle::South);
+          wire(loc, southsw, WireBundle::North, sw, WireBundle::South);
         }
       } else if (row == 0) {
         if (tile.isShimNOCTile()) {
           if (analyzer.coordToShimMux.count({col, 0})) {
             auto shimsw = analyzer.coordToShimMux[{col, 0}];
-            WireOp::create(
-                builder, loc, shimsw,
-                WireBundle::North, // Changed to connect into the north
-                sw, WireBundle::South);
+            wire(loc, shimsw,
+                 WireBundle::North, // Changed to connect into the north
+                 sw, WireBundle::South);
             // PLIO is attached to shim mux
             if (analyzer.coordToPLIO.count(col)) {
               auto plio = analyzer.coordToPLIO[col];
-              WireOp::create(builder, loc, plio, WireBundle::North, shimsw,
-                             WireBundle::South);
+              wire(loc, plio, WireBundle::North, shimsw, WireBundle::South);
             }
 
             // abstract 'DMA' connection on tile is attached to shim mux ( in
             // row 0 )
-            WireOp::create(builder, loc, tile, WireBundle::DMA, shimsw,
-                           WireBundle::DMA);
+            wire(loc, tile, WireBundle::DMA, shimsw, WireBundle::DMA);
           }
         } else if (tile.isShimPLTile()) {
           // PLIO is attached directly to switch
           if (analyzer.coordToPLIO.count(col)) {
             auto plio = analyzer.coordToPLIO[col];
-            WireOp::create(builder, loc, plio, WireBundle::North, sw,
-                           WireBundle::South);
+            wire(loc, plio, WireBundle::North, sw, WireBundle::South);
           }
         }
       }

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -12,6 +12,9 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+
 namespace xilinx::AIE {
 #define GEN_PASS_DEF_AIEFINDFLOWS
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h.inc"
@@ -36,18 +39,123 @@ using PortConnection = struct PortConnection {
 using PortMaskValue = struct PortMaskValue {
   Port port;
   MaskValue mv;
+  // The interconnect ops that implement this hop (a circuit ConnectOp, or a
+  // packet PacketRuleOp + MasterSetOp + AMSelOp). Recorded so the flows that
+  // consume them can be lifted out of the physical IR.
+  llvm::SmallVector<Operation *, 3> ops;
+};
+
+// One intermediate stop of a flow: the tile whose switchbox the stream passes
+// through, and the ingress/egress ports it uses there.
+using Via = struct Via {
+  Value tile;
+  Port ingress;
+  Port egress;
 };
 
 using PacketConnection = struct PacketConnection {
   PortConnection portConnection;
   MaskValue mv;
+  llvm::SmallVector<Via, 4> vias;
+  // Interconnect ops traversed on the way to this endpoint.
+  llvm::SmallVector<Operation *, 8> usedOps;
 };
 
 class ConnectivityAnalysis {
   DeviceOp &device;
+  // Fan-out splitting: when enabled, a linear traversal stops at any switchbox
+  // input port that drives more than one output (a fan-out), leaving the
+  // fan-out switchbox explicit and recording its output ports as new section
+  // sources.
+  bool splitFanouts = false;
+  mutable llvm::DenseSet<std::pair<Operation *, int>> fanoutIngresses;
+  mutable llvm::DenseSet<std::pair<Operation *, int>> fanoutEgressSeeds;
+
+  static int encodePort(Port p) {
+    return static_cast<int>(p.bundle) * 64 + p.channel;
+  }
 
 public:
   ConnectivityAnalysis(DeviceOp &d) : device(d) {}
+
+  // Enable fan-out splitting and precompute which interconnect input ports fan
+  // out (drive more than one output).
+  void enableFanoutSplitting() {
+    splitFanouts = true;
+    auto scan = [&](Operation *sw, Region &connections) {
+      llvm::SmallVector<Port, 8> sources;
+      Block &b = connections.front();
+      for (auto connectOp : b.getOps<ConnectOp>())
+        if (!llvm::is_contained(sources, connectOp.sourcePort()))
+          sources.push_back(connectOp.sourcePort());
+      for (auto rulesOp : b.getOps<PacketRulesOp>())
+        if (!llvm::is_contained(sources, rulesOp.sourcePort()))
+          sources.push_back(rulesOp.sourcePort());
+      // Fan-out: a source that drives more than one output.
+      for (Port p : sources)
+        if (getConnectionsThroughSwitchbox(connections, p).size() > 1)
+          fanoutIngresses.insert({sw, encodePort(p)});
+      // Fan-in: an output driven from more than one source (a packet merge).
+      // Every source feeding a shared output is a section boundary as well, so
+      // the merge node stays materialized and the linear sections stop at it.
+      llvm::DenseMap<int, llvm::SmallVector<Port, 4>> outputSources;
+      for (Port p : sources)
+        for (PortMaskValue &pmv :
+             getConnectionsThroughSwitchbox(connections, p)) {
+          auto &v = outputSources[encodePort(pmv.port)];
+          if (!llvm::is_contained(v, p))
+            v.push_back(p);
+        }
+      for (auto &[egress, srcs] : outputSources)
+        if (srcs.size() > 1)
+          for (Port p : srcs)
+            fanoutIngresses.insert({sw, encodePort(p)});
+      // Break at hops whose configuration carries state a lifted flow cannot
+      // reconstruct, so only that switchbox stays materialized while the rest
+      // of the flow still lifts (split-at-change). keep_pkt_header on a real
+      // endpoint is carried on the flow (so it does not break), and control
+      // overlays are kept whole elsewhere; every other attribute breaks here.
+      auto isFabric = [](WireBundle bnd) {
+        return bnd == WireBundle::North || bnd == WireBundle::South ||
+               bnd == WireBundle::East || bnd == WireBundle::West;
+      };
+      auto hasNonCtrlDiscardable = [](Operation *op) {
+        return llvm::any_of(op->getDiscardableAttrDictionary(),
+                            [](NamedAttribute a) {
+                              return a.getName() != "is_ctrl_pkt_overlay";
+                            });
+      };
+      for (Port p : sources)
+        for (PortMaskValue &pmv :
+             getConnectionsThroughSwitchbox(connections, p))
+          for (Operation *op : pmv.ops) {
+            if (!op)
+              continue;
+            bool unliftable = hasNonCtrlDiscardable(op);
+            if (auto r = dyn_cast<PacketRuleOp>(op))
+              if (Operation *par = r->getParentOp())
+                unliftable |= hasNonCtrlDiscardable(par);
+            if (auto ms = dyn_cast<MasterSetOp>(op))
+              unliftable |=
+                  ms.getKeepPktHeaderAttr() && isFabric(ms.getDestBundle());
+            if (unliftable)
+              fanoutIngresses.insert({sw, encodePort(p)});
+          }
+    };
+    for (auto switchOp : device.getOps<SwitchboxOp>())
+      scan(switchOp, switchOp.getConnections());
+    for (auto shimMuxOp : device.getOps<ShimMuxOp>())
+      scan(shimMuxOp, shimMuxOp.getConnections());
+  }
+
+  // Fan-out output ports discovered while traversing, each a source for a new
+  // linear section.  Consumed and cleared by the pass.
+  llvm::DenseSet<std::pair<Operation *, int>> &getFanoutEgressSeeds() {
+    return fanoutEgressSeeds;
+  }
+  static Port decodePort(int e) {
+    return {static_cast<WireBundle>(e / 64), e % 64};
+  }
 
 private:
   std::optional<PortConnection>
@@ -88,7 +196,7 @@ private:
     for (auto connectOp : b.getOps<ConnectOp>()) {
       if (connectOp.sourcePort() == sourcePort) {
         MaskValue maskValue = {0, 0};
-        portSet.push_back({connectOp.destPort(), maskValue});
+        portSet.push_back({connectOp.destPort(), maskValue, {connectOp}});
         LLVM_DEBUG(llvm::dbgs()
                    << "To:" << stringifyWireBundle(connectOp.destPort().bundle)
                    << " " << connectOp.destPort().channel << "\n");
@@ -110,7 +218,10 @@ private:
                            << stringifyWireBundle(masterSetOp.destPort().bundle)
                            << " " << masterSetOp.destPort().channel << "\n");
                 MaskValue maskValue = {ruleOp.maskInt(), ruleOp.valueInt()};
-                portSet.push_back({masterSetOp.destPort(), maskValue});
+                portSet.push_back(
+                    {masterSetOp.destPort(),
+                     maskValue,
+                     {ruleOp, masterSetOp, amsel.getDefiningOp()}});
               }
             }
       }
@@ -118,11 +229,18 @@ private:
     return portSet;
   }
 
-  std::vector<PacketConnection>
-  maskSwitchboxConnections(Operation *switchOp,
-                           const std::vector<PortMaskValue> &nextPortMaskValues,
-                           MaskValue maskValue) const {
+  std::vector<PacketConnection> maskSwitchboxConnections(
+      Operation *switchOp, Port ingressPort, ArrayRef<Via> currentVias,
+      ArrayRef<Operation *> currentUsedOps,
+      const std::vector<PortMaskValue> &nextPortMaskValues, MaskValue maskValue,
+      bool keepPartialFlows,
+      std::vector<PacketConnection> &partialEndpoints) const {
     std::vector<PacketConnection> worklist;
+    // Only switchbox hops become vias; the shim-mux is not stream-switch
+    // configuration and is regenerated by routing.
+    Value viaTile;
+    if (auto sb = dyn_cast<SwitchboxOp>(switchOp))
+      viaTile = sb.getTile();
     for (auto &nextPortMaskValue : nextPortMaskValues) {
       Port nextPort = nextPortMaskValue.port;
       MaskValue nextMaskValue = nextPortMaskValue.mv;
@@ -141,93 +259,305 @@ private:
       MaskValue newMaskValue = {maskValue.mask | nextMaskValue.mask,
                                 maskValue.value |
                                     (nextMaskValue.mask & nextMaskValue.value)};
+      SmallVector<Via, 4> newVias(currentVias.begin(), currentVias.end());
+      if (viaTile)
+        newVias.push_back({viaTile, ingressPort, nextPort});
+      SmallVector<Operation *, 8> newUsedOps(currentUsedOps.begin(),
+                                             currentUsedOps.end());
+      newUsedOps.append(nextPortMaskValue.ops.begin(),
+                        nextPortMaskValue.ops.end());
       auto nextConnection = getConnectionThroughWire(switchOp, nextPort);
 
-      // If there is no wire to follow then bail out.
-      if (!nextConnection)
+      if (!nextConnection) {
+        // The switchbox drives nextPort but no wire continues from it (an array
+        // edge or an off-fabric consumer). Under partial recovery this output
+        // port is itself the flow's endpoint.
+        if (keepPartialFlows)
+          partialEndpoints.push_back(
+              {{switchOp, nextPort}, newMaskValue, newVias, newUsedOps});
         continue;
+      }
 
-      worklist.push_back({*nextConnection, newMaskValue});
+      worklist.push_back({*nextConnection, newMaskValue, newVias, newUsedOps});
     }
     return worklist;
   }
 
 public:
-  // Get the tiles connected to the given tile, starting from the given
-  // output port of the tile.  This is 1:N relationship because each
-  // switchbox can broadcast.
-  std::vector<PacketConnection> getConnectedTiles(TileOp tileOp,
-                                                  Port port) const {
+  // Follow the single upstream wire out of an interconnect input port.
+  std::optional<PortConnection> upstreamOf(Operation *op, Port port) const {
+    return getConnectionThroughWire(op, port);
+  }
 
-    LLVM_DEBUG(llvm::dbgs()
-               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
-               << port.channel << ")");
-    LLVM_DEBUG(tileOp.dump());
+  // Whether `port` is driven (is the destination of a connect or masterset)
+  // inside the given interconnect op.
+  bool drivesPort(Operation *op, Port port) const {
+    Region *r = nullptr;
+    if (auto sb = dyn_cast<SwitchboxOp>(op))
+      r = &sb.getConnections();
+    else if (auto sm = dyn_cast<ShimMuxOp>(op))
+      r = &sm.getConnections();
+    if (!r)
+      return false;
+    Block &b = r->front();
+    for (auto connectOp : b.getOps<ConnectOp>())
+      if (connectOp.destPort() == port)
+        return true;
+    for (auto masterSetOp : b.getOps<MasterSetOp>())
+      if (masterSetOp.destPort() == port)
+        return true;
+    return false;
+  }
 
-    // The accumulated result;
+  // Traverse forward from switchbox/shim-mux input ports, collecting the
+  // endpoints each stream reaches: flow-endpoint tiles, or -- under
+  // keepPartialFlows -- driven interconnect ports that have no onward wire.
+  std::vector<PacketConnection> traverse(std::vector<PacketConnection> worklist,
+                                         bool keepPartialFlows) const {
     std::vector<PacketConnection> connectedTiles;
-    // A worklist of PortConnections to visit.  These are all input ports of
-    // some object (likely either a TileOp or a SwitchboxOp).
-    std::vector<PacketConnection> worklist;
-    // Start the worklist by traversing from the tile to its connected
-    // switchbox.
-    auto t = getConnectionThroughWire(tileOp.getOperation(), port);
-
-    // If there is no wire to traverse, then just return no connection
-    if (!t)
-      return connectedTiles;
-    worklist.push_back({*t, {0, 0}});
-
     while (!worklist.empty()) {
       PacketConnection t = worklist.back();
       worklist.pop_back();
-      PortConnection portConnection = t.portConnection;
+      Operation *other = t.portConnection.op;
+      Port otherPort = t.portConnection.port;
       MaskValue maskValue = t.mv;
-      Operation *other = portConnection.op;
-      Port otherPort = portConnection.port;
       if (other && other->hasTrait<IsFlowEndPoint>()) {
         // If we got to a tile, then add it to the result.
         connectedTiles.push_back(t);
-      } else if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other)) {
-        std::vector<PortMaskValue> nextPortMaskValues =
-            getConnectionsThroughSwitchbox(switchOp.getConnections(),
-                                           otherPort);
-        std::vector<PacketConnection> newWorkList =
-            maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
-        // append to the worklist
-        worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
-          // No rule matched some incoming packet.  This is likely a
-          // configuration error.
-          LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
-          LLVM_DEBUG(other->dump());
-        }
-      } else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other)) {
-        std::vector<PortMaskValue> nextPortMaskValues =
-            getConnectionsThroughSwitchbox(switchOp.getConnections(),
-                                           otherPort);
-        std::vector<PacketConnection> newWorkList =
-            maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
-        // append to the worklist
-        worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
-          // No rule matched some incoming packet.  This is likely a
-          // configuration error.
-          LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
-          LLVM_DEBUG(other->dump());
-        }
-      } else {
+        continue;
+      }
+      Region *connections = nullptr;
+      if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other))
+        connections = &switchOp.getConnections();
+      else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other))
+        connections = &switchOp.getConnections();
+      if (!connections) {
         LLVM_DEBUG(llvm::dbgs()
                    << "*** Connection Terminated at unknown operation: ");
+        LLVM_DEBUG(other->dump());
+        continue;
+      }
+      // A fan-out port ends the current linear section: the flow terminates at
+      // this input, the fan-out switchbox stays explicit (its ops are not
+      // lifted), and every output it drives becomes a new section source.
+      if (splitFanouts &&
+          fanoutIngresses.count({other, encodePort(otherPort)})) {
+        connectedTiles.push_back(t);
+        for (PortMaskValue &pmv :
+             getConnectionsThroughSwitchbox(*connections, otherPort))
+          fanoutEgressSeeds.insert({other, encodePort(pmv.port)});
+        continue;
+      }
+      std::vector<PortMaskValue> nextPortMaskValues =
+          getConnectionsThroughSwitchbox(*connections, otherPort);
+      std::vector<PacketConnection> partialEndpoints;
+      std::vector<PacketConnection> newWorkList = maskSwitchboxConnections(
+          other, otherPort, t.vias, t.usedOps, nextPortMaskValues, maskValue,
+          keepPartialFlows, partialEndpoints);
+      worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
+      connectedTiles.insert(connectedTiles.end(), partialEndpoints.begin(),
+                            partialEndpoints.end());
+      if (!nextPortMaskValues.empty() && newWorkList.empty() &&
+          partialEndpoints.empty()) {
+        // No rule matched some incoming packet.  This is likely a
+        // configuration error.
+        LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
         LLVM_DEBUG(other->dump());
       }
     }
     return connectedTiles;
   }
+
+  // Get the tiles connected to the given tile, starting from the given
+  // output port of the tile.  This is 1:N relationship because each
+  // switchbox can broadcast.
+  std::vector<PacketConnection> getConnectedTiles(TileOp tileOp, Port port,
+                                                  bool keepPartialFlows) const {
+    LLVM_DEBUG(llvm::dbgs()
+               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
+               << port.channel << ")");
+    LLVM_DEBUG(tileOp.dump());
+    // Traverse from the tile to its connected switchbox.
+    auto t = getConnectionThroughWire(tileOp.getOperation(), port);
+    // If there is no wire to traverse, then just return no connection
+    if (!t)
+      return {};
+    return traverse({PacketConnection{*t, {0, 0}, {}, {}}}, keepPartialFlows);
+  }
+
+  // Get the endpoints reached by a stream that enters the fabric at the given
+  // input port of an interconnect (switchbox / shim-mux).  Used to lift flows
+  // whose source is not a core or DMA.
+  std::vector<PacketConnection>
+  getConnectedTilesFromInput(Operation *switchOp, Port inputPort,
+                             bool keepPartialFlows) const {
+    return traverse(
+        {PacketConnection{PortConnection{switchOp, inputPort}, {0, 0}, {}, {}}},
+        keepPartialFlows);
+  }
+
+  // Get the endpoints reached by a stream leaving the given output port of a
+  // fan-out interconnect: cross the outgoing wire and traverse the next linear
+  // section.
+  std::vector<PacketConnection>
+  getConnectedTilesFromEgress(Operation *switchOp, Port egressPort,
+                              bool keepPartialFlows) const {
+    auto t = getConnectionThroughWire(switchOp, egressPort);
+    if (!t)
+      return {};
+    return traverse({PacketConnection{*t, {0, 0}, {}, {}}}, keepPartialFlows);
+  }
 };
 
+// The endpoint of a lifted flow: a flow-endpoint op directly, or the tile
+// owning a directional switchbox / shim-mux port (partial flow).
+static Value resolveEndpointTile(Operation *op) {
+  if (auto sb = dyn_cast<SwitchboxOp>(op))
+    return sb.getTile();
+  if (auto sm = dyn_cast<ShimMuxOp>(op))
+    return sm.getTile();
+  if (op->hasTrait<IsFlowEndPoint>() && op->getNumResults() == 1)
+    return op->getResult(0);
+  return nullptr;
+}
+
+static void emitFlows(OpBuilder &rewriter, Location loc, Value srcTile,
+                      WireBundle srcBundle, int srcChannel,
+                      const std::vector<PacketConnection> &endpoints,
+                      bool emitVias, bool dropIntraTile,
+                      llvm::DenseSet<Operation *> &consumed) {
+  for (const PacketConnection &c : endpoints) {
+    Operation *destOp = c.portConnection.op;
+    Port destPort = c.portConnection.port;
+    MaskValue maskValue = c.mv;
+    Value destTile = resolveEndpointTile(destOp);
+    if (!destTile)
+      continue;
+    // Never silently drop configuration. Control overlays (in any mode) are
+    // kept materialized, and when pinning so is any section carrying op state a
+    // lifted flow cannot rebuild -- keep_pkt_header on a non-destination hop,
+    // or any discardable annotation (present or future) the rebuild does not
+    // carry. Leaving it materialized keeps it faithful and visible rather than
+    // dropping it and having the round-trip silently diverge.
+    bool keepMaterialized = false;
+    for (Operation *op : c.usedOps) {
+      Operation *rulesParent =
+          isa_and_nonnull<PacketRuleOp>(op) ? op->getParentOp() : nullptr;
+      if (op->hasAttr("is_ctrl_pkt_overlay") ||
+          (rulesParent && rulesParent->hasAttr("is_ctrl_pkt_overlay"))) {
+        keepMaterialized = true;
+      } else if (emitVias) {
+        if (!op->getDiscardableAttrDictionary().empty() ||
+            (rulesParent &&
+             !rulesParent->getDiscardableAttrDictionary().empty()))
+          keepMaterialized = true;
+        else if (auto ms = dyn_cast<MasterSetOp>(op))
+          keepMaterialized = ms.getKeepPktHeaderAttr() &&
+                             (ms.getDestBundle() != destPort.bundle ||
+                              ms.getDestChannel() != destPort.channel);
+      }
+      if (keepMaterialized)
+        break;
+    }
+    if (keepMaterialized)
+      continue;
+    // In pinning mode a path realized only by shim-mux connections has no
+    // switchbox transit and therefore no via to pin it; split-flow-vias cannot
+    // materialize it and re-routing cannot honor it. Leave that shim-mux
+    // configuration in place rather than lifting an unroutable flow.
+    if (emitVias && c.vias.empty())
+      continue;
+    // Recovery mode (no vias): a packet endpoint becomes a plain logical packet
+    // flow and its physical configuration is reclaimed.
+    if (maskValue.mask != 0 && !emitVias) {
+      for (Operation *op : c.usedOps)
+        if (op)
+          consumed.insert(op);
+      auto flowOp = PacketFlowOp::create(rewriter, loc, maskValue.value,
+                                         nullptr, nullptr);
+      PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter, loc);
+      OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
+      PacketSourceOp::create(rewriter, loc, srcTile, srcBundle, srcChannel);
+      PacketDestOp::create(rewriter, loc, destTile, destPort.bundle,
+                           destPort.channel);
+      rewriter.restoreInsertionPoint(ip);
+      continue;
+    }
+    // A section that lifts no interconnect configuration carries no routing:
+    // it is either a fan-out output feeding its own tile with no hop, or the
+    // physical wire between two retained fan nodes. The wire is implicit and
+    // the switchboxes at both ends stay explicit, so emitting a flow for it
+    // would only fight their fixed connections on re-routing.
+    if (c.usedOps.empty())
+      continue;
+    // A flow seeded from a fabric-entry / fan-out output that terminates on a
+    // real endpoint of the same tile never leaves that tile -- it is a dead or
+    // orphan interconnect connection (e.g. an undriven shim-mux write path),
+    // not a routable flow, so do not lift it.
+    if (dropIntraTile && destTile == srcTile && isa<TileOp>(destOp))
+      continue;
+    // Every interconnect op on this endpoint's path is lifted into the flow.
+    for (Operation *op : c.usedOps)
+      if (op)
+        consumed.insert(op);
+    MLIRContext *ctx = rewriter.getContext();
+    SmallVector<Value> viaTiles;
+    SmallVector<int32_t> ingressBundles, ingressChannels, egressBundles,
+        egressChannels;
+    if (emitVias)
+      for (const Via &via : c.vias) {
+        viaTiles.push_back(via.tile);
+        ingressBundles.push_back(static_cast<int32_t>(via.ingress.bundle));
+        ingressChannels.push_back(via.ingress.channel);
+        egressBundles.push_back(static_cast<int32_t>(via.egress.bundle));
+        egressChannels.push_back(via.egress.channel);
+      }
+    auto ib = viaTiles.empty() ? nullptr
+                               : DenseI32ArrayAttr::get(ctx, ingressBundles);
+    auto ic = viaTiles.empty() ? nullptr
+                               : DenseI32ArrayAttr::get(ctx, ingressChannels);
+    auto eb =
+        viaTiles.empty() ? nullptr : DenseI32ArrayAttr::get(ctx, egressBundles);
+    auto ec = viaTiles.empty() ? nullptr
+                               : DenseI32ArrayAttr::get(ctx, egressChannels);
+    if (maskValue.mask == 0) {
+      FlowOp::create(rewriter, loc, srcTile, srcBundle, srcChannel, destTile,
+                     destPort.bundle, destPort.channel, viaTiles, ib, ic, eb,
+                     ec);
+    } else {
+      // A straight-line packet section: pin its route with vias and record the
+      // ID mask so --aie-split-flow-vias can rebuild the switchbox rules. The
+      // fan-out/fan-in nodes at either end stay materialized in place.
+      // keep_pkt_header lives on the master set that drives the section's
+      // destination; carry it on the lifted flow so re-lowering restores it
+      // (dropping it would strip the header and misroute the packet
+      // downstream).
+      BoolAttr keepPktHeader;
+      for (Operation *op : c.usedOps)
+        if (auto ms = dyn_cast_or_null<MasterSetOp>(op))
+          if (ms.getDestBundle() == destPort.bundle &&
+              ms.getDestChannel() == destPort.channel)
+            keepPktHeader = ms.getKeepPktHeaderAttr();
+      auto flowOp = PacketFlowOp::create(
+          rewriter, loc, rewriter.getI8IntegerAttr(maskValue.value),
+          rewriter.getI8IntegerAttr(maskValue.mask), keepPktHeader, BoolAttr(),
+          viaTiles, ib, ic, eb, ec);
+      PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter, loc);
+      OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
+      PacketSourceOp::create(rewriter, loc, srcTile, srcBundle, srcChannel);
+      PacketDestOp::create(rewriter, loc, destTile, destPort.bundle,
+                           destPort.channel);
+      rewriter.restoreInsertionPoint(ip);
+    }
+  }
+}
+
 static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
-                          OpBuilder &rewriter) {
+                          OpBuilder &rewriter, bool keepPartialFlows,
+                          bool emitVias,
+                          llvm::DenseSet<Operation *> &consumed) {
   Operation *Op = op.getOperation();
   rewriter.setInsertionPoint(Op->getBlock()->getTerminator());
 
@@ -238,33 +568,79 @@ static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
                << op.getNumSourceConnections(bundle) << " Connections\n");
     for (size_t i = 0; i < op.getNumSourceConnections(bundle); i++) {
       std::vector<PacketConnection> tiles =
-          analysis.getConnectedTiles(op, {bundle, (int)i});
+          analysis.getConnectedTiles(op, {bundle, (int)i}, keepPartialFlows);
       LLVM_DEBUG(llvm::dbgs() << tiles.size() << " Flows\n");
-
-      for (PacketConnection &c : tiles) {
-        PortConnection portConnection = c.portConnection;
-        MaskValue maskValue = c.mv;
-        Operation *destOp = portConnection.op;
-        Port destPort = portConnection.port;
-        if (maskValue.mask == 0) {
-          FlowOp::create(rewriter, Op->getLoc(), Op->getResult(0), bundle, i,
-                         destOp->getResult(0), destPort.bundle,
-                         destPort.channel);
-        } else {
-          auto flowOp = PacketFlowOp::create(rewriter, Op->getLoc(),
-                                             maskValue.value, nullptr, nullptr);
-          PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter,
-                                         Op->getLoc());
-          OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
-          rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
-          PacketSourceOp::create(rewriter, Op->getLoc(), Op->getResult(0),
-                                 bundle, i);
-          PacketDestOp::create(rewriter, Op->getLoc(), destOp->getResult(0),
-                               destPort.bundle, destPort.channel);
-          rewriter.restoreInsertionPoint(ip);
-        }
-      }
+      emitFlows(rewriter, Op->getLoc(), Op->getResult(0), bundle, (int)i, tiles,
+                emitVias, /*dropIntraTile=*/false, consumed);
     }
+  }
+}
+
+// Lift flows whose source is not a core/DMA.  Seed from every switchbox /
+// shim-mux input port that drives a connection but is not itself driven by an
+// upstream interconnect connection.  Ports driven by a core/DMA tile are
+// already covered by findFlowsFrom; ports driven by an upstream interconnect
+// are covered by that interconnect's own source, so both are skipped here to
+// avoid emitting a flow twice.
+static void findFlowsFromInterconnect(Operation *switchOp,
+                                      ConnectivityAnalysis &analysis,
+                                      OpBuilder &rewriter,
+                                      bool keepPartialFlows, bool emitVias,
+                                      llvm::DenseSet<Operation *> &consumed) {
+  Region *connections = nullptr;
+  if (auto sb = dyn_cast<SwitchboxOp>(switchOp))
+    connections = &sb.getConnections();
+  else if (auto sm = dyn_cast<ShimMuxOp>(switchOp))
+    connections = &sm.getConnections();
+  if (!connections)
+    return;
+  rewriter.setInsertionPoint(switchOp->getBlock()->getTerminator());
+
+  // Distinct source ports of this interconnect's connections and packet rules.
+  llvm::SmallVector<Port, 8> sourcePorts;
+  auto addPort = [&](Port p) {
+    if (!llvm::is_contained(sourcePorts, p))
+      sourcePorts.push_back(p);
+  };
+  Block &b = connections->front();
+  for (auto connectOp : b.getOps<ConnectOp>())
+    addPort(connectOp.sourcePort());
+  for (auto rulesOp : b.getOps<PacketRulesOp>())
+    addPort(rulesOp.sourcePort());
+
+  for (Port p : sourcePorts) {
+    Value srcTile;
+    WireBundle srcBundle = p.bundle;
+    int srcChannel = p.channel;
+    if (auto up = analysis.upstreamOf(switchOp, p)) {
+      Operation *upOp = up->op;
+      Port upPort = up->port;
+      if (upOp && upOp->hasTrait<IsFlowEndPoint>()) {
+        // Driven by a tile.  Core/DMA sources are handled by findFlowsFrom;
+        // recover the remaining tile-source bundles (e.g. PLIO) from here.
+        if (upPort.bundle == WireBundle::Core ||
+            upPort.bundle == WireBundle::DMA)
+          continue;
+        srcTile = upOp->getResult(0);
+        srcBundle = upPort.bundle;
+        srcChannel = upPort.channel;
+      } else if (analysis.drivesPort(upOp, upPort)) {
+        // Mid-chain: an upstream interconnect drives this port.
+        continue;
+      } else {
+        // Wire exists but nothing drives it: this input is a fabric entry.
+        srcTile = resolveEndpointTile(switchOp);
+      }
+    } else {
+      // No upstream wire: this input is a fabric entry (array edge).
+      srcTile = resolveEndpointTile(switchOp);
+    }
+    if (!srcTile)
+      continue;
+    std::vector<PacketConnection> tiles =
+        analysis.getConnectedTilesFromInput(switchOp, p, keepPartialFlows);
+    emitFlows(rewriter, switchOp->getLoc(), srcTile, srcBundle, srcChannel,
+              tiles, emitVias, /*dropIntraTile=*/true, consumed);
   }
 }
 
@@ -274,16 +650,119 @@ struct AIEFindFlowsPass
     registry.insert<func::FuncDialect>();
     registry.insert<AIEDialect>();
   }
+
+  // An interconnect whose region holds nothing but its terminator carries no
+  // configuration and can be dropped.
+  static bool isEmptyInterconnect(Region &connections) {
+    Block &b = connections.front();
+    return b.getOps<ConnectOp>().empty() && b.getOps<PacketRulesOp>().empty() &&
+           b.getOps<MasterSetOp>().empty() && b.getOps<AMSelOp>().empty();
+  }
+
   void runOnOperation() override {
 
     DeviceOp d = getOperation();
     ConnectivityAnalysis analysis(d);
     d.getTargetModel().validate();
+    if (clEmitVias)
+      analysis.enableFanoutSplitting();
 
+    // In pinning mode the packet routes are re-emitted as straight-line section
+    // flows carrying vias; the original packet_flow ops they replace are
+    // recorded now so they can be dropped once the sections are in place.
+    SmallVector<PacketFlowOp> originalPacketFlows;
+    if (clEmitVias)
+      for (auto pf : d.getOps<PacketFlowOp>())
+        originalPacketFlows.push_back(pf);
+
+    llvm::DenseSet<Operation *> consumed;
     OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
     for (auto tile : d.getOps<TileOp>()) {
-      findFlowsFrom(tile, analysis, builder);
+      findFlowsFrom(tile, analysis, builder, clKeepPartialFlows, clEmitVias,
+                    consumed);
     }
+    // Lift flows whose source is not a core/DMA (transit fills, packet routing
+    // steered at runtime, PLIO/edge entries) directly from the interconnect.
+    if (clKeepPartialFlows) {
+      for (auto switchOp : d.getOps<SwitchboxOp>())
+        findFlowsFromInterconnect(switchOp, analysis, builder,
+                                  clKeepPartialFlows, clEmitVias, consumed);
+      for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+        findFlowsFromInterconnect(shimMuxOp, analysis, builder,
+                                  clKeepPartialFlows, clEmitVias, consumed);
+    }
+
+    // Each output of a fan-out node starts a new linear section; drain those
+    // seeds to a fixpoint (a branch may reach further fan-outs).  The fan-out
+    // nodes themselves stay explicit.
+    if (clEmitVias) {
+      builder.setInsertionPoint(d.getBody()->getTerminator());
+      llvm::DenseSet<std::pair<Operation *, int>> seeded;
+      bool progress = true;
+      while (progress) {
+        progress = false;
+        llvm::SmallVector<std::pair<Operation *, int>> snapshot(
+            analysis.getFanoutEgressSeeds().begin(),
+            analysis.getFanoutEgressSeeds().end());
+        for (auto &seed : snapshot) {
+          if (!seeded.insert(seed).second)
+            continue;
+          progress = true;
+          Operation *switchOp = seed.first;
+          Port egress = ConnectivityAnalysis::decodePort(seed.second);
+          Value srcTile = resolveEndpointTile(switchOp);
+          if (!srcTile)
+            continue;
+          std::vector<PacketConnection> tiles =
+              analysis.getConnectedTilesFromEgress(switchOp, egress,
+                                                   clKeepPartialFlows);
+          emitFlows(builder, switchOp->getLoc(), srcTile, egress.bundle,
+                    egress.channel, tiles, clEmitVias, /*dropIntraTile=*/true,
+                    consumed);
+        }
+      }
+    }
+
+    // The lifted section flows now describe the packet routes; drop the
+    // originals so they are not routed a second time.
+    for (PacketFlowOp pf : originalPacketFlows)
+      pf.erase();
+
+    if (!clRemoveLifted)
+      return;
+
+    // Every recovered flow makes the interconnect ops it traversed redundant;
+    // drop exactly those, leaving any configuration that could not be lifted
+    // (e.g. an unreachable connect) in place.  Leaf routing ops go first;
+    // amsels that lose all users and now-empty rule containers follow.
+    for (Operation *op : consumed)
+      if (isa<ConnectOp, PacketRuleOp, MasterSetOp>(op))
+        op->erase();
+    auto cleanupInterconnect = [](Region &connections) {
+      for (auto amselOp :
+           llvm::make_early_inc_range(connections.getOps<AMSelOp>()))
+        if (amselOp.use_empty())
+          amselOp.erase();
+      for (auto rulesOp :
+           llvm::make_early_inc_range(connections.getOps<PacketRulesOp>()))
+        if (rulesOp.getRules().front().getOps<PacketRuleOp>().empty())
+          rulesOp.erase();
+    };
+    for (auto switchOp : d.getOps<SwitchboxOp>())
+      cleanupInterconnect(switchOp.getConnections());
+    for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+      cleanupInterconnect(shimMuxOp.getConnections());
+
+    // Wires reference interconnect results and are regenerated by routing, so
+    // drop them, then remove any interconnect left fully empty.
+    for (auto wireOp : llvm::make_early_inc_range(d.getOps<WireOp>()))
+      wireOp.erase();
+    for (auto switchOp : llvm::make_early_inc_range(d.getOps<SwitchboxOp>()))
+      if (isEmptyInterconnect(switchOp.getConnections()))
+        switchOp.erase();
+    for (auto shimMuxOp : llvm::make_early_inc_range(d.getOps<ShimMuxOp>()))
+      if (isEmptyInterconnect(shimMuxOp.getConnections()))
+        shimMuxOp.erase();
   }
 };
 

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -17,6 +17,9 @@
 #include <utility>
 #include <vector>
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+
 namespace xilinx::AIE {
 #define GEN_PASS_DEF_AIEFINDFLOWS
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h.inc"
@@ -41,11 +44,17 @@ using PortConnection = struct PortConnection {
 using PortMaskValue = struct PortMaskValue {
   Port port;
   MaskValue mv;
+  // The interconnect ops that implement this hop (a circuit ConnectOp, or a
+  // packet PacketRuleOp + MasterSetOp + AMSelOp). Recorded so the flows that
+  // consume them can be lifted out of the physical IR.
+  llvm::SmallVector<Operation *, 3> ops;
 };
 
 using PacketConnection = struct PacketConnection {
   PortConnection portConnection;
   MaskValue mv;
+  // Interconnect ops traversed on the way to this endpoint.
+  llvm::SmallVector<Operation *, 8> usedOps;
 };
 
 class ConnectivityAnalysis {
@@ -93,7 +102,7 @@ private:
     for (auto connectOp : b.getOps<ConnectOp>()) {
       if (connectOp.sourcePort() == sourcePort) {
         MaskValue maskValue = {0, 0};
-        portSet.push_back({connectOp.destPort(), maskValue});
+        portSet.push_back({connectOp.destPort(), maskValue, {connectOp}});
         LLVM_DEBUG(llvm::dbgs()
                    << "To:" << stringifyWireBundle(connectOp.destPort().bundle)
                    << " " << connectOp.destPort().channel << "\n");
@@ -115,7 +124,10 @@ private:
                            << stringifyWireBundle(masterSetOp.destPort().bundle)
                            << " " << masterSetOp.destPort().channel << "\n");
                 MaskValue maskValue = {ruleOp.maskInt(), ruleOp.valueInt()};
-                portSet.push_back({masterSetOp.destPort(), maskValue});
+                portSet.push_back(
+                    {masterSetOp.destPort(),
+                     maskValue,
+                     {ruleOp, masterSetOp, amsel.getDefiningOp()}});
               }
             }
       }
@@ -123,10 +135,11 @@ private:
     return portSet;
   }
 
-  std::vector<PacketConnection>
-  maskSwitchboxConnections(Operation *switchOp,
-                           const std::vector<PortMaskValue> &nextPortMaskValues,
-                           MaskValue maskValue) const {
+  std::vector<PacketConnection> maskSwitchboxConnections(
+      Operation *switchOp, ArrayRef<Operation *> currentUsedOps,
+      const std::vector<PortMaskValue> &nextPortMaskValues, MaskValue maskValue,
+      bool keepPartialFlows,
+      std::vector<PacketConnection> &partialEndpoints) const {
     std::vector<PacketConnection> worklist;
     for (auto &nextPortMaskValue : nextPortMaskValues) {
       Port nextPort = nextPortMaskValue.port;
@@ -146,107 +159,146 @@ private:
       MaskValue newMaskValue = {maskValue.mask | nextMaskValue.mask,
                                 maskValue.value |
                                     (nextMaskValue.mask & nextMaskValue.value)};
+      SmallVector<Operation *, 8> newUsedOps(currentUsedOps.begin(),
+                                             currentUsedOps.end());
+      newUsedOps.append(nextPortMaskValue.ops.begin(),
+                        nextPortMaskValue.ops.end());
       auto nextConnection = getConnectionThroughWire(switchOp, nextPort);
 
-      // If there is no wire to follow then bail out.
-      if (!nextConnection)
+      if (!nextConnection) {
+        // The switchbox drives nextPort but no wire continues from it (an array
+        // edge or an off-fabric consumer). Under partial recovery this output
+        // port is itself the flow's endpoint.
+        if (keepPartialFlows)
+          partialEndpoints.push_back(
+              {{switchOp, nextPort}, newMaskValue, newUsedOps});
         continue;
+      }
 
-      worklist.push_back({*nextConnection, newMaskValue});
+      worklist.push_back({*nextConnection, newMaskValue, newUsedOps});
     }
     return worklist;
   }
 
 public:
-  // Get the tiles connected to the given tile, starting from the given
-  // output port of the tile.  This is 1:N relationship because each
-  // switchbox can broadcast.
-  std::vector<PacketConnection> getConnectedTiles(TileOp tileOp,
-                                                  Port port) const {
+  // Follow the single upstream wire out of an interconnect input port.
+  std::optional<PortConnection> upstreamOf(Operation *op, Port port) const {
+    return getConnectionThroughWire(op, port);
+  }
 
-    LLVM_DEBUG(llvm::dbgs()
-               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
-               << port.channel << ")");
-    LLVM_DEBUG(tileOp.dump());
+  // Whether `port` is driven (is the destination of a connect or masterset)
+  // inside the given interconnect op.
+  bool drivesPort(Operation *op, Port port) const {
+    Region *r = nullptr;
+    if (auto sb = dyn_cast<SwitchboxOp>(op))
+      r = &sb.getConnections();
+    else if (auto sm = dyn_cast<ShimMuxOp>(op))
+      r = &sm.getConnections();
+    if (!r)
+      return false;
+    Block &b = r->front();
+    for (auto connectOp : b.getOps<ConnectOp>())
+      if (connectOp.destPort() == port)
+        return true;
+    for (auto masterSetOp : b.getOps<MasterSetOp>())
+      if (masterSetOp.destPort() == port)
+        return true;
+    return false;
+  }
 
-    // The accumulated result;
+  // Traverse forward from switchbox/shim-mux input ports, collecting the
+  // endpoints each stream reaches: flow-endpoint tiles, or -- under
+  // keepPartialFlows -- driven interconnect ports that have no onward wire.
+  std::vector<PacketConnection> traverse(std::vector<PacketConnection> worklist,
+                                         bool keepPartialFlows) const {
     std::vector<PacketConnection> connectedTiles;
-    // A worklist of PortConnections to visit.  These are all input ports of
-    // some object (likely either a TileOp or a SwitchboxOp).
-    std::vector<PacketConnection> worklist;
-    // Start the worklist by traversing from the tile to its connected
-    // switchbox.
-    auto t = getConnectionThroughWire(tileOp.getOperation(), port);
-
-    // If there is no wire to traverse, then just return no connection
-    if (!t)
-      return connectedTiles;
-    worklist.push_back({*t, {0, 0}});
-
     while (!worklist.empty()) {
       PacketConnection t = worklist.back();
       worklist.pop_back();
-      PortConnection portConnection = t.portConnection;
+      Operation *other = t.portConnection.op;
+      Port otherPort = t.portConnection.port;
       MaskValue maskValue = t.mv;
-      Operation *other = portConnection.op;
-      Port otherPort = portConnection.port;
       if (other && other->hasTrait<IsFlowEndPoint>()) {
         // If we got to a tile, then add it to the result.
         connectedTiles.push_back(t);
-      } else if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other)) {
-        std::vector<PortMaskValue> nextPortMaskValues =
-            getConnectionsThroughSwitchbox(switchOp.getConnections(),
-                                           otherPort);
-        std::vector<PacketConnection> newWorkList =
-            maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
-        // append to the worklist
-        worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
-          // No rule matched some incoming packet.  This is likely a
-          // configuration error.
-          LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
-          LLVM_DEBUG(other->dump());
-        }
-      } else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other)) {
-        std::vector<PortMaskValue> nextPortMaskValues =
-            getConnectionsThroughSwitchbox(switchOp.getConnections(),
-                                           otherPort);
-        std::vector<PacketConnection> newWorkList =
-            maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
-        // append to the worklist
-        worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
-          // No rule matched some incoming packet.  This is likely a
-          // configuration error.
-          LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
-          LLVM_DEBUG(other->dump());
-        }
-      } else {
+        continue;
+      }
+      Region *connections = nullptr;
+      if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other))
+        connections = &switchOp.getConnections();
+      else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other))
+        connections = &switchOp.getConnections();
+      if (!connections) {
         LLVM_DEBUG(llvm::dbgs()
                    << "*** Connection Terminated at unknown operation: ");
+        LLVM_DEBUG(other->dump());
+        continue;
+      }
+      std::vector<PortMaskValue> nextPortMaskValues =
+          getConnectionsThroughSwitchbox(*connections, otherPort);
+      std::vector<PacketConnection> partialEndpoints;
+      std::vector<PacketConnection> newWorkList = maskSwitchboxConnections(
+          other, t.usedOps, nextPortMaskValues, maskValue, keepPartialFlows,
+          partialEndpoints);
+      worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
+      connectedTiles.insert(connectedTiles.end(), partialEndpoints.begin(),
+                            partialEndpoints.end());
+      if (!nextPortMaskValues.empty() && newWorkList.empty() &&
+          partialEndpoints.empty()) {
+        // No rule matched some incoming packet.  This is likely a
+        // configuration error.
+        LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
         LLVM_DEBUG(other->dump());
       }
     }
     return connectedTiles;
   }
+
+  // Get the tiles connected to the given tile, starting from the given
+  // output port of the tile.  This is 1:N relationship because each
+  // switchbox can broadcast.
+  std::vector<PacketConnection> getConnectedTiles(TileOp tileOp, Port port,
+                                                  bool keepPartialFlows) const {
+    LLVM_DEBUG(llvm::dbgs()
+               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
+               << port.channel << ")");
+    LLVM_DEBUG(tileOp.dump());
+    // Traverse from the tile to its connected switchbox.
+    auto t = getConnectionThroughWire(tileOp.getOperation(), port);
+    // If there is no wire to traverse, then just return no connection
+    if (!t)
+      return {};
+    return traverse({PacketConnection{*t, {0, 0}, {}}}, keepPartialFlows);
+  }
+
+  // Get the endpoints reached by a stream that enters the fabric at the given
+  // input port of an interconnect (switchbox / shim-mux).  Used to lift flows
+  // whose source is not a core or DMA.
+  std::vector<PacketConnection>
+  getConnectedTilesFromInput(Operation *switchOp, Port inputPort,
+                             bool keepPartialFlows) const {
+    return traverse(
+        {PacketConnection{PortConnection{switchOp, inputPort}, {0, 0}, {}}},
+        keepPartialFlows);
+  }
 };
 
 // Identifies a flow by its two endpoints -- tile coordinates plus port -- and
-// the packet ID it carries, using kCircuitFlow for circuit-switched flows.
+// the packet claim it carries, using kCircuitFlow for circuit-switched flows.
 // Coordinates rather than SSA values, so flows written against different
 // aie.tile ops for the same tile still compare equal.
 static constexpr int kCircuitFlow = -1;
-using FlowKey = std::tuple<int, int, int, int, int, int, int, int, int>;
+using FlowKey = std::tuple<int, int, int, int, int, int, int, int, int, int>;
 using FlowKeySet = std::set<FlowKey>;
 
 // Returns nullopt when either endpoint's coordinates are unknown, in which
 // case the caller cannot tell the flow apart from any other and must not
 // dedupe it away.
-static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
-                                            Operation *destOp, Port destPort,
-                                            int packetID) {
-  auto coords = [](Operation *op) -> std::optional<std::pair<int, int>> {
-    auto tile = llvm::dyn_cast_or_null<TileLike>(op);
+static std::optional<FlowKey> tryGetFlowKey(Value srcTileValue, Port srcPort,
+                                            Value destTileValue, Port destPort,
+                                            int packetID, int packetMask) {
+  auto coords = [](Value v) -> std::optional<std::pair<int, int>> {
+    auto tile = llvm::dyn_cast_or_null<TileLike>(v.getDefiningOp());
     if (!tile)
       return std::nullopt;
     std::optional<int> col = tile.tryGetCol();
@@ -255,8 +307,8 @@ static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
       return std::nullopt;
     return std::make_pair(*col, *row);
   };
-  std::optional<std::pair<int, int>> src = coords(srcOp);
-  std::optional<std::pair<int, int>> dest = coords(destOp);
+  std::optional<std::pair<int, int>> src = coords(srcTileValue);
+  std::optional<std::pair<int, int>> dest = coords(destTileValue);
   if (!src || !dest)
     return std::nullopt;
   return FlowKey{src->first,
@@ -267,27 +319,131 @@ static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
                  dest->second,
                  static_cast<int>(destPort.bundle),
                  destPort.channel,
-                 packetID};
+                 packetID,
+                 packetMask};
 }
 
-// Drops the flows the device already declares. This pass recovers the logical
-// flows a routed design implements, so the flows it writes are the answer --
-// leaving the originals in place next to them would just describe the same
-// routing twice, which DeviceOp::verify now rejects. It really does happen:
-// --aie-create-pathfinder-flows leaves behind every aie.flow it folded into an
-// earlier flow with the same source, and it never consumes aie.packet_flow.
-static void eraseExistingFlows(DeviceOp device) {
-  SmallVector<Operation *> toErase;
-  for (FlowOp flow : device.getOps<FlowOp>())
-    toErase.push_back(flow);
-  for (PacketFlowOp packetFlow : device.getOps<PacketFlowOp>())
-    toErase.push_back(packetFlow);
-  for (Operation *op : toErase)
-    op->erase();
+// The tile an endpoint of a lifted flow belongs to.
+//
+// aie.flow names tiles: --aie-create-pathfinder-flows casts both endpoints of
+// every flow to TileOp. A tile element such as an aie.shim_dma therefore has to
+// resolve to its owning tile, or the flow this pass emits crashes the router it
+// is meant to feed. TileElement covers every element that can end a flow, and
+// Interconnect extends it, so a switchbox or shim-mux port resolves the same
+// way.
+static Value resolveEndpointTile(Operation *op) {
+  if (isa<TileOp>(op))
+    return op->getResult(0);
+  if (auto element = dyn_cast<TileElement>(op))
+    return element.getTile();
+  return nullptr;
+}
+
+static void emitFlows(OpBuilder &rewriter, Location loc, Value srcTile,
+                      WireBundle srcBundle, int srcChannel,
+                      const std::vector<PacketConnection> &endpoints,
+                      bool dropIntraTile, int idMask, FlowKeySet &seen,
+                      llvm::DenseSet<Operation *> &consumed) {
+  for (const PacketConnection &c : endpoints) {
+    Operation *destOp = c.portConnection.op;
+    Port destPort = c.portConnection.port;
+    MaskValue maskValue = c.mv;
+    Value destTile = resolveEndpointTile(destOp);
+    if (!destTile)
+      continue;
+    // A control overlay stays materialized. Its switchbox configuration carries
+    // the is_ctrl_pkt_overlay marker, and a lifted flow cannot rebuild it.
+    bool keepMaterialized = false;
+    for (Operation *op : c.usedOps) {
+      Operation *rulesParent =
+          isa_and_nonnull<PacketRuleOp>(op) ? op->getParentOp() : nullptr;
+      if (op->hasAttr("is_ctrl_pkt_overlay") ||
+          (rulesParent && rulesParent->hasAttr("is_ctrl_pkt_overlay"))) {
+        keepMaterialized = true;
+        break;
+      }
+    }
+    if (keepMaterialized)
+      continue;
+    // A packet endpoint becomes a logical packet flow, and the pass reclaims
+    // its physical configuration.
+    //
+    // The rules decide this, not the mask: a rule may carry mask 0, which
+    // accepts every id, and a circuit path accumulates the same mask 0.
+    bool isPacket = llvm::any_of(c.usedOps, [](Operation *op) {
+      return isa_and_nonnull<PacketRuleOp>(op);
+    });
+    // The traversal reaches one endpoint more than once when a broadcast
+    // re-converges on it, and the three seeds can arrive at one route from
+    // different directions. Those repeats describe one flow, and
+    // DeviceOp::verify rejects a flow declared twice.
+    std::optional<FlowKey> key =
+        tryGetFlowKey(srcTile, {srcBundle, srcChannel}, destTile, destPort,
+                      isPacket ? maskValue.value : kCircuitFlow,
+                      isPacket ? maskValue.mask : 0);
+    if (key && !seen.insert(*key).second)
+      continue;
+    if (isPacket) {
+      for (Operation *op : c.usedOps)
+        if (op)
+          consumed.insert(op);
+      // The lowering stores keep_pkt_header on the master set that drives the
+      // destination. Carry it onto the recovered flow, or re-lowering strips
+      // the header and misroutes the packet downstream.
+      BoolAttr keepPktHeader;
+      for (Operation *op : c.usedOps)
+        if (auto ms = dyn_cast_or_null<MasterSetOp>(op))
+          if (ms.getDestBundle() == destPort.bundle &&
+              ms.getDestChannel() == destPort.channel)
+            keepPktHeader = ms.getKeepPktHeaderAttr();
+      // The rules along the path accept every id that agrees with value on the
+      // bits mask selects. Which of those a running design sends is not
+      // decidable here, so state the pair and let routing rebuild the same
+      // rules.
+      //
+      // A full-width mask selects one id, which the id states on its own.
+      // Leaving the attribute off keeps such a flow mergeable with the others
+      // that share its route, the way routing found it.
+      IntegerAttr mask;
+      if (maskValue.mask != idMask)
+        mask = rewriter.getI8IntegerAttr(maskValue.mask);
+      auto flowOp = PacketFlowOp::create(
+          rewriter, loc, rewriter.getI8IntegerAttr(maskValue.value), mask,
+          keepPktHeader, BoolAttr());
+      PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter, loc);
+      OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
+      PacketSourceOp::create(rewriter, loc, srcTile, srcBundle, srcChannel);
+      PacketDestOp::create(rewriter, loc, destTile, destPort.bundle,
+                           destPort.channel);
+      rewriter.restoreInsertionPoint(ip);
+      continue;
+    }
+    // A section that lifts no interconnect configuration carries no routing: it
+    // is the physical wire between two retained nodes. The wire is implicit and
+    // the switchboxes at both ends stay explicit, so a flow emitted for it
+    // would only fight their fixed connections on re-routing.
+    if (c.usedOps.empty())
+      continue;
+    // A flow seeded from a fabric entry that terminates on a real endpoint of
+    // the same tile never leaves that tile. It is a dead or orphan interconnect
+    // connection, such as an undriven shim-mux write path, so the pass leaves
+    // it alone.
+    if (dropIntraTile && destTile == srcTile && isa<TileOp>(destOp))
+      continue;
+    // Every interconnect op on this endpoint's path is lifted into the flow.
+    for (Operation *op : c.usedOps)
+      if (op)
+        consumed.insert(op);
+    FlowOp::create(rewriter, loc, srcTile, srcBundle, srcChannel, destTile,
+                   destPort.bundle, destPort.channel);
+  }
 }
 
 static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
-                          OpBuilder &rewriter, FlowKeySet &seen) {
+                          OpBuilder &rewriter, bool keepPartialFlows,
+                          int idMask, FlowKeySet &seen,
+                          llvm::DenseSet<Operation *> &consumed) {
   Operation *Op = op.getOperation();
   rewriter.setInsertionPoint(Op->getBlock()->getTerminator());
 
@@ -298,42 +454,80 @@ static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
                << op.getNumSourceConnections(bundle) << " Connections\n");
     for (size_t i = 0; i < op.getNumSourceConnections(bundle); i++) {
       std::vector<PacketConnection> tiles =
-          analysis.getConnectedTiles(op, {bundle, (int)i});
+          analysis.getConnectedTiles(op, {bundle, (int)i}, keepPartialFlows);
       LLVM_DEBUG(llvm::dbgs() << tiles.size() << " Flows\n");
-
-      for (PacketConnection &c : tiles) {
-        PortConnection portConnection = c.portConnection;
-        MaskValue maskValue = c.mv;
-        Operation *destOp = portConnection.op;
-        Port destPort = portConnection.port;
-        // The traversal can reach the same endpoint more than once, for
-        // instance when a broadcast re-converges on it. Those repeats all
-        // describe one logical flow, and a flow declared twice is rejected by
-        // DeviceOp::verify.
-        std::optional<FlowKey> key =
-            tryGetFlowKey(Op, {bundle, (int)i}, destOp, destPort,
-                          maskValue.mask == 0 ? kCircuitFlow : maskValue.value);
-        if (key && !seen.insert(*key).second)
-          continue;
-        if (maskValue.mask == 0) {
-          FlowOp::create(rewriter, Op->getLoc(), Op->getResult(0), bundle, i,
-                         destOp->getResult(0), destPort.bundle,
-                         destPort.channel);
-        } else {
-          auto flowOp = PacketFlowOp::create(rewriter, Op->getLoc(),
-                                             maskValue.value, nullptr, nullptr);
-          PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter,
-                                         Op->getLoc());
-          OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
-          rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
-          PacketSourceOp::create(rewriter, Op->getLoc(), Op->getResult(0),
-                                 bundle, i);
-          PacketDestOp::create(rewriter, Op->getLoc(), destOp->getResult(0),
-                               destPort.bundle, destPort.channel);
-          rewriter.restoreInsertionPoint(ip);
-        }
-      }
+      emitFlows(rewriter, Op->getLoc(), Op->getResult(0), bundle, (int)i, tiles,
+                /*dropIntraTile=*/false, idMask, seen, consumed);
     }
+  }
+}
+
+// Lift flows whose source is not a core/DMA.  Seed from every switchbox /
+// shim-mux input port that drives a connection but is not itself driven by an
+// upstream interconnect connection.  Ports driven by a core/DMA tile are
+// already covered by findFlowsFrom; ports driven by an upstream interconnect
+// are covered by that interconnect's own source, so both are skipped here to
+// avoid emitting a flow twice.
+static void findFlowsFromInterconnect(Operation *switchOp,
+                                      ConnectivityAnalysis &analysis,
+                                      OpBuilder &rewriter,
+                                      bool keepPartialFlows, int idMask,
+                                      FlowKeySet &seen,
+                                      llvm::DenseSet<Operation *> &consumed) {
+  Region *connections = nullptr;
+  if (auto sb = dyn_cast<SwitchboxOp>(switchOp))
+    connections = &sb.getConnections();
+  else if (auto sm = dyn_cast<ShimMuxOp>(switchOp))
+    connections = &sm.getConnections();
+  if (!connections)
+    return;
+  rewriter.setInsertionPoint(switchOp->getBlock()->getTerminator());
+
+  // Distinct source ports of this interconnect's connections and packet rules.
+  llvm::SmallVector<Port, 8> sourcePorts;
+  auto addPort = [&](Port p) {
+    if (!llvm::is_contained(sourcePorts, p))
+      sourcePorts.push_back(p);
+  };
+  Block &b = connections->front();
+  for (auto connectOp : b.getOps<ConnectOp>())
+    addPort(connectOp.sourcePort());
+  for (auto rulesOp : b.getOps<PacketRulesOp>())
+    addPort(rulesOp.sourcePort());
+
+  for (Port p : sourcePorts) {
+    Value srcTile;
+    WireBundle srcBundle = p.bundle;
+    int srcChannel = p.channel;
+    if (auto up = analysis.upstreamOf(switchOp, p)) {
+      Operation *upOp = up->op;
+      Port upPort = up->port;
+      if (upOp && upOp->hasTrait<IsFlowEndPoint>()) {
+        // Driven by a tile.  Core/DMA sources are handled by findFlowsFrom;
+        // recover the remaining tile-source bundles (e.g. PLIO) from here.
+        if (upPort.bundle == WireBundle::Core ||
+            upPort.bundle == WireBundle::DMA)
+          continue;
+        srcTile = upOp->getResult(0);
+        srcBundle = upPort.bundle;
+        srcChannel = upPort.channel;
+      } else if (analysis.drivesPort(upOp, upPort)) {
+        // Mid-chain: an upstream interconnect drives this port.
+        continue;
+      } else {
+        // Wire exists but nothing drives it: this input is a fabric entry.
+        srcTile = resolveEndpointTile(switchOp);
+      }
+    } else {
+      // No upstream wire: this input is a fabric entry (array edge).
+      srcTile = resolveEndpointTile(switchOp);
+    }
+    if (!srcTile)
+      continue;
+    std::vector<PacketConnection> tiles =
+        analysis.getConnectedTilesFromInput(switchOp, p, keepPartialFlows);
+    emitFlows(rewriter, switchOp->getLoc(), srcTile, srcBundle, srcChannel,
+              tiles, /*dropIntraTile=*/true, idMask, seen, consumed);
   }
 }
 
@@ -343,21 +537,106 @@ struct AIEFindFlowsPass
     registry.insert<func::FuncDialect>();
     registry.insert<AIEDialect>();
   }
+
+  // An interconnect whose region holds nothing but its terminator carries no
+  // configuration and can be dropped.
+  static bool isEmptyInterconnect(Region &connections) {
+    Block &b = connections.front();
+    return b.getOps<ConnectOp>().empty() && b.getOps<PacketRulesOp>().empty() &&
+           b.getOps<MasterSetOp>().empty() && b.getOps<AMSelOp>().empty();
+  }
+
   void runOnOperation() override {
 
     DeviceOp d = getOperation();
     ConnectivityAnalysis analysis(d);
     d.getTargetModel().validate();
 
-    // The analysis above reads only the switchboxes and shim muxes, so the
-    // flows can be cleared before rebuilding them from that routing.
-    eraseExistingFlows(d);
+    // Widest mask the target's packet ids can carry.
+    const int idMask =
+        (1 << llvm::Log2_32_Ceil(d.getTargetModel().getMaxPacketId() + 1)) - 1;
 
-    OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
+    llvm::DenseSet<Operation *> consumed;
     FlowKeySet seen;
+    OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
     for (auto tile : d.getOps<TileOp>()) {
-      findFlowsFrom(tile, analysis, builder, seen);
+      findFlowsFrom(tile, analysis, builder, clKeepPartialFlows, idMask, seen,
+                    consumed);
     }
+    // Lift flows whose source is not a core/DMA (transit fills, packet routing
+    // steered at runtime, PLIO/edge entries) directly from the interconnect.
+    if (clKeepPartialFlows) {
+      for (auto switchOp : d.getOps<SwitchboxOp>())
+        findFlowsFromInterconnect(switchOp, analysis, builder,
+                                  clKeepPartialFlows, idMask, seen, consumed);
+      for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+        findFlowsFromInterconnect(shimMuxOp, analysis, builder,
+                                  clKeepPartialFlows, idMask, seen, consumed);
+    }
+
+    if (!clRemoveLifted)
+      return;
+
+    // Every recovered flow makes the interconnect ops it traversed redundant;
+    // drop exactly those, leaving any configuration that could not be lifted
+    // (e.g. an unreachable connect) in place.  Leaf routing ops go first;
+    // amsels that lose all users and now-empty rule containers follow.
+    for (Operation *op : consumed)
+      if (isa<ConnectOp, PacketRuleOp, MasterSetOp>(op))
+        op->erase();
+    auto cleanupInterconnect = [](Region &connections) {
+      for (auto amselOp :
+           llvm::make_early_inc_range(connections.getOps<AMSelOp>()))
+        if (amselOp.use_empty())
+          amselOp.erase();
+      for (auto rulesOp :
+           llvm::make_early_inc_range(connections.getOps<PacketRulesOp>()))
+        if (rulesOp.getRules().front().getOps<PacketRuleOp>().empty())
+          rulesOp.erase();
+    };
+    for (auto switchOp : d.getOps<SwitchboxOp>())
+      cleanupInterconnect(switchOp.getConnections());
+    for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+      cleanupInterconnect(shimMuxOp.getConnections());
+
+    // An interconnect still holding configuration was not lifted: a control
+    // overlay, a connect this pass could not reach, or -- under
+    // keep-partial-flows=false -- a partial route left in place. Routing
+    // regenerates a wire only for the flows it routes, so a wire reaching such
+    // an interconnect has to stay, or that configuration ends up unreachable.
+    llvm::DenseSet<Operation *> retained;
+    auto retainNonEmpty = [&](Operation *op, Region &connections) {
+      if (!isEmptyInterconnect(connections))
+        retained.insert(op);
+    };
+    for (auto switchOp : d.getOps<SwitchboxOp>())
+      retainNonEmpty(switchOp, switchOp.getConnections());
+    for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+      retainNonEmpty(shimMuxOp, shimMuxOp.getConnections());
+
+    llvm::DenseSet<Operation *> wiredToRetained;
+    for (auto wireOp : llvm::make_early_inc_range(d.getOps<WireOp>())) {
+      Operation *src = wireOp.getSource().getDefiningOp();
+      Operation *dst = wireOp.getDest().getDefiningOp();
+      if (!retained.contains(src) && !retained.contains(dst)) {
+        wireOp.erase();
+        continue;
+      }
+      wiredToRetained.insert(src);
+      wiredToRetained.insert(dst);
+    }
+
+    // A surviving wire keeps its operands alive, so an empty interconnect one
+    // of them names outlives its configuration.
+    auto eraseIfUnused = [&](Operation *op, Region &connections) {
+      return isEmptyInterconnect(connections) && !wiredToRetained.contains(op);
+    };
+    for (auto switchOp : llvm::make_early_inc_range(d.getOps<SwitchboxOp>()))
+      if (eraseIfUnused(switchOp, switchOp.getConnections()))
+        switchOp.erase();
+    for (auto shimMuxOp : llvm::make_early_inc_range(d.getOps<ShimMuxOp>()))
+      if (eraseIfUnused(shimMuxOp, shimMuxOp.getConnections()))
+        shimMuxOp.erase();
   }
 };
 

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -151,6 +151,16 @@ struct AIEGenerateColumnControlOverlayPass
         }
         continue;
       }
+      // A device that already carries a control overlay -- e.g. a physically
+      // routed design recompiled through aiecc -- must not receive a second
+      // one, or the regenerated control flows would double-drive its shim
+      // control ports during routing.
+      if (deviceHasControlOverlay(dev)) {
+        if (clEmitStandaloneOverlay) {
+          dev->setAttr("has_ctrl_pkt_overlay", builder.getBoolAttr(true));
+        }
+        continue;
+      }
       participating.push_back(dev);
     }
 
@@ -373,6 +383,18 @@ struct AIEGenerateColumnControlOverlayPass
   static bool deviceOptedOut(DeviceOp device) {
     auto attr = device->getAttrOfType<BoolAttr>("needs_ctrl_pkt_overlay");
     return attr && !attr.getValue();
+  }
+
+  // Return true when `device` already contains a control-packet overlay,
+  // identified by the `is_ctrl_pkt_overlay` marker the overlay's routed
+  // switchbox configuration carries.
+  static bool deviceHasControlOverlay(DeviceOp device) {
+    return device
+        .walk([](Operation *op) {
+          return op->hasAttr("is_ctrl_pkt_overlay") ? WalkResult::interrupt()
+                                                    : WalkResult::advance();
+        })
+        .wasInterrupted();
   }
 
   AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, Location loc,

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -155,6 +155,16 @@ struct AIEGenerateColumnControlOverlayPass
         }
         continue;
       }
+      // A device that already carries a control overlay -- e.g. a physically
+      // routed design recompiled through aiecc -- must not receive a second
+      // one, or the regenerated control flows would double-drive its shim
+      // control ports during routing.
+      if (deviceHasControlOverlay(dev)) {
+        if (clEmitStandaloneOverlay) {
+          dev->setAttr("has_ctrl_pkt_overlay", builder.getBoolAttr(true));
+        }
+        continue;
+      }
       participating.push_back(dev);
     }
 
@@ -432,6 +442,18 @@ struct AIEGenerateColumnControlOverlayPass
         flows.try_emplace(*key, flow);
     }
     return flows;
+  }
+
+  // Return true when `device` already contains a control-packet overlay,
+  // identified by the `is_ctrl_pkt_overlay` marker the overlay's routed
+  // switchbox configuration carries.
+  static bool deviceHasControlOverlay(DeviceOp device) {
+    return device
+        .walk([](Operation *op) {
+          return op->hasAttr("is_ctrl_pkt_overlay") ? WalkResult::interrupt()
+                                                    : WalkResult::advance();
+        })
+        .wasInterrupted();
   }
 
   AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, Location loc,

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_os_ostream.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 
 using namespace mlir;
@@ -385,27 +386,71 @@ bool Pathfinder::addFixedConnection(SwitchboxOp switchboxOp) {
   int row = switchboxOp.rowIndex();
   TileID coords = {col, row};
   auto &sb = graph[std::make_pair(coords, coords)];
+  // Validate every connect against the original connectivity before reserving
+  // any resource, so a broadcast (one source fanning out to several dests) does
+  // not invalidate its own sibling connects mid-scan. A destination port may be
+  // driven only once; a source port may legally recur across a broadcast.
+  llvm::SmallVector<std::pair<int, int>, 8> reserved;
+  llvm::SmallDenseSet<int, 8> claimedDsts;
   for (ConnectOp connectOp : switchboxOp.getOps<ConnectOp>()) {
-    bool found = false;
-    for (size_t i = 0; i < sb.srcPorts.size(); i++) {
-      if (sb.srcPorts[i] != connectOp.sourcePort())
-        continue;
-      // A circuit-switched ConnectOp monopolizes its entire source port;
-      // mark all connectivity[i][*] INVALID so the pathfinder cannot route
-      // any packet flow through this source port.
-      for (size_t j = 0; j < sb.dstPorts.size(); j++) {
-        if (sb.dstPorts[j] == connectOp.destPort() &&
-            sb.connectivity[i][j] == Connectivity::AVAILABLE)
-          found = true;
-        sb.connectivity[i][j] = Connectivity::INVALID;
+    int srcIdx = -1, dstIdx = -1;
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      if (sb.srcPorts[i] == connectOp.sourcePort()) {
+        srcIdx = static_cast<int>(i);
+        break;
       }
-    }
-    if (!found) {
-      // ConnectOp references a (srcPort, dstPort) pair absent from or already
-      // fully invalidated in the switchbox model; IR/graph mismatch.
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      if (sb.dstPorts[j] == connectOp.destPort()) {
+        dstIdx = static_cast<int>(j);
+        break;
+      }
+    // Reject an illegal pair (absent from the switchbox model) or a second
+    // driver on the same output port; a repeated source port is a broadcast.
+    if (srcIdx < 0 || dstIdx < 0 ||
+        sb.connectivity[srcIdx][dstIdx] != Connectivity::AVAILABLE ||
+        !claimedDsts.insert(dstIdx).second)
       return false;
-    }
+    reserved.emplace_back(srcIdx, dstIdx);
   }
+  // A pre-placed packet-switched output (an aie.masterset, e.g. materialized
+  // from a `via`-pinned aie.packet_flow) also monopolizes its destination port:
+  // that stream-switch output is already configured for packet switching, so no
+  // circuit stream may drive it, and the router cannot emit a second masterset
+  // on the same port for another packet flow. Reserve those output ports too;
+  // otherwise the circuit pathfinder, blind to packet ops, may route a flow
+  // onto an output the masterset already owns, producing an illegal
+  // double-driver (two ops targeting the same dest) at materialization.
+  llvm::SmallVector<int, 8> reservedMasterDsts;
+  for (MasterSetOp masterSetOp : switchboxOp.getOps<MasterSetOp>()) {
+    int dstIdx = -1;
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      if (sb.dstPorts[j] == masterSetOp.destPort()) {
+        dstIdx = static_cast<int>(j);
+        break;
+      }
+    // Reject an output port absent from the switchbox model or already driven
+    // by a circuit connect or another masterset.
+    if (dstIdx < 0 || !claimedDsts.insert(dstIdx).second)
+      return false;
+    reservedMasterDsts.push_back(dstIdx);
+  }
+  // A circuit-switched ConnectOp monopolizes both its source port (the stream
+  // switch input) and its destination port (the output): no other stream may
+  // inject on that input, and the output can carry only this one stream.
+  // Reserving the whole column also reserves the outgoing wire, since that wire
+  // is reachable only by driving this output port.
+  for (auto [srcIdx, dstIdx] : reserved) {
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      sb.connectivity[srcIdx][j] = Connectivity::INVALID;
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      sb.connectivity[i][dstIdx] = Connectivity::INVALID;
+  }
+  // A masterset only fixes its output port (its inputs arrive through arbiters
+  // shared among packet flows), so reserve just that destination column and
+  // leave source rows free.
+  for (int dstIdx : reservedMasterDsts)
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      sb.connectivity[i][dstIdx] = Connectivity::INVALID;
   return true;
 }
 

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_os_ostream.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 
 using namespace mlir;
@@ -385,27 +386,69 @@ bool Pathfinder::addFixedConnection(SwitchboxOp switchboxOp) {
   int row = switchboxOp.rowIndex();
   TileID coords = {col, row};
   auto &sb = graph[std::make_pair(coords, coords)];
+  // Validate every connect against the original connectivity before reserving
+  // any resource, so a broadcast (one source fanning out to several dests) does
+  // not invalidate its own sibling connects mid-scan. A destination port may be
+  // driven only once; a source port may legally recur across a broadcast.
+  llvm::SmallVector<std::pair<int, int>, 8> reserved;
+  llvm::SmallDenseSet<int, 8> claimedDsts;
   for (ConnectOp connectOp : switchboxOp.getOps<ConnectOp>()) {
-    bool found = false;
-    for (size_t i = 0; i < sb.srcPorts.size(); i++) {
-      if (sb.srcPorts[i] != connectOp.sourcePort())
-        continue;
-      // A circuit-switched ConnectOp monopolizes its entire source port;
-      // mark all connectivity[i][*] INVALID so the pathfinder cannot route
-      // any packet flow through this source port.
-      for (size_t j = 0; j < sb.dstPorts.size(); j++) {
-        if (sb.dstPorts[j] == connectOp.destPort() &&
-            sb.connectivity[i][j] == Connectivity::AVAILABLE)
-          found = true;
-        sb.connectivity[i][j] = Connectivity::INVALID;
+    int srcIdx = -1, dstIdx = -1;
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      if (sb.srcPorts[i] == connectOp.sourcePort()) {
+        srcIdx = static_cast<int>(i);
+        break;
       }
-    }
-    if (!found) {
-      // ConnectOp references a (srcPort, dstPort) pair absent from or already
-      // fully invalidated in the switchbox model; IR/graph mismatch.
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      if (sb.dstPorts[j] == connectOp.destPort()) {
+        dstIdx = static_cast<int>(j);
+        break;
+      }
+    // Reject an illegal pair (absent from the switchbox model) or a second
+    // driver on the same output port; a repeated source port is a broadcast.
+    if (srcIdx < 0 || dstIdx < 0 ||
+        sb.connectivity[srcIdx][dstIdx] != Connectivity::AVAILABLE ||
+        !claimedDsts.insert(dstIdx).second)
       return false;
-    }
+    reserved.emplace_back(srcIdx, dstIdx);
   }
+  // A pre-placed packet-switched output (an aie.masterset) also monopolizes its
+  // destination port. That stream-switch output is already configured for
+  // packet switching, so no circuit stream may drive it, and the router cannot
+  // emit a second masterset on the same port for another packet flow. The
+  // circuit pathfinder does not read packet ops, so without this reservation it
+  // may route a flow onto an output the masterset owns and produce two ops
+  // driving one destination.
+  llvm::SmallVector<int, 8> reservedMasterDsts;
+  for (MasterSetOp masterSetOp : switchboxOp.getOps<MasterSetOp>()) {
+    int dstIdx = -1;
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      if (sb.dstPorts[j] == masterSetOp.destPort()) {
+        dstIdx = static_cast<int>(j);
+        break;
+      }
+    // Reject an output port absent from the switchbox model or already driven
+    // by a circuit connect or another masterset.
+    if (dstIdx < 0 || !claimedDsts.insert(dstIdx).second)
+      return false;
+    reservedMasterDsts.push_back(dstIdx);
+  }
+  // A circuit-switched ConnectOp monopolizes both its source port (the stream
+  // switch input) and its destination port (the output): no other stream may
+  // inject on that input, and the output can carry only this one stream.
+  // Reserving the whole column also reserves the outgoing wire, since that wire
+  // is reachable only by driving this output port.
+  for (auto [srcIdx, dstIdx] : reserved) {
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      sb.connectivity[srcIdx][j] = Connectivity::INVALID;
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      sb.connectivity[i][dstIdx] = Connectivity::INVALID;
+  }
+  // A masterset fixes only its output port. Its inputs arrive through arbiters
+  // that packet flows share, so the source rows stay free.
+  for (int dstIdx : reservedMasterDsts)
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      sb.connectivity[i][dstIdx] = Connectivity::INVALID;
   return true;
 }
 

--- a/lib/Dialect/AIE/Transforms/AIESplitFlowVias.cpp
+++ b/lib/Dialect/AIE/Transforms/AIESplitFlowVias.cpp
@@ -1,0 +1,337 @@
+//===- AIESplitFlowVias.cpp -------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
+
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallSet.h"
+
+namespace xilinx::AIE {
+#define GEN_PASS_DEF_AIESPLITFLOWVIAS
+#include "aie/Dialect/AIE/Transforms/AIEPasses.h.inc"
+} // namespace xilinx::AIE
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIE;
+
+namespace {
+
+// True when (srcTile, srcBundle:srcChannel) and (dstTile, dstBundle:dstChannel)
+// are the two ends of a single physical inter-switchbox wire. Such a segment is
+// realized by the wire itself and must not become a routable flow: doing so
+// would double-drive the port that the adjacent via's fixed connection already
+// produces.
+static bool isDirectWire(Value srcTile, WireBundle srcBundle, int srcChannel,
+                         Value dstTile, WireBundle dstBundle, int dstChannel) {
+  if (srcChannel != dstChannel)
+    return false;
+  auto src = srcTile.getDefiningOp<TileOp>();
+  auto dst = dstTile.getDefiningOp<TileOp>();
+  if (!src || !dst)
+    return false;
+  int sc = src.colIndex(), sr = src.rowIndex();
+  int dc = dst.colIndex(), dr = dst.rowIndex();
+  if (sc == dc) {
+    if (srcBundle == WireBundle::North && dstBundle == WireBundle::South &&
+        dr == sr + 1)
+      return true;
+    if (srcBundle == WireBundle::South && dstBundle == WireBundle::North &&
+        dr == sr - 1)
+      return true;
+  }
+  if (sr == dr) {
+    if (srcBundle == WireBundle::East && dstBundle == WireBundle::West &&
+        dc == sc + 1)
+      return true;
+    if (srcBundle == WireBundle::West && dstBundle == WireBundle::East &&
+        dc == sc - 1)
+      return true;
+  }
+  return false;
+}
+
+// Return the switchbox for `tile`, reusing an existing one or creating an empty
+// one immediately after the tile so its operand dominates the connections.
+static SwitchboxOp getOrCreateSwitchbox(OpBuilder &builder, Value tile,
+                                        DenseMap<Value, SwitchboxOp> &cache) {
+  if (auto it = cache.find(tile); it != cache.end())
+    return it->second;
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointAfterValue(tile);
+  auto switchboxOp = SwitchboxOp::create(builder, tile.getLoc(), tile);
+  SwitchboxOp::ensureTerminator(switchboxOp.getConnections(), builder,
+                                tile.getLoc());
+  cache[tile] = switchboxOp;
+  return switchboxOp;
+}
+
+// Return the shim-mux for `tile`, reusing an existing one or creating an empty
+// one immediately after the tile so its operand dominates the connections.
+static ShimMuxOp getOrCreateShimMux(OpBuilder &builder, Value tile,
+                                    DenseMap<Value, ShimMuxOp> &cache) {
+  if (auto it = cache.find(tile); it != cache.end())
+    return it->second;
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointAfterValue(tile);
+  auto shimMuxOp = ShimMuxOp::create(builder, tile.getLoc(), tile);
+  ShimMuxOp::ensureTerminator(shimMuxOp.getConnections(), builder,
+                              tile.getLoc());
+  cache[tile] = shimMuxOp;
+  return shimMuxOp;
+}
+
+// Allocate a fresh (arbiter, msel) amsel in `sb` that is not already used by
+// its configuration, creating the amsel at the top of the switchbox block so it
+// dominates the master sets and rules that reference it.
+static AMSelOp allocateAmsel(OpBuilder &builder, Location loc, SwitchboxOp sb) {
+  Block &block = sb.getConnections().front();
+  llvm::SmallSet<std::pair<int, int>, 24> used;
+  for (auto a : block.getOps<AMSelOp>())
+    used.insert({a.arbiterIndex(), a.getMselValue()});
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(&block);
+  for (int msel = 0; msel < 4; msel++)
+    for (int arb = 0; arb < 6; arb++)
+      if (!used.count({arb, msel}))
+        return AMSelOp::create(builder, loc, arb, msel);
+  return nullptr;
+}
+
+// Return the packet_rules for `ingress` in `sb`, creating an empty one if none
+// exists, so several rules for the same ingress port accumulate in one op.
+static PacketRulesOp getOrCreatePacketRules(OpBuilder &builder, Location loc,
+                                            SwitchboxOp sb, WireBundle ingress,
+                                            int ingressChannel) {
+  Block &block = sb.getConnections().front();
+  for (auto rules : block.getOps<PacketRulesOp>())
+    if (rules.getSourceBundle() == ingress &&
+        rules.getSourceChannel() == ingressChannel)
+      return rules;
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(block.getTerminator());
+  auto rules = PacketRulesOp::create(builder, loc, ingress, ingressChannel);
+  PacketRulesOp::ensureTerminator(rules.getRules(), builder, loc);
+  return rules;
+}
+
+// Emit the routable portion of a segment between two pinned ports, eliding the
+// parts the wires and vias already realize: a degenerate same-port segment, a
+// single inter-switchbox wire, or an intra-shim hop (realized through the
+// shim-mux, since the switchbox South:N port appears as mux North:N). Whatever
+// remains is a gap the router must fill and becomes a flow -- circuit when
+// `packetID` < 0, otherwise a packet_flow(packetID).
+static void emitRoutableSegment(OpBuilder &builder, Location loc,
+                                Operation *anchor, Value srcTile,
+                                WireBundle srcBundle, int srcChannel,
+                                Value dstTile, WireBundle dstBundle,
+                                int dstChannel, int packetID,
+                                DenseMap<Value, ShimMuxOp> &shimMuxes,
+                                mlir::IntegerAttr maskAttr = {}) {
+  if (srcTile == dstTile && srcBundle == dstBundle && srcChannel == dstChannel)
+    return;
+  if (isDirectWire(srcTile, srcBundle, srcChannel, dstTile, dstBundle,
+                   dstChannel))
+    return;
+  if (srcTile == dstTile) {
+    if (auto tileOp = srcTile.getDefiningOp<TileOp>();
+        tileOp && tileOp.isShimNOCorPLTile()) {
+      auto toMux = [](WireBundle b) {
+        return b == WireBundle::South ? WireBundle::North : b;
+      };
+      ShimMuxOp mux = getOrCreateShimMux(builder, srcTile, shimMuxes);
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(mux.getConnections().front().getTerminator());
+      ConnectOp::create(builder, loc, toMux(srcBundle), srcChannel,
+                        toMux(dstBundle), dstChannel);
+      return;
+    }
+  }
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(anchor);
+  if (packetID < 0) {
+    FlowOp::create(builder, loc, srcTile, srcBundle, srcChannel, dstTile,
+                   dstBundle, dstChannel);
+    return;
+  }
+  auto pf = PacketFlowOp::create(builder, loc, static_cast<uint8_t>(packetID),
+                                 BoolAttr(), BoolAttr());
+  // Preserve the flow's pinned packet-rule mask on the routed remainder;
+  // without it the pathfinder derives a full 0x1f mask that mismatches the
+  // pinned via segments' rules for the same flow and the packet is never
+  // accepted.
+  if (maskAttr)
+    pf.setMaskAttr(maskAttr);
+  PacketFlowOp::ensureTerminator(pf.getPorts(), builder, loc);
+  builder.setInsertionPoint(pf.getPorts().front().getTerminator());
+  PacketSourceOp::create(builder, loc, srcTile, srcBundle, srcChannel);
+  PacketDestOp::create(builder, loc, dstTile, dstBundle, dstChannel);
+}
+
+struct AIESplitFlowViasPass
+    : public xilinx::AIE::impl::AIESplitFlowViasBase<AIESplitFlowViasPass> {
+  void runOnOperation() override {
+    DeviceOp device = getOperation();
+    OpBuilder builder(device.getContext());
+
+    DenseMap<Value, SwitchboxOp> switchboxes;
+    for (auto switchboxOp : device.getOps<SwitchboxOp>())
+      switchboxes[switchboxOp.getTile()] = switchboxOp;
+    DenseMap<Value, ShimMuxOp> shimMuxes;
+    for (auto shimMuxOp : device.getOps<ShimMuxOp>())
+      shimMuxes[shimMuxOp.getTile()] = shimMuxOp;
+
+    SmallVector<FlowOp> flowsWithVias;
+    for (auto flow : device.getOps<FlowOp>())
+      if (!flow.getVias().empty())
+        flowsWithVias.push_back(flow);
+
+    for (FlowOp flow : flowsWithVias) {
+      ArrayRef<int32_t> ingressBundles =
+          flow.getViaIngressBundlesAttr().asArrayRef();
+      ArrayRef<int32_t> ingressChannels =
+          flow.getViaIngressChannelsAttr().asArrayRef();
+      ArrayRef<int32_t> egressBundles =
+          flow.getViaEgressBundlesAttr().asArrayRef();
+      ArrayRef<int32_t> egressChannels =
+          flow.getViaEgressChannelsAttr().asArrayRef();
+      Location loc = flow.getLoc();
+
+      // Running source of the next segment, starting at the flow's source.
+      Value srcTile = flow.getSource();
+      WireBundle srcBundle = flow.getSourceBundle();
+      int srcChannel = flow.getSourceChannel();
+
+      auto emitSegment = [&](Value dstTile, WireBundle dstBundle,
+                             int dstChannel) {
+        emitRoutableSegment(builder, loc, flow, srcTile, srcBundle, srcChannel,
+                            dstTile, dstBundle, dstChannel, /*packetID=*/-1,
+                            shimMuxes);
+      };
+
+      for (size_t i = 0, e = flow.getVias().size(); i < e; i++) {
+        Value viaTile = flow.getVias()[i];
+        auto ingressBundle = static_cast<WireBundle>(ingressBundles[i]);
+        int ingressChannel = ingressChannels[i];
+        auto egressBundle = static_cast<WireBundle>(egressBundles[i]);
+        int egressChannel = egressChannels[i];
+
+        emitSegment(viaTile, ingressBundle, ingressChannel);
+
+        SwitchboxOp switchboxOp =
+            getOrCreateSwitchbox(builder, viaTile, switchboxes);
+        {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(
+              switchboxOp.getConnections().front().getTerminator());
+          ConnectOp::create(builder, loc, ingressBundle, ingressChannel,
+                            egressBundle, egressChannel);
+        }
+
+        srcTile = viaTile;
+        srcBundle = egressBundle;
+        srcChannel = egressChannel;
+      }
+
+      emitSegment(flow.getDest(), flow.getDestBundle(), flow.getDestChannel());
+      flow.erase();
+    }
+
+    // Packet sections pin their route with vias too. Each via becomes a
+    // stream-switch rule/master-set pair carrying the flow's ID; the amsel is
+    // allocated locally (its numeric value is not pinned). Fan-out/fan-in nodes
+    // are already materialized in the IR, so a section only needs its own hops.
+    SmallVector<PacketFlowOp> pktFlowsWithVias;
+    for (auto pf : device.getOps<PacketFlowOp>())
+      if (!pf.getVias().empty())
+        pktFlowsWithVias.push_back(pf);
+
+    for (PacketFlowOp pf : pktFlowsWithVias) {
+      Location loc = pf.getLoc();
+      int id = pf.IDInt();
+      int mask = pf.getMask() ? static_cast<int>(*pf.getMask()) : 0x1f;
+      ArrayRef<int32_t> inB = pf.getViaIngressBundlesAttr().asArrayRef();
+      ArrayRef<int32_t> inC = pf.getViaIngressChannelsAttr().asArrayRef();
+      ArrayRef<int32_t> egB = pf.getViaEgressBundlesAttr().asArrayRef();
+      ArrayRef<int32_t> egC = pf.getViaEgressChannelsAttr().asArrayRef();
+
+      // A section has exactly one source and one dest; the gaps between the
+      // pinned vias (and before the first / after the last) are routed.
+      PacketSourceOp source;
+      PacketDestOp dest;
+      for (Operation &op : pf.getPorts().front()) {
+        if (auto s = dyn_cast<PacketSourceOp>(op))
+          source = s;
+        else if (auto d = dyn_cast<PacketDestOp>(op))
+          dest = d;
+      }
+      Value srcTile = source.getTile();
+      WireBundle srcBundle = source.getBundle();
+      int srcChannel = source.getChannel();
+      auto emitSegment = [&](Value dstTile, WireBundle dstBundle,
+                             int dstChannel) {
+        emitRoutableSegment(builder, loc, pf, srcTile, srcBundle, srcChannel,
+                            dstTile, dstBundle, dstChannel, id, shimMuxes,
+                            pf.getMaskAttr());
+      };
+
+      for (size_t i = 0, e = pf.getVias().size(); i < e; i++) {
+        Value viaTile = pf.getVias()[i];
+        auto ingress = static_cast<WireBundle>(inB[i]);
+        int ingressChannel = inC[i];
+        auto egress = static_cast<WireBundle>(egB[i]);
+        int egressChannel = egC[i];
+
+        emitSegment(viaTile, ingress, ingressChannel);
+
+        SwitchboxOp sb = getOrCreateSwitchbox(builder, viaTile, switchboxes);
+        AMSelOp amsel = allocateAmsel(builder, loc, sb);
+        if (!amsel) {
+          pf.emitOpError("via tile has no free arbiter-msel combination");
+          signalPassFailure();
+          return;
+        }
+        {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(
+              sb.getConnections().front().getTerminator());
+          // Restore keep_pkt_header on the master set that drives the flow's
+          // destination; the intermediate hops always keep the header.
+          BoolAttr keepPktHeader;
+          if (viaTile == dest.getTile() && egress == dest.getBundle() &&
+              egressChannel == dest.getChannel())
+            keepPktHeader = pf.getKeepPktHeaderAttr();
+          MasterSetOp::create(builder, loc, builder.getIndexType(), egress,
+                              egressChannel, ValueRange{amsel}, keepPktHeader);
+        }
+        PacketRulesOp rules =
+            getOrCreatePacketRules(builder, loc, sb, ingress, ingressChannel);
+        {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(rules.getRules().front().getTerminator());
+          PacketRuleOp::create(builder, loc, mask, id, amsel);
+        }
+
+        srcTile = viaTile;
+        srcBundle = egress;
+        srcChannel = egressChannel;
+      }
+
+      emitSegment(dest.getTile(), dest.getBundle(), dest.getChannel());
+      pf.erase();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<DeviceOp>> AIE::createAIESplitFlowViasPass() {
+  return std::make_unique<AIESplitFlowViasPass>();
+}

--- a/lib/Dialect/AIE/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIE/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_dialect_library(
   AIEAssignCoreLinkFiles.cpp
   AIEAssignLockIDs.cpp
   AIEFindFlows.cpp
+  AIESplitFlowVias.cpp
   AIEPathFinder.cpp
   AIECreatePathFindFlows.cpp
   AIECoreToStandard.cpp

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -718,7 +718,7 @@ class packetflow(PacketFlowOp):
         dests: Union[Dict, List[Dict]],
         keep_pkt_header: bool | None = None,
     ):
-        super().__init__(ID=pkt_id, keep_pkt_header=keep_pkt_header)
+        super().__init__(ID=pkt_id, keep_pkt_header=keep_pkt_header, vias=[])
         bb = Block.create_at_start(self.ports)
         with InsertionPoint(bb):
             PacketSourceOp(source, source_port, source_channel)
@@ -1028,7 +1028,13 @@ def flow(
     if dest_channel is None:
         dest_channel = 0
     return FlowOp(
-        source, source_bundle, source_channel, dest, dest_bundle, dest_channel
+        source,
+        source_bundle,
+        source_channel,
+        dest,
+        dest_bundle,
+        dest_channel,
+        vias=[],
     )
 
 

--- a/test/aiecc/checkpoint_resume_aiesim.mlir
+++ b/test/aiecc/checkpoint_resume_aiesim.mlir
@@ -10,33 +10,32 @@
 // The aiesim work-folder subgraph must round-trip through checkpoint/resume.
 // A straight-through `--get-aiesim` build (which assembles the whole `sim/`
 // folder from declarative graph edges) is compared against a build that is cut
-// at an aiesim IR edge (`sim/flows_physical.mlir`), snapshotted with
-// `--checkpoint`, and then completed with `--resume`. Resume reloads the routed
-// flows from the checkpoint and rebuilds everything downstream, so its `sim/`
-// descriptors must be byte-identical to the reference.
+// at the IR edge feeding that subgraph (`perDevice_{0}.mlir`), snapshotted with
+// `--checkpoint`, and then completed with `--resume`. Resume reloads the
+// per-device IR from the checkpoint and rebuilds every `sim/` descriptor, so
+// they must be byte-identical to the reference.
 
 // RUN: rm -rf %t && mkdir -p %t
 
 // Straight-through reference: assemble the whole sim/ folder in one go.
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge --tmpdir=%t/ref.prj %s
 
-// Cut at the routed-flows IR edge and snapshot it. With --cut the build stops
-// at the cut point, so only the prefix up to sim/flows_physical.mlir runs here.
-// RUN: %aiecc --get-aiesim --xchesscc --xbridge --tmpdir=%t/cut.prj --cut='sim/flows_physical.mlir' --checkpoint=%t/cut.ckpt %s
+// Cut at the per-device IR edge and snapshot it. With --cut the build stops at
+// the cut point, so only the prefix up to perDevice_{0}.mlir runs here.
+// RUN: %aiecc --get-aiesim --xchesscc --xbridge --tmpdir=%t/cut.prj --cut='perDevice_{0}.mlir' --checkpoint=%t/cut.ckpt %s
 
 // The captured frontier is textual MLIR, not a binary artifact.
-// RUN: cat %t/cut.ckpt/*/flows_physical.mlir | FileCheck --check-prefix=IR %s
+// RUN: cat %t/cut.ckpt/*/*.mlir | FileCheck --check-prefix=IR %s
 // IR: aie.device
 
-// Resume rebuilds the graph from the checkpoint's argv, reloads the flows IR,
-// and completes the sim/ folder in %t/cut.prj.
+// Resume rebuilds the graph from the checkpoint's argv, reloads the per-device
+// IR, and completes the sim/ folder in %t/cut.prj.
 // RUN: %aiecc --resume=%t/cut.ckpt/manifest.json
 
 // The resumed descriptors match the straight-through reference bit for bit.
 // RUN: cmp %t/ref.prj/sim/reports/graph.xpe %t/cut.prj/sim/reports/graph.xpe
 // RUN: cmp %t/ref.prj/sim/arch/aieshim_solution.aiesol %t/cut.prj/sim/arch/aieshim_solution.aiesol
 // RUN: cmp %t/ref.prj/sim/config/scsim_config.json %t/cut.prj/sim/config/scsim_config.json
-// RUN: cmp %t/ref.prj/sim/flows_physical.json %t/cut.prj/sim/flows_physical.json
 
 module @checkpoint_resume_aiesim {
   aie.device(xcvc1902) {

--- a/test/aiecc/cpp_aiesim.mlir
+++ b/test/aiecc/cpp_aiesim.mlir
@@ -24,7 +24,6 @@
 // CHECK-DAG: graph.xpe
 // CHECK-DAG: aieshim_solution.aiesol
 // CHECK-DAG: scsim_config.json
-// CHECK-DAG: flows_physical.json
 // CHECK-DAG: -D__AIESIM__
 // CHECK-DAG: genwrapper_for_ps.cpp
 // CHECK-DAG: {{.*}}ps.so

--- a/test/create-flows/broadcast.mlir
+++ b/test/create-flows/broadcast.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/find_flows_emit_vias.mlir
+++ b/test/create-flows/find_flows_emit_vias.mlir
@@ -1,0 +1,35 @@
+//===- find_flows_emit_vias.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// With emit-vias, --aie-find-flows recovers a routed design as grouped flows
+// that pin every switchbox hop and then drops the now-redundant switchboxes and
+// wires, so re-lowering with --aie-split-flow-vias needs no routing and cannot
+// collide with a leftover switchbox.  Route a flow, recover it with vias, split
+// it back, and re-route: the switchbox configuration is reproduced.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=emit-vias=true | FileCheck %s --check-prefix=VIAS --implicit-check-not=aie.switchbox
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=emit-vias=true | aie-opt --aie-split-flow-vias --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// The lifted flow carries the full route and no switchbox survives (the
+// --implicit-check-not above rejects any surviving aie.switchbox).
+// VIAS: %[[T02:.*]] = aie.tile(0, 2)
+// VIAS: %[[T03:.*]] = aie.tile(0, 3)
+// VIAS: aie.flow(%[[T02]], DMA : 0, %[[T03]], DMA : 0) via (%[[T02]] : DMA : 0 -> North : {{[0-9]+}}, %[[T03]] : South : {{[0-9]+}} -> DMA : 0)
+
+// ROUTED: %[[T02:.*]] = aie.tile(0, 2)
+// ROUTED: aie.switchbox(%[[T02]]) {
+// ROUTED:   aie.connect<DMA : 0, North : {{[0-9]+}}>
+// ROUTED: %[[T03:.*]] = aie.tile(0, 3)
+// ROUTED: aie.switchbox(%[[T03]]) {
+// ROUTED:   aie.connect<South : {{[0-9]+}}, DMA : 0>
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    aie.flow(%t02, DMA : 0, %t03, DMA : 0)
+  }
+}

--- a/test/create-flows/find_flows_fanout_packet.mlir
+++ b/test/create-flows/find_flows_fanout_packet.mlir
@@ -1,0 +1,51 @@
+//===- find_flows_fanout_packet.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A packet broadcast is pinned by keeping its fan-out node materialized (the
+// shared amsel driving two mastersets) and lifting the straight-line sections
+// around it as packet flows that carry vias. --aie-split-flow-vias rebuilds the
+// section switchbox rules, so create-pathfinder-flows reproduces the routing.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=emit-vias=true | FileCheck %s
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=emit-vias=true | aie-opt --aie-split-flow-vias | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUNDTRIP
+
+// The fan-out node stays materialized: one amsel feeding two mastersets.
+// CHECK: %[[P04:.*]] = aie.tile(0, 4)
+// CHECK: aie.switchbox(%[[P04]]) {
+// CHECK:   %[[AS:.*]] = aie.amsel<0> (0)
+// CHECK:   aie.masterset(DMA : 0, %[[AS]])
+// CHECK:   aie.masterset(North : {{[0-9]+}}, %[[AS]])
+// CHECK:   aie.packet_rules(South : {{[0-9]+}}) {
+// CHECK:     aie.rule(31, 1, %[[AS]])
+// CHECK:   }
+// CHECK: }
+// The sections into and out of the fan-out node are pinned packet flows.
+// CHECK: aie.packet_flow(1 mask 31) {
+// CHECK:   aie.packet_source<%{{.*}}, DMA : 0>
+// CHECK:   aie.packet_dest<%[[P04]], South : {{[0-9]+}}>
+// CHECK: } via (
+// CHECK: aie.packet_flow(1 mask 31) {
+// CHECK:   aie.packet_source<%[[P04]], North : {{[0-9]+}}>
+// CHECK:   aie.packet_dest<%{{.*}}, DMA : 0>
+// CHECK: } via (
+
+// After splitting the vias and re-routing, the broadcast is reproduced: one
+// amsel drives both the local DMA and the northbound continuation.
+// ROUNDTRIP: aie.masterset(DMA : 0, %[[R:.*]])
+// ROUNDTRIP: aie.masterset(North : {{[0-9]+}}, %[[R]])
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %t04 = aie.tile(0, 4)
+    %t05 = aie.tile(0, 5)
+    aie.packet_flow(0x1) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t04, DMA : 0>
+      aie.packet_dest<%t05, DMA : 0>
+    }
+  }
+}

--- a/test/create-flows/find_flows_fanout_vias.mlir
+++ b/test/create-flows/find_flows_fanout_vias.mlir
@@ -1,0 +1,37 @@
+//===- find_flows_fanout_vias.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// With emit-vias, --aie-find-flows splits a broadcast at its fan-out node into
+// linear sections: a trunk flow to the fan-out's input, the fan-out switchbox
+// left explicit, and a branch flow from each output.  The shared trunk is not
+// duplicated, so the result splits without colliding.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=emit-vias=true | FileCheck %s
+
+// Circuit broadcast: (0,2) -> {(0,4), (0,5)}, fanning out at (0,4).
+// CHECK: %[[T02:.*]] = aie.tile(0, 2)
+// CHECK: %[[T04:.*]] = aie.tile(0, 4)
+// CHECK: %[[T05:.*]] = aie.tile(0, 5)
+// CHECK: %[[T03:.*]] = aie.tile(0, 3)
+// The fan-out node stays explicit (one input driving two outputs).
+// CHECK: aie.switchbox(%[[T04]]) {
+// CHECK:   aie.connect<South : [[IN:[0-9]+]], DMA : 0>
+// CHECK:   aie.connect<South : [[IN]], North : [[OUT:[0-9]+]]>
+// CHECK: }
+// Trunk ends at the fan-out input; branch starts at the fan-out output.
+// CHECK: aie.flow(%[[T02]], DMA : 0, %[[T04]], South : [[IN]]) via (%[[T02]] : DMA : 0 -> North : {{[0-9]+}}, %[[T03]] : South : {{[0-9]+}} -> North : {{[0-9]+}})
+// CHECK: aie.flow(%[[T04]], North : [[OUT]], %[[T05]], DMA : 0) via (%[[T05]] : South : {{[0-9]+}} -> DMA : 0)
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %t04 = aie.tile(0, 4)
+    %t05 = aie.tile(0, 5)
+    aie.flow(%t02, DMA : 0, %t04, DMA : 0)
+    aie.flow(%t02, DMA : 0, %t05, DMA : 0)
+  }
+}
+

--- a/test/create-flows/find_flows_packet_mask.mlir
+++ b/test/create-flows/find_flows_packet_mask.mlir
@@ -1,0 +1,45 @@
+//===- find_flows_packet_mask.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A packet rule states a (mask, id) pair, and a lifted flow carries that pair.
+//
+// The rules a routed design holds are the only record of which ids reach a
+// port, because a core may build a packet header at run time. Recovering the
+// id alone would narrow the first flow from 0x8..0xb down to 0x8, so routing
+// the recovered design would drop the other three ids.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | FileCheck %s --check-prefix=LIFTED
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// The first flow states the rule it came from. The second matches one id, and
+// an id states that on its own, so it carries no mask.
+// LIFTED-DAG: aie.packet_flow(8 mask 28)
+// LIFTED-DAG: aie.packet_flow(0)
+
+// Routing the recovered design rebuilds the same two rules.
+// ROUTED: aie.switchbox(%{{.*}}tile_0_2)
+// ROUTED:   aie.packet_rules(DMA : 0)
+// ROUTED-DAG:     aie.rule(28, 8, %{{.*}})
+// ROUTED-DAG:     aie.rule(31, 0, %{{.*}})
+
+module {
+  aie.device(npu1_1col) {
+    %t00 = aie.tile(0, 0)
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+
+    aie.packet_flow(8 mask 28) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t00, DMA : 0>
+    }
+
+    aie.packet_flow(0) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+  }
+}

--- a/test/create-flows/find_flows_packet_merge.mlir
+++ b/test/create-flows/find_flows_packet_merge.mlir
@@ -1,0 +1,52 @@
+//===- find_flows_packet_merge.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Routing gives one rule to several ids that travel together, and narrow rules
+// where they part. Ids 9 and 10 share a route up column 0 and separate at
+// tile(0,4), so the switchboxes below it carry the enclosing cube of the pair,
+// (mask 0x1c, id 0x8).
+//
+// A recovered flow matching one id must therefore carry no mask: stating the
+// full-width mask would make each flow claim its own rule, and the shared
+// switchboxes would need two rules where routing used one.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | FileCheck %s --check-prefix=LIFTED
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// LIFTED-DAG: aie.packet_flow(9)
+// LIFTED-DAG: aie.packet_flow(10)
+// LIFTED-NOT: mask
+
+// The rules come back as routing first wrote them: merged below the split,
+// narrow above it.
+// ROUTED: aie.switchbox(%{{.*}}tile_0_2)
+// ROUTED:   aie.rule(28, 8, %{{.*}})
+// ROUTED: aie.switchbox(%{{.*}}tile_0_4)
+// ROUTED-DAG:   aie.rule(31, 9, %{{.*}})
+// ROUTED-DAG:   aie.rule(31, 10, %{{.*}})
+// ROUTED: aie.switchbox(%{{.*}}tile_0_5)
+// ROUTED:   aie.rule(31, 10, %{{.*}})
+// ROUTED: aie.switchbox(%{{.*}}tile_0_3)
+// ROUTED:   aie.rule(28, 8, %{{.*}})
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    %t04 = aie.tile(0, 4)
+    %t05 = aie.tile(0, 5)
+
+    aie.packet_flow(9) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t04, DMA : 0>
+    }
+
+    aie.packet_flow(10) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t05, DMA : 0>
+    }
+  }
+}

--- a/test/create-flows/find_flows_remove_lifted.mlir
+++ b/test/create-flows/find_flows_remove_lifted.mlir
@@ -1,0 +1,37 @@
+//===- find_flows_remove_lifted.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// By default --aie-find-flows removes the interconnect configuration it lifts
+// into flows, so its output is a purely logical, re-routable design.  With
+// remove-lifted=false the switchboxes are kept alongside the recovered flows.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | FileCheck %s --check-prefix=LIFTED --implicit-check-not=aie.switchbox
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=remove-lifted=false | FileCheck %s --check-prefix=KEPT
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// Lifted: the flow is recovered and every switchbox/wire is gone.
+// LIFTED: %[[T02:.*]] = aie.tile(0, 2)
+// LIFTED: %[[T03:.*]] = aie.tile(0, 3)
+// LIFTED: aie.flow(%[[T02]], DMA : 0, %[[T03]], DMA : 0)
+
+// Kept: switchboxes remain when removal is disabled.
+// KEPT: aie.switchbox
+
+// Round-trippable: re-routing the lifted flow reproduces the switchbox config.
+// ROUTED: %[[R02:.*]] = aie.tile(0, 2)
+// ROUTED: %[[R03:.*]] = aie.tile(0, 3)
+// ROUTED: aie.switchbox(%[[R02]]) {
+// ROUTED:   aie.connect<DMA : 0, North : {{[0-9]+}}>
+// ROUTED: aie.switchbox(%[[R03]]) {
+// ROUTED:   aie.connect<South : {{[0-9]+}}, DMA : 0>
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    aie.flow(%t02, DMA : 0, %t03, DMA : 0)
+  }
+}

--- a/test/create-flows/find_flows_shim_mux_vestigial.mlir
+++ b/test/create-flows/find_flows_shim_mux_vestigial.mlir
@@ -1,0 +1,72 @@
+//===- find_flows_shim_mux_vestigial.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A shim-mux connection is not a switchbox transit, so it cannot be pinned by a
+// via. A shim-mux connection whose stream never enters a switchbox (a dead
+// input mux like DMA:1 -> North:7 here) therefore has nothing to lift into; it
+// must be left materialized rather than turned into a via-less flow that
+// --aie-create-pathfinder-flows could not route. The live shim-mux connection
+// feeding the packet route (DMA:0 -> North:3) is instead reconstructed by
+// --aie-split-flow-vias, so the whole design still round-trips.
+
+// RUN: aie-opt --aie-find-flows=emit-vias=true %s | FileCheck %s
+// RUN: aie-opt --aie-find-flows=emit-vias=true %s | aie-opt --aie-split-flow-vias | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUNDTRIP
+
+// The dead input mux stays materialized, and nothing lifts it into a flow.
+// CHECK: aie.shim_mux(%{{.*}}) {
+// CHECK:   aie.connect<DMA : 1, North : 7>
+// CHECK: }
+// CHECK-NOT: aie.flow(
+// The live packet route lifts with its via chain.
+// CHECK: aie.packet_flow(0 mask 31) {
+// CHECK:   aie.packet_source<%{{.*}}, DMA : 0>
+// CHECK:   aie.packet_dest<%{{.*}}, DMA : 0>
+// CHECK: } via (
+
+// Re-lowering keeps the dead mux and regenerates the live one, and routes.
+// ROUNDTRIP: aie.shim_mux(%{{.*}}) {
+// ROUNDTRIP-DAG: aie.connect<DMA : 1, North : 7>
+// ROUNDTRIP-DAG: aie.connect<DMA : 0, North : 3>
+// ROUNDTRIP: }
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    %shim_mux_0_0 = aie.shim_mux(%shim_noc_tile_0_0) {
+      aie.connect<DMA : 0, North : 3>
+      aie.connect<DMA : 1, North : 7>
+    }
+    %switchbox_0_0 = aie.switchbox(%shim_noc_tile_0_0) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(North : 1, %0)
+      aie.packet_rules(South : 3) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %mem_tile_0_1 = aie.tile(0, 1)
+    %switchbox_0_1 = aie.switchbox(%mem_tile_0_1) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(North : 1, %0)
+      aie.packet_rules(South : 1) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_2 = aie.tile(0, 2)
+    %switchbox_0_2 = aie.switchbox(%tile_0_2) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(DMA : 0, %0)
+      aie.packet_rules(South : 1) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    aie.wire(%shim_noc_tile_0_0 : DMA, %shim_mux_0_0 : DMA)
+    aie.wire(%shim_mux_0_0 : North, %switchbox_0_0 : South)
+    aie.wire(%switchbox_0_0 : North, %switchbox_0_1 : South)
+    aie.wire(%switchbox_0_1 : North, %switchbox_0_2 : South)
+    aie.wire(%tile_0_2 : DMA, %switchbox_0_2 : DMA)
+  }
+}

--- a/test/create-flows/find_flows_split_at_attr.mlir
+++ b/test/create-flows/find_flows_split_at_attr.mlir
@@ -1,0 +1,80 @@
+//===- find_flows_split_at_attr.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A lifted flow is rebuilt from its via chain plus the attributes carried on the
+// flow, so an attribute it cannot reconstruct -- here keep_pkt_header on an
+// intermediate master set -- would otherwise be dropped. Instead the flow is
+// split at that switchbox: the attributed switchbox (0, 3) stays materialized
+// verbatim while the sections before and after it lift, so the round-trip
+// preserves the attribute rather than silently dropping it.
+
+// RUN: aie-opt --aie-find-flows=emit-vias=true %s | FileCheck %s
+// RUN: aie-opt --aie-find-flows=emit-vias=true %s | aie-opt --aie-split-flow-vias | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUNDTRIP
+
+// The attributed hop stays materialized verbatim.
+// CHECK: %[[T03:.*]] = aie.tile(0, 3)
+// CHECK: aie.switchbox(%[[T03]]) {
+// CHECK:   aie.masterset(North : 0, %{{.*}}) {keep_pkt_header = true}
+// CHECK:   aie.packet_rules(South : 3) {
+// CHECK:     aie.rule(31, 0, %{{.*}})
+// CHECK:   }
+// CHECK: }
+// The flow lifts on both sides of the attributed switchbox.
+// CHECK: aie.packet_flow(0 mask 31) {
+// CHECK:   aie.packet_source<%{{.*}}, DMA : 0>
+// CHECK:   aie.packet_dest<%[[T03]], South : 3>
+// CHECK: } via (
+// CHECK: aie.packet_flow(0 mask 31) {
+// CHECK:   aie.packet_source<%[[T03]], North : 0>
+// CHECK:   aie.packet_dest<%{{.*}}, DMA : 0>
+// CHECK: } via (
+
+// After splitting the vias and re-routing, keep_pkt_header still rides on the
+// intermediate master set.
+// ROUNDTRIP: aie.masterset(North : 0, %{{.*}}) {keep_pkt_header = true}
+
+module {
+  aie.device(npu2) {
+    %tile_0_2 = aie.tile(0, 2)
+    %switchbox_0_2 = aie.switchbox(%tile_0_2) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(North : 3, %0)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_3 = aie.tile(0, 3)
+    %switchbox_0_3 = aie.switchbox(%tile_0_3) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(North : 0, %0) {keep_pkt_header = true}
+      aie.packet_rules(South : 3) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_4 = aie.tile(0, 4)
+    %switchbox_0_4 = aie.switchbox(%tile_0_4) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(North : 4, %0)
+      aie.packet_rules(South : 0) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_5 = aie.tile(0, 5)
+    %switchbox_0_5 = aie.switchbox(%tile_0_5) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(DMA : 0, %0)
+      aie.packet_rules(South : 4) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    aie.wire(%tile_0_2 : DMA, %switchbox_0_2 : DMA)
+    aie.wire(%switchbox_0_2 : North, %switchbox_0_3 : South)
+    aie.wire(%switchbox_0_3 : North, %switchbox_0_4 : South)
+    aie.wire(%switchbox_0_4 : North, %switchbox_0_5 : South)
+    aie.wire(%tile_0_5 : DMA, %switchbox_0_5 : DMA)
+  }
+}

--- a/test/create-flows/find_partial_flows.mlir
+++ b/test/create-flows/find_partial_flows.mlir
@@ -1,0 +1,80 @@
+//===- find_partial_flows.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// --aie-find-flows lifts every configured connection into a flow, including
+// partial flows whose source or destination is a directional switchbox port
+// rather than a core or DMA (array edges, off-fabric consumers, PLIO/edge
+// entries, or packet routes a running design steers by packet id).  With
+// keep-partial-flows=false only flows that begin and end on a core/DMA are
+// recovered.
+
+// RUN: aie-opt --aie-find-flows --split-input-file %s | FileCheck %s
+// RUN: aie-opt --aie-find-flows=keep-partial-flows=false --split-input-file %s | FileCheck %s --check-prefix=NONE
+
+// A circuit-switched connection driven out an edge port (North:0 has no wire).
+// NONE-NOT: aie.flow
+// CHECK-LABEL: aie.device
+// CHECK: %[[T02:.*]] = aie.tile(0, 2)
+// CHECK: aie.flow(%[[T02]], DMA : 0, %[[T02]], North : 0)
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %sb02 = aie.switchbox(%t02) {
+      aie.connect<DMA : 0, North : 0>
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+  }
+}
+
+// -----
+
+// Time-multiplexed packet routing: one source fans out to different edge ports
+// by packet id.  Each id recovers a partial packet flow to its output port.
+// NONE-NOT: aie.packet_flow
+// CHECK-LABEL: aie.device
+// CHECK: %[[T12:.*]] = aie.tile(0, 2)
+// CHECK: aie.packet_flow(0)
+// CHECK:   aie.packet_source<%[[T12]], DMA : 0>
+// CHECK:   aie.packet_dest<%[[T12]], North : 0>
+// CHECK: aie.packet_flow(1)
+// CHECK:   aie.packet_source<%[[T12]], DMA : 0>
+// CHECK:   aie.packet_dest<%[[T12]], East : 0>
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %sb02 = aie.switchbox(%t02) {
+      %a0 = aie.amsel<0> (0)
+      %a1 = aie.amsel<0> (1)
+      aie.masterset(North : 0, %a0)
+      aie.masterset(East : 0, %a1)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %a0)
+        aie.rule(31, 1, %a1)
+      }
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+  }
+}
+
+// -----
+
+// Pure transit: a switchbox forwards West:0 -> East:0 with neither endpoint on
+// a core or DMA.  The source side seeds from the (undriven) West:0 input and
+// the destination side from the (unwired) East:0 output, lifting the whole
+// segment into one partial flow so the switchbox can be dropped.
+// NONE-NOT: aie.flow
+// CHECK-LABEL: aie.device
+// CHECK: %[[T22:.*]] = aie.tile(2, 2)
+// CHECK: aie.flow(%[[T22]], West : 0, %[[T22]], East : 0)
+module {
+  aie.device(xcvc1902) {
+    %t22 = aie.tile(2, 2)
+    %sb22 = aie.switchbox(%t22) {
+      aie.connect<West : 0, East : 0>
+    }
+  }
+}

--- a/test/create-flows/fixed_connection_broadcast.mlir
+++ b/test/create-flows/fixed_connection_broadcast.mlir
@@ -1,0 +1,54 @@
+//===- fixed_connection_broadcast.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test for ingesting a pre-lowered broadcast switchbox alongside a
+// freshly added flow.  addFixedConnection() must accept a broadcast -- one
+// source port fanning out to several destination ports -- rather than rejecting
+// the sibling connects.
+//
+// Setup
+// -----
+//   tile(2,2) already contains a lowered broadcast: source North:0 drives both
+//   South:0 and East:0.  (This is what --aie-create-pathfinder-flows emits for
+//   several aie.flows sharing one source.)
+//
+//   An independent flow tile(2,3) DMA:0 -> tile(2,1) DMA:1 is added at the
+//   physical level, without lifting the switchbox back to flows.
+//
+// Before the fix addFixedConnection() invalidated the whole North:0 source row
+// when it recorded the first fan-out connect, so the second (North:0 -> East:0)
+// failed its AVAILABLE check and the pass aborted with
+// "Unable to add fixed connections".  The broadcast is now ingested and the new
+// flow routes around the reserved ports.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// CHECK: %[[T22:.*]] = aie.tile(2, 2)
+
+// The broadcast is preserved intact: both fan-out connects survive.
+// CHECK:      aie.switchbox(%[[T22]]) {
+// CHECK-DAG:    aie.connect<North : 0, South : 0>
+// CHECK-DAG:    aie.connect<North : 0, East : 0>
+// CHECK:      }
+
+module {
+  aie.device(xcvc1902) {
+    %t21 = aie.tile(2, 1)
+    %t22 = aie.tile(2, 2)
+    %t23 = aie.tile(2, 3)
+    %t32 = aie.tile(3, 2)
+
+    // Pre-lowered broadcast at tile(2,2): North:0 -> {South:0, East:0}.
+    %sb22 = aie.switchbox(%t22) {
+      aie.connect<North : 0, South : 0>
+      aie.connect<North : 0, East : 0>
+    }
+
+    // New flow added alongside the fixed broadcast switchbox.
+    aie.flow(%t23, DMA : 0, %t21, DMA : 1)
+  }
+}

--- a/test/create-flows/fixed_connection_egress_conflict.mlir
+++ b/test/create-flows/fixed_connection_egress_conflict.mlir
@@ -1,0 +1,57 @@
+//===- fixed_connection_egress_conflict.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test for the egress side of addFixedConnection(): a circuit
+// ConnectOp monopolizes its destination (output) port, not just its source
+// port.  addFixedConnection() must mark all connectivity[*][dst] cells INVALID
+// so the pathfinder cannot drive a second stream onto an occupied output.
+//
+// Setup
+// -----
+//   tile(2,2) has a pre-existing circuit connection: North:1 -> South:0.
+//   This occupies output port South:0 (and the wire to tile(2,1)).
+//
+//   A flow is requested from tile(2,3) DMA:0 to tile(2,1) DMA:0.  The
+//   straight-line path goes down column 2 through tile(2,2), entering from the
+//   North and exiting to the South.
+//
+// Without the egress reservation the pathfinder is free to route the flow
+// through tile(2,2) as North:0 -> South:0, colliding with the pre-existing
+// ConnectOp on output South:0; the verifier then rejects the switchbox
+// ("different destinations") and aie-opt exits non-zero.
+//
+// With the egress reservation output South:0 is unavailable, so the flow exits
+// tile(2,2) on a different south channel and the pre-existing connect is
+// preserved untouched.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// CHECK: %[[T22:.*]] = aie.tile(2, 2)
+
+// tile(2,2) keeps its original output connection and gains no second connect
+// driving South:0.
+// CHECK:      aie.switchbox(%[[T22]]) {
+// CHECK:        aie.connect<North : 1, South : 0>
+// CHECK-NOT:    South : 0>
+// CHECK:      }
+
+module {
+  aie.device(xcvc1902) {
+    %tile_2_1 = aie.tile(2, 1)
+    %tile_2_2 = aie.tile(2, 2)
+    %tile_2_3 = aie.tile(2, 3)
+
+    // Fixed circuit connection at tile(2,2): occupies output port South:0.
+    %switchbox_2_2 = aie.switchbox(%tile_2_2) {
+      aie.connect<North : 1, South : 0>
+    }
+
+    // Straight-line flow down column 2 through tile(2,2).  Must not reuse the
+    // occupied South:0 output port.
+    aie.flow(%tile_2_3, DMA : 0, %tile_2_1, DMA : 0)
+  }
+}

--- a/test/create-flows/flow_test_1.mlir
+++ b/test/create-flows/flow_test_1.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/flow_test_2.mlir
+++ b/test/create-flows/flow_test_2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/flow_test_3.mlir
+++ b/test/create-flows/flow_test_3.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/flow_vias.mlir
+++ b/test/create-flows/flow_vias.mlir
@@ -1,0 +1,36 @@
+//===- flow_vias.mlir -------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A flow's `via` list pins the tiles and stream-switch ports it routes through.
+
+// RUN: aie-opt %s | aie-opt | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: aie-opt --aie-split-flow-vias %s | FileCheck %s
+
+// ROUNDTRIP: %[[T02:.*]] = aie.tile(0, 2)
+// ROUNDTRIP: %[[T03:.*]] = aie.tile(0, 3)
+// ROUNDTRIP: aie.flow(%[[T02]], DMA : 0, %[[T03]], DMA : 0) via (%[[T02]] : DMA : 0 -> North : 4, %[[T03]] : South : 4 -> DMA : 0)
+
+// --aie-split-flow-vias rewrites the via flow into a pinned switchbox at each
+// via tile.  The head/tail segments coincide with the flow's own source/dest
+// port and the hop between the two via tiles is a single inter-switchbox wire,
+// so every segment is elided and only the pinned connections remain.
+// CHECK: %[[T02:.*]] = aie.tile(0, 2)
+// CHECK: aie.switchbox(%[[T02]]) {
+// CHECK:   aie.connect<DMA : 0, North : 4>
+// CHECK: }
+// CHECK: %[[T03:.*]] = aie.tile(0, 3)
+// CHECK: aie.switchbox(%[[T03]]) {
+// CHECK:   aie.connect<South : 4, DMA : 0>
+// CHECK: }
+// CHECK-NOT: aie.flow
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    aie.flow(%t02, DMA : 0, %t03, DMA : 0) via (%t02 : DMA : 0 -> North : 4, %t03 : South : 4 -> DMA : 0)
+  }
+}

--- a/test/create-flows/many_flows.mlir
+++ b/test/create-flows/many_flows.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/many_flows2.mlir
+++ b/test/create-flows/many_flows2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/memtile.mlir
+++ b/test/create-flows/memtile.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/memtile_routing_constraints.mlir
+++ b/test/create-flows/memtile_routing_constraints.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/mmult.mlir
+++ b/test/create-flows/mmult.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/over_flows.mlir
+++ b/test/create-flows/over_flows.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/routed_herd_3x1.mlir
+++ b/test/create-flows/routed_herd_3x1.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/routed_herd_3x2.mlir
+++ b/test/create-flows/routed_herd_3x2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple.mlir
+++ b/test/create-flows/simple.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple2.mlir
+++ b/test/create-flows/simple2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple_flows.mlir
+++ b/test/create-flows/simple_flows.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple_flows2.mlir
+++ b/test/create-flows/simple_flows2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/vecmul_4x4_slow_test.mlir
+++ b/test/create-flows/vecmul_4x4_slow_test.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-packet-flows/aie2_memtile_connection.mlir
+++ b/test/create-packet-flows/aie2_memtile_connection.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-packet-flows/packet_flow_mask.mlir
+++ b/test/create-packet-flows/packet_flow_mask.mlir
@@ -1,0 +1,48 @@
+//===- packet_flow_mask.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A packet flow states the rule it wants with `mask`, and routing keeps that
+// rule instead of deriving one from the ids.
+//
+// A core may build a packet header at run time, so a design can send ids that
+// appear nowhere in the IR. Here one flow claims 0x8 through 0xb by masking off
+// the low two bits, and routing must leave that claim to it: the rules the
+// other two flows get may not match any id in that range.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// The stated rule reaches the slave port unchanged.
+// CHECK: aie.switchbox(%{{.*}}tile_0_2)
+// CHECK:   aie.packet_rules(DMA : 0)
+// CHECK-DAG:     aie.rule(28, 8, %{{.*}})
+// The derived rules match one id each, so none of them reaches into 0x8..0xb.
+// CHECK-DAG:     aie.rule(31, 0, %{{.*}})
+// CHECK-DAG:     aie.rule(31, 15, %{{.*}})
+
+module {
+  aie.device(npu1_1col) {
+    %t00 = aie.tile(0, 0)
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+
+    // Claims every id that agrees with 0x8 on the bits 0x1c selects.
+    aie.packet_flow(8 mask 28) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t00, DMA : 0>
+    }
+
+    aie.packet_flow(0) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+
+    aie.packet_flow(15) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+  }
+}

--- a/test/create-packet-flows/packet_flow_mask_conflict.mlir
+++ b/test/create-packet-flows/packet_flow_mask_conflict.mlir
@@ -1,0 +1,35 @@
+//===- packet_flow_mask_conflict.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Two claims on one slave port that share an id.
+//
+// The first flow claims 0x8 through 0xb. The second carries 0x9, which sits
+// inside that range, so the port would need two routes for one id. Routing
+// reports the pair rather than handing the id to whichever rule the arbiter
+// checks first.
+
+// RUN: not aie-opt --aie-create-pathfinder-flows %s 2>&1 | FileCheck %s
+
+// CHECK: error: packet flows through DMA0 claim rule (mask 0x1F, id 0x9) and rule (mask 0x1C, id 0x8), which both match id 0x9
+
+module {
+  aie.device(npu1_1col) {
+    %t00 = aie.tile(0, 0)
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+
+    aie.packet_flow(8 mask 28) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t00, DMA : 0>
+    }
+
+    aie.packet_flow(9) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+  }
+}

--- a/test/create-packet-flows/packet_routing_keep_pkt_header.mlir
+++ b/test/create-packet-flows/packet_routing_keep_pkt_header.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
@@ -14,13 +14,16 @@
 // CHECK1:    %[[VAL_2:.*]] = aie.tile(0, 3)
 // CHECK1:    %[[VAL_3:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[VAL_4:.*]] = aie.tile(0, 5)
-// CHECK1:    aie.packet_flow(0) {
-// CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
-// CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 0>
-// CHECK1:    }
+// The pathfinder now removes the lowered packet flows; --aie-find-flows
+// re-derives them from the switchbox routing, emitting the two fan-out
+// destinations of tile(0,2) DMA:0 in discovery order (flow 4 before flow 0).
 // CHECK1:    aie.packet_flow(4) {
 // CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 4>
+// CHECK1:    }
+// CHECK1:    aie.packet_flow(0) {
+// CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
+// CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 0>
 // CHECK1:    }
 // CHECK1:    aie.packet_flow(1) {
 // CHECK1:      aie.packet_source<%[[VAL_2:.*]], DMA : 0>

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
@@ -14,11 +14,9 @@
 // CHECK1:    %[[VAL_2:.*]] = aie.tile(0, 3)
 // CHECK1:    %[[VAL_3:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[VAL_4:.*]] = aie.tile(0, 5)
-// The flows below are the ones --aie-find-flows recovers from the routing, in
-// the order it walks the tiles and their packet rules; the flows this file
-// declares up front are replaced by them rather than kept alongside. Both
-// flows out of tile (0, 2) share a source port, so their relative order comes
-// from the routed switchbox rather than from this file.
+// The pathfinder now removes the lowered packet flows; --aie-find-flows
+// re-derives them from the switchbox routing, emitting the two fan-out
+// destinations of tile(0,2) DMA:0 in discovery order (flow 4 before flow 0).
 // CHECK1:    aie.packet_flow(4) {
 // CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 4>

--- a/test/create-packet-flows/test_congestion1.mlir
+++ b/test/create-packet-flows/test_congestion1.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
@@ -16,15 +16,17 @@
 // CHECK1:    %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK1:    %[[TILE_1_0:.*]] = aie.tile(1, 0)
-// CHECK1:    aie.packet_flow(0) {
-// CHECK1:      aie.packet_source<%[[TILE_0_5]], DMA : 1>
-// CHECK1:      aie.packet_dest<%[[TILE_0_1]], DMA : 4>
-// CHECK1:    }
+// The pathfinder now removes the lowered flows; --aie-find-flows re-derives
+// them from the switchbox routing, emitting circuit flows before packet flows.
 // CHECK1:    aie.flow(%[[TILE_0_1]], DMA : 0, %[[TILE_0_0]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_2]], DMA : 0, %[[TILE_0_1]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_3]], DMA : 0, %[[TILE_0_1]], DMA : 1)
 // CHECK1:    aie.flow(%[[TILE_0_4]], DMA : 0, %[[TILE_0_1]], DMA : 2)
 // CHECK1:    aie.flow(%[[TILE_0_5]], DMA : 0, %[[TILE_0_1]], DMA : 3)
+// CHECK1:    aie.packet_flow(0) {
+// CHECK1:      aie.packet_source<%[[TILE_0_5]], DMA : 1>
+// CHECK1:      aie.packet_dest<%[[TILE_0_1]], DMA : 4>
+// CHECK1:    }
 
 // CHECK2: "total_path_length": 19
 

--- a/test/create-packet-flows/test_congestion1.mlir
+++ b/test/create-packet-flows/test_congestion1.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
@@ -16,9 +16,8 @@
 // CHECK1:    %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK1:    %[[TILE_1_0:.*]] = aie.tile(1, 0)
-// The flows below are the ones --aie-find-flows recovers from the routing, in
-// the order it walks the tiles; the flows this file declares up front are
-// replaced by them rather than kept alongside.
+// The pathfinder now removes the lowered flows; --aie-find-flows re-derives
+// them from the switchbox routing, emitting circuit flows before packet flows.
 // CHECK1:    aie.flow(%[[TILE_0_1]], DMA : 0, %[[TILE_0_0]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_2]], DMA : 0, %[[TILE_0_1]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_3]], DMA : 0, %[[TILE_0_1]], DMA : 1)

--- a/test/create-packet-flows/test_create_packet_flows7.mlir
+++ b/test/create-packet-flows/test_create_packet_flows7.mlir
@@ -28,10 +28,9 @@
 // CHECK:            aie.rule(31, 1, %[[VAL1]])
 // CHECK:          }
 // CHECK:        }
-// CHECK:        aie.packet_flow(1) {
-// CHECK:          aie.packet_source<%[[TILE_1_2]], Trace : 0>
-// CHECK:          aie.packet_dest<%[[TILE_0_0]], DMA : 1>
-// CHECK:        } {keep_pkt_header = true}
+// The pathfinder removes the packet_flow op once it has been lowered into
+// switchbox masterset/packet_rules, so it must not reappear in the output.
+// CHECK-NOT:     aie.packet_flow
 // CHECK:        %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:        %{{.*}} = aie.switchbox(%[[TILE_1_0]]) {
 // CHECK:          %[[VAL2:.*]] = aie.amsel<0> (0)

--- a/test/dialect/AIE/duplicate_flow.mlir
+++ b/test/dialect/AIE/duplicate_flow.mlir
@@ -58,7 +58,7 @@ module @flow_dup_logical {
 // -----
 
 // The same packet flow declared twice, as reported in issue #3706.
-// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 0 is already declared between the same sources and destinations
+// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 0 under mask 0x1F is already declared between the same sources and destinations
 // CHECK: note:{{.*}}the other packet flow is here
 module @packet_flow_dup {
   aie.device(npu2) {
@@ -81,7 +81,7 @@ module @packet_flow_dup {
 // same endpoints in a different order is still the same flow. Disagreeing
 // keep_pkt_header attributes make the redeclaration contradictory, not merely
 // redundant, so the attributes are deliberately not part of the key.
-// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 3 is already declared between the same sources and destinations
+// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 3 under mask 0x1F is already declared between the same sources and destinations
 module @packet_flow_dup_reordered {
   aie.device(npu2) {
     %shim = aie.tile(2, 0)
@@ -158,6 +158,27 @@ module @packet_flow_no_false_positives {
     aie.packet_flow(0) {
       aie.packet_source<%u0, DMA : 0>
       aie.packet_dest<%u1, DMA : 0>
+    }
+  }
+}
+
+// -----
+
+// Two flows carrying one ID between one pair of endpoints under different
+// masks claim different sets of packets, so neither duplicates the other.
+// The first claims 0x0 through 0x3, the second 0x0 alone.
+// CHECK-LABEL: @packet_flow_distinct_masks
+module @packet_flow_distinct_masks {
+  aie.device(npu2) {
+    %shim = aie.tile(2, 0)
+    %core = aie.tile(2, 2)
+    aie.packet_flow(0 mask 28) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
+    }
+    aie.packet_flow(0) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
     }
   }
 }

--- a/test/dialect/AIE/packet_flow_mask_bad_id.mlir
+++ b/test/dialect/AIE/packet_flow_mask_bad_id.mlir
@@ -1,0 +1,23 @@
+//===- packet_flow_mask_bad_id.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A slave port accepts a packet when `incoming & mask == ID`. ID 0x3 sets a bit
+// the mask 0x1 clears, so the test never holds and the flow carries nothing.
+
+// RUN: not aie-opt %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'aie.packet_flow' op has ID 0x3 outside mask 0x1, which no packet can match
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    aie.packet_flow(3 mask 1) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t02, DMA : 0>
+    }
+  }
+}

--- a/test/find-flows/id_check.mlir
+++ b/test/find-flows/id_check.mlir
@@ -9,7 +9,7 @@
 // RUN: aie-opt -aie-find-flows %s | FileCheck %s
 // CHECK: %[[T23:.*]] = aie.tile(2, 3)
 // CHECK: %[[T22:.*]] = aie.tile(2, 2)
-// CHECK: aie.packet_flow(15) {
+// CHECK: aie.packet_flow(15 mask 15) {
 // CHECK:   aie.packet_source<%[[T22]], DMA : 0>
 // CHECK:   aie.packet_dest<%[[T23]], DMA : 1>
 // CHECK: }

--- a/test/find-flows/id_check2.mlir
+++ b/test/find-flows/id_check2.mlir
@@ -9,7 +9,7 @@
 // RUN: aie-opt -aie-find-flows %s | FileCheck %s
 // CHECK: %[[T23:.*]] = aie.tile(2, 3)
 // CHECK: %[[T22:.*]] = aie.tile(2, 2)
-// CHECK: aie.packet_flow(13) {
+// CHECK: aie.packet_flow(13 mask 15) {
 // CHECK:   aie.packet_source<%[[T22]], DMA : 0>
 // CHECK:   aie.packet_dest<%[[T23]], DMA : 1>
 // CHECK: }

--- a/test/find-flows/packet_mask_hops.mlir
+++ b/test/find-flows/packet_mask_hops.mlir
@@ -1,0 +1,77 @@
+//===- packet_mask_hops.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The rules along one path may state different masks. Each hop narrows the set
+// of ids that reach the end, so a lifted flow claims what every hop on its path
+// accepts.
+
+// RUN: aie-opt --aie-find-flows --split-input-file %s | FileCheck %s
+
+// The first hop accepts 0x8 through 0xb and the second only 0x9, so the path
+// carries 0x9. A full-width mask selects one id, which the id states alone.
+// CHECK: aie.packet_flow(9)
+// CHECK-NOT: mask
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    %sb02 = aie.switchbox(%t02) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(North : 0, %a)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(28, 8, %a)
+      }
+    }
+    %sb03 = aie.switchbox(%t03) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(DMA : 0, %a)
+      aie.packet_rules(South : 0) {
+        aie.rule(31, 9, %a)
+      }
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+    aie.wire(%sb02 : North, %sb03 : South)
+    aie.wire(%t03 : DMA, %sb03 : DMA)
+  }
+}
+
+// -----
+
+// The two hops accept disjoint sets, so nothing reaches the end. The pass
+// recovers no flow and leaves both switchboxes in place, rather than lifting a
+// route that carries nothing.
+
+// CHECK-NOT: aie.packet_flow
+// CHECK: aie.switchbox
+// CHECK:   aie.rule(28, 8
+// CHECK: aie.switchbox
+// CHECK:   aie.rule(31, 4
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    %sb02 = aie.switchbox(%t02) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(North : 0, %a)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(28, 8, %a)
+      }
+    }
+    %sb03 = aie.switchbox(%t03) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(DMA : 0, %a)
+      aie.packet_rules(South : 0) {
+        aie.rule(31, 4, %a)
+      }
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+    aie.wire(%sb02 : North, %sb03 : South)
+    aie.wire(%t03 : DMA, %sb03 : DMA)
+  }
+}

--- a/test/find-flows/shim.mlir
+++ b/test/find-flows/shim.mlir
@@ -42,30 +42,20 @@ module {
 
 // -----
 
+// The route is now carried by the flow, so remove-lifted (on by default) drops
+// the switchboxes, the shim-mux and the wires it lifted.
 // CHECK:  %{{.*}}tile_2_1 = aie.tile(2, 1)
 // CHECK:  %{{.*}}tile_2_0 = aie.tile(2, 0)
 // CHECK:  %core_2_1 = aie.core(%tile_2_1) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  %switchbox_2_1 = aie.switchbox(%{{.*}}tile_2_1) {
-// CHECK:    aie.connect<Core : 0, South : 0>
-// CHECK:  }
-// CHECK:  %switchbox_2_0 = aie.switchbox(%{{.*}}tile_2_0) {
-// CHECK:    aie.connect<North : 0, South : 2>
-// CHECK:  }
-// CHECK:  %shim_mux_2_0 = aie.shim_mux(%{{.*}}tile_2_0) {
-// CHECK:    aie.connect<North : 2, DMA : 0>
-// CHECK:  }
 // CHECK:  %shim_dma_2_0 = aie.shim_dma(%{{.*}}tile_2_0) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  aie.wire(%switchbox_2_1 : South, %switchbox_2_0 : North)
-// CHECK:  aie.wire(%switchbox_2_0 : South, %shim_mux_2_0 : North)
-// CHECK:  aie.wire(%shim_mux_2_0 : DMA, %shim_dma_2_0 : DMA)
-// CHECK:  aie.wire(%shim_mux_2_0 : South, %{{.*}}tile_2_0 : DMA)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %core_2_1 : Core)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %{{.*}}tile_2_1 : Core)
 // CHECK:  aie.flow(%{{.*}}tile_2_1, Core : 0, %shim_dma_2_0, DMA : 0)
+// CHECK-NOT: aie.switchbox
+// CHECK-NOT: aie.shim_mux
+// CHECK-NOT: aie.wire
 
 module {
   aie.device(xcvc1902) {

--- a/test/find-flows/shim.mlir
+++ b/test/find-flows/shim.mlir
@@ -11,7 +11,8 @@
 // CHECK:           %[[VAL_0:.*]] = aie.tile(2, 1)
 // CHECK:           %[[VAL_1:.*]] = aie.tile(2, 0)
 // CHECK:           %[[VAL_6:.*]] = aie.shim_dma(%[[VAL_1]])
-// CHECK:           aie.flow(%[[VAL_0]], Core : 0, %[[VAL_6]], DMA : 0)
+// aie.flow names tiles, so the shim DMA endpoint resolves to its tile.
+// CHECK:           aie.flow(%[[VAL_0]], Core : 0, %[[VAL_1]], DMA : 0)
 module {
   aie.device(xcvc1902) {
     %t21 = aie.tile(2, 1)
@@ -42,30 +43,20 @@ module {
 
 // -----
 
+// The route is now carried by the flow, so remove-lifted (on by default) drops
+// the switchboxes, the shim-mux and the wires it lifted.
 // CHECK:  %{{.*}}tile_2_1 = aie.tile(2, 1)
 // CHECK:  %{{.*}}tile_2_0 = aie.tile(2, 0)
 // CHECK:  %core_2_1 = aie.core(%tile_2_1) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  %switchbox_2_1 = aie.switchbox(%{{.*}}tile_2_1) {
-// CHECK:    aie.connect<Core : 0, South : 0>
-// CHECK:  }
-// CHECK:  %switchbox_2_0 = aie.switchbox(%{{.*}}tile_2_0) {
-// CHECK:    aie.connect<North : 0, South : 2>
-// CHECK:  }
-// CHECK:  %shim_mux_2_0 = aie.shim_mux(%{{.*}}tile_2_0) {
-// CHECK:    aie.connect<North : 2, DMA : 0>
-// CHECK:  }
 // CHECK:  %shim_dma_2_0 = aie.shim_dma(%{{.*}}tile_2_0) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  aie.wire(%switchbox_2_1 : South, %switchbox_2_0 : North)
-// CHECK:  aie.wire(%switchbox_2_0 : South, %shim_mux_2_0 : North)
-// CHECK:  aie.wire(%shim_mux_2_0 : DMA, %shim_dma_2_0 : DMA)
-// CHECK:  aie.wire(%shim_mux_2_0 : South, %{{.*}}tile_2_0 : DMA)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %core_2_1 : Core)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %{{.*}}tile_2_1 : Core)
-// CHECK:  aie.flow(%{{.*}}tile_2_1, Core : 0, %shim_dma_2_0, DMA : 0)
+// CHECK:  aie.flow(%{{.*}}tile_2_1, Core : 0, %{{.*}}tile_2_0, DMA : 0)
+// CHECK-NOT: aie.switchbox
+// CHECK-NOT: aie.shim_mux
+// CHECK-NOT: aie.wire
 
 module {
   aie.device(xcvc1902) {

--- a/tools/aie-routing-command-line/mlir2json.sh
+++ b/tools/aie-routing-command-line/mlir2json.sh
@@ -2,4 +2,9 @@
 # Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-aie-opt --aie-create-pathfinder-flows --aie-find-flows $1 | aie-translate --aie-flows-to-json > $2.json
+# aie-translate traces each flow through the switchbox that configures it, so
+# --aie-find-flows has to keep the interconnect configuration it recovers from.
+# It also expects every flow to start on a core or DMA.
+aie-opt --aie-create-pathfinder-flows \
+        --aie-find-flows='keep-partial-flows=false remove-lifted=false' $1 \
+  | aie-translate --aie-flows-to-json > $2.json

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -856,8 +856,9 @@ getInputWithAddressesPipeline(mlir::MLIRContext *ctx, mlir::ModuleOp mod,
 inline std::unique_ptr<mlir::PassManager>
 getRoutingPipeline(mlir::MLIRContext *ctx) {
   auto pm = std::make_unique<mlir::PassManager>(ctx);
-  pm->nest<xilinx::AIE::DeviceOp>().addPass(
-      xilinx::AIE::createAIEPathfinderPass());
+  mlir::OpPassManager &dpm = pm->nest<xilinx::AIE::DeviceOp>();
+  dpm.addPass(xilinx::AIE::createAIESplitFlowViasPass());
+  dpm.addPass(xilinx::AIE::createAIEPathfinderPass());
   return pm;
 }
 

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -389,8 +389,8 @@ buildHostExeSubgraph(EdgeWithTypedOutput<std::string> &aieInc,
 }
 
 // AIE-simulator work-folder subgraph. Emits the `sim/` folder the aiesimulator
-// consumes: the graph/shim/scsim descriptors, the routed flows, the ps.so
-// co-simulation model, the `.target` marker, and the `aiesim.sh` launcher.
+// consumes: the graph/shim/scsim descriptors, the ps.so co-simulation model,
+// the `.target` marker, and the `aiesim.sh` launcher.
 //
 // Each artifact is its own edge/Item. They are declared with work-dir-relative
 // names, so as intermediates they land in the `.prj` (aiesim.sh derives
@@ -406,7 +406,6 @@ buildAiesimSubgraph(mlir::MLIRContext &context,
                     EdgeWithTypedOutput<std::string> &aieInc) {
   std::string installDir = getInstallDir();
   std::string aietoolsRoot = discoverAietoolsDir(aietoolsDir.getValue());
-  const std::string &devFilter = deviceName.getValue();
 
   // graph.xpe / aieshim_solution.aiesol / scsim_config.json: in-process
   // translations of the per-device module.
@@ -438,27 +437,10 @@ buildAiesimSubgraph(mlir::MLIRContext &context,
                                                     d.getSymName());
       });
 
-  // Routed flows: run `aie-find-flows` to annotate the module, emit it as
-  // flows_physical.mlir, then serialize the flows to JSON.
-  auto findFlowsPM = std::make_unique<mlir::PassManager>(&context);
-  findFlowsPM->nest<DeviceOp>().addPass(xilinx::AIE::createAIEFindFlowsPass());
-  auto &flows = staticPerDevice.map<ModRef>(
-      "sim/flows_physical.mlir", PassPipeline{std::move(findFlowsPM)});
-  auto &flowsJson = flows.map<std::string>(
-      "sim/flows_physical.json",
-      [devFilter](const Item<ModRef> &item,
-                  Item<std::string> &out) -> mlir::LogicalResult {
-        mlir::ModuleOp mod = item.get().get();
-        std::string devName = devFilter;
-        if (devName.empty()) {
-          for (auto d : mod.getOps<DeviceOp>()) {
-            devName = d.getSymName().str();
-            break;
-          }
-        }
-        llvm::raw_string_ostream os(out.value.emplace());
-        return xilinx::AIE::AIEFlowsToJSON(mod, os, devName);
-      });
+  // The routing description `aie-translate --aie-flows-to-json` produces
+  // belongs to the route visualizer, not to aiesimulator, which reads only the
+  // graph/shim/scsim descriptors and ps.so. Run
+  // tools/aie-routing-command-line/mlir2json.sh to obtain it.
 
   // ps.so: the SystemC co-simulation model. clang++ links the toolchain's
   // `genwrapper_for_ps.cpp` (which #includes aie_inc.cpp from the work dir)
@@ -582,26 +564,24 @@ aiesimulator --pkg-dir=${prj_name}/sim --dump-vcd ${vcd_filename}
   // materializes them -- via asFile(), the Item abstraction's "I need this on
   // disk" request -- into the `.prj`. Produces no file of its own.
   auto &aiesim =
-      bundle(xpe.out, shim.out, scsim.out, flows.out, flowsJson.out, ps.out,
-             target.out, script.out)
-          .join<File>(
-              "aiesim.stamp",
-              [](const Node<std::string> &xpe, const Node<std::string> &shim,
-                 const Node<std::string> &scsim, const Node<ModRef> &flows,
-                 const Node<std::string> &flowsJson, const Node<File> &ps,
-                 const Node<std::string> &target,
-                 const Node<std::string> &script,
-                 Item<File> &out) -> mlir::LogicalResult {
-                const NodeBase *nodes[] = {&xpe,       &shim, &scsim,  &flows,
-                                           &flowsJson, &ps,   &target, &script};
-                for (const NodeBase *n : nodes) {
-                  for (const ItemBase *it : n->itemRefs()) {
-                    (void)it->asFile();
-                  }
-                }
-                out.value = File{};
-                return mlir::success();
-              });
+      bundle(xpe.out, shim.out, scsim.out, ps.out, target.out, script.out)
+          .join<File>("aiesim.stamp",
+                      [](const Node<std::string> &xpe,
+                         const Node<std::string> &shim,
+                         const Node<std::string> &scsim, const Node<File> &ps,
+                         const Node<std::string> &target,
+                         const Node<std::string> &script,
+                         Item<File> &out) -> mlir::LogicalResult {
+                        const NodeBase *nodes[] = {&xpe, &shim,   &scsim,
+                                                   &ps,  &target, &script};
+                        for (const NodeBase *n : nodes) {
+                          for (const ItemBase *it : n->itemRefs()) {
+                            (void)it->asFile();
+                          }
+                        }
+                        out.value = File{};
+                        return mlir::success();
+                      });
   aiesim.producesFiles = false;
   return aiesim;
 }


### PR DESCRIPTION
Builds on #3711 (separated out from this) 

Routing offers two levels today: a physical design that carries an `aie.switchbox` at every hop, or a flow that names only its source and destination.

This PR adds a `via` list to `aie.flow` and `aie.packet_flow`. Each via names a tile together with the ingress and egress port the stream uses at that tile, so a flow can pin part of its route and leave the rest to the router. The new pass `--aie-split-flow-vias` rewrites such a flow into the segments that meet on the via ports, plus an `aie.switchbox` connection at each via tile.

```mlir
aie.flow(%00, "DMA" : 0, %11, "Core" : 1) via (%01 : South : 0 -> North : 0)
```

To support this, `--aie-find-flows` now:

- Lifts partial flows, that is, flows whose source or destination is a directional switchbox port rather than a core or DMA. The option `keep-partial-flows=false` restricts recovery to core-to-core flows.
- Annotates each lifted flow with the via list of the route it came from, under the option `emit-vias=true`. Without the option the pass lifts to a plain source-to-destination flow, as before.
- Removes the interconnect configuration it lifted, under the option `remove-lifted=true`. A route is then either an `aie.flow` or a chain of `aie.connect` operations, and never both. Both forms at once would mean two claims on the same routing resource.
- Splits a flow at its fan-in and fan-out points. The switchbox at such a point keeps its explicit configuration, one flow leads into it, and one flow leaves each of its outputs. The lifted flows therefore share no trunk. The earlier implementation emitted one flow per output of a broadcast, and those flows shared a prefix.
- Lifts straight-line packet flows and carries `keep_pkt_header` across the segments.

`aie.packet_flow` gains an optional `mask` attribute that pins the packet-rule mask of the flow instead of deriving it from the ids.