### PR TITLE
CI: fail NPU jobs when their hardware is missing

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -45,7 +45,7 @@ env:
 jobs:
 
   build-and-test-from-source:
-    name: Run Tests and Examples on Ryzen AI (Built from Source)
+    name: Run Tests and Examples on Ryzen AI (Built from Source) (${{ matrix.runner_type }})
     # The goal for this job is to run the full test suite, including programming guide and examples, on a freshly built-from-source MLIR-AIE.
     # This also exercises the build-mlir-aie-from-wheels.sh script, which is the most common developer-facing way to rebuild MLIR-AIE from source.
     runs-on: ${{ matrix.runner_type }}

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -52,8 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type: [ aie2-4col, aie2p-8col ]
+        include:
+          - runner_type: aie2-4col
+            expected_npu: npu1
+          - runner_type: aie2p-8col
+            expected_npu: npu2
     env:
+      AIE_EXPECTED_NPU: ${{ matrix.expected_npu }}
       NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-${{ matrix.runner_type }}-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache-${{ matrix.runner_type }}-${{ github.run_id }}
     steps:
@@ -241,7 +246,6 @@ jobs:
           fi
 
           popd
-
       - name: Cleanup NPU_CACHE_HOME
         if: always()
         run: |
@@ -332,7 +336,7 @@ jobs:
           #         (run_chain) backend test, cached/uncached runtime behavior,
           #         and the multi-process dispatch/isolation test -- self-building
           #         via @iron.jit / @compileconfig, gated on the
-          #         hrx_python_bindings lit feature and run_on_npu2;
+          #         hrx_python_bindings and hrx_npu2 lit features;
           #       * host-side (test_hrx_runtime_selection): the runtime-selection
           #         contract + lazy-init thread-safety tests, which need no NPU
           #         but are exercised here in the real HRX-present / XRT-absent
@@ -342,7 +346,8 @@ jobs:
           echo "===== lit: HRX python tests (npu-hrx + selection) ====="
           export AIE_XCLBINUTIL="$PWD/install/bin/xclbinutil"
           pushd build
-          LIT_FILTER='npu-hrx|test_hrx_runtime_selection' ninja check-aie
+          AIE_HRX_NPU=npu2 \
+            LIT_FILTER='npu-hrx|test_hrx_runtime_selection' ninja check-aie
           popd
 
           # 2) end-to-end on hardware: package with the bundled tool (NPU_RUNTIME=hrx)

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
 
@@ -191,6 +192,12 @@ class LitConfigHelper:
         if vitis_components is None:
             vitis_components = []
 
+        expected_npu = os.environ.get("AIE_EXPECTED_NPU")
+        if expected_npu and expected_npu not in LitConfigHelper.NPU_MODELS:
+            llvm_config.lit_config.fatal(
+                "AIE_EXPECTED_NPU must be 'npu1' or 'npu2', " f"got {expected_npu!r}"
+            )
+
         config = HardwareConfig()
         run_on_npu1 = "echo"
         run_on_npu2 = "echo"
@@ -199,6 +206,12 @@ class LitConfigHelper:
             logger.info("xrt not found")
             config.flags = ""
             config.substitutions["%xrt_flags"] = ""
+
+            if expected_npu:
+                llvm_config.lit_config.fatal(
+                    f"AIE_EXPECTED_NPU={expected_npu}, but XRT is unavailable"
+                )
+
             config.substitutions["%run_on_npu1%"] = run_on_npu1
             config.substitutions["%run_on_npu2%"] = run_on_npu2
             return config
@@ -237,13 +250,49 @@ class LitConfigHelper:
                     probe_env[key] = value
 
             print(f"Using xrt-smi: {xrtsmi}")
-            result = subprocess.run(
-                [xrtsmi, "examine"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=probe_env,
-                timeout=10,
-            )
+            attempts = 3 if expected_npu else 1
+            result = None
+            for attempt in range(1, attempts + 1):
+                try:
+                    result = subprocess.run(
+                        [xrtsmi, "examine"],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        env=probe_env,
+                        timeout=10,
+                    )
+                except subprocess.TimeoutExpired:
+                    if attempt == attempts:
+                        raise
+                else:
+                    if not expected_npu:
+                        break
+                    probe_output = result.stdout.decode(
+                        "utf-8", errors="ignore"
+                    ) + result.stderr.decode("utf-8", errors="ignore")
+                    if result.returncode == 0 and any(
+                        model in probe_output
+                        for model in LitConfigHelper.NPU_MODELS[expected_npu]
+                    ):
+                        break
+
+                if attempt < attempts:
+                    delay = attempt * 3
+                    logger.warning(
+                        "Expected %s was not visible to xrt-smi on attempt %d/%d; "
+                        "retrying in %ds",
+                        expected_npu.upper(),
+                        attempt,
+                        attempts,
+                        delay,
+                    )
+                    time.sleep(delay)
+
+            if result is None:
+                raise RuntimeError("xrt-smi did not complete")
+            if expected_npu and result.returncode != 0:
+                raise subprocess.CalledProcessError(result.returncode, result.args)
+
             output = (
                 result.stdout.decode("utf-8", errors="ignore")
                 + "\n"
@@ -315,6 +364,12 @@ class LitConfigHelper:
             logger.warning("Failed to run xrt-smi (not found)")
         except Exception as e:
             logger.warning("Failed to run xrt-smi: %s", e)
+
+        if expected_npu and f"ryzen_ai_{expected_npu}" not in config.features:
+            llvm_config.lit_config.fatal(
+                f"AIE_EXPECTED_NPU={expected_npu}, but the matching hardware "
+                "feature was not enabled"
+            )
 
         config.substitutions["%run_on_npu1%"] = run_on_npu1
         config.substitutions["%run_on_npu2%"] = run_on_npu2

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -368,7 +368,7 @@ class LitConfigHelper:
         if expected_npu and f"ryzen_ai_{expected_npu}" not in config.features:
             llvm_config.lit_config.fatal(
                 f"AIE_EXPECTED_NPU={expected_npu}, but the matching hardware "
-                "feature was not enabled"
+                "feature was not found!"
             )
 
         config.substitutions["%run_on_npu1%"] = run_on_npu1

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -42,6 +42,19 @@ LitConfigHelper.setup_standard_environment(
 if "MLIR_AIE_INSTALL_DIR" in os.environ:
     llvm_config.with_system_environment("MLIR_AIE_INSTALL_DIR")
 
+# HRX discovery runs during lit configuration, but dispatch runs in test
+# subprocesses. Keep both in the same provisioned runtime environment.
+llvm_config.with_system_environment(
+    [
+        "AIE_XCLBINUTIL",
+        "CMAKE_PREFIX_PATH",
+        "HRX_DIR",
+        "HRX_LIBHRX",
+        "LIBHRX_DIR",
+        "LD_LIBRARY_PATH",
+    ]
+)
+
 # Basic substitutions
 config.substitutions.append(("%PYTHON", config.python_executable))
 config.substitutions.append(("%extraAieCcFlags%", config.extraAieCcFlags))

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -207,6 +207,16 @@ if LitConfigHelper.python_expr_is_true(
 ):
     config.available_features.add("hrx_python_bindings")
 
+# The pure-HRX hardware job has no XRT probe. Its explicit NPU declaration
+# enables only HRX hardware tests; XRT tests remain unsupported.
+hrx_npu = os.environ.get("AIE_HRX_NPU")
+if hrx_npu:
+    if hrx_npu not in {"npu1", "npu2"}:
+        lit_config.fatal(f"AIE_HRX_NPU must be 'npu1' or 'npu2', got {hrx_npu!r}")
+    config.available_features.add(f"hrx_{hrx_npu}")
+    if hrx_npu == "npu2":
+        llvm_config.with_environment("NPU2", "1")
+
 if config.xrt_python_bindings and LitConfigHelper.can_import_python_module(
     config, config.python_executable, "pyxrt"
 ):

--- a/test/python/npu-hrx/test_chain_hrx.py
+++ b/test/python/npu-hrx/test_chain_hrx.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-# RUN: %run_on_npu2% env NPU_RUNTIME=hrx %pytest %s
-# REQUIRES: hrx_python_bindings
+# RUN: env NPU_RUNTIME=hrx %pytest %s
+# REQUIRES: hrx_python_bindings, hrx_npu2
 
 """HRX multi-dispatch / chain (runlist) backend test.
 
@@ -78,9 +78,10 @@ def add_one(input_buf: In, output_buf: Out, *, N: CompileTime[int]):
 def _hrx_runtime():
     """The default NPU runtime, which is the HRX runtime under NPU_RUNTIME=hrx.
 
-    The RUN line forces ``NPU_RUNTIME=hrx`` (and the ``hrx_python_bindings``
-    REQUIRES gate keeps this off non-HRX hosts), so ``DefaultNPURuntime`` here is
-    the ``CachedHRXRuntime`` that provides the ``run_chain`` under test.
+    The RUN line forces ``NPU_RUNTIME=hrx``. The ``hrx_python_bindings`` and
+    ``hrx_npu2`` gates keep this off non-HRX or non-NPU2 hosts.
+    ``DefaultNPURuntime`` is therefore the ``CachedHRXRuntime`` that provides
+    the ``run_chain`` under test.
     """
     import aie.utils as u
 

--- a/test/python/npu-hrx/test_hrx_runtime.py
+++ b/test/python/npu-hrx/test_hrx_runtime.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-# RUN: %run_on_npu2% env NPU_RUNTIME=hrx %pytest %s
-# REQUIRES: hrx_python_bindings
+# RUN: env NPU_RUNTIME=hrx %pytest %s
+# REQUIRES: hrx_python_bindings, hrx_npu2
 
 """Cached vs. uncached HRX runtime behavior.
 
@@ -17,7 +17,7 @@ Covers the two HRX runtimes:
 The design under test is a plain IRON ObjectFifo ``out = in + 1`` kernel built
 through the normal ``@compileconfig`` path; only the runtime wiring is
 backend-specific. Loading an executable requires the amdxdna device, so this is
-an on-hardware test (gated by ``hrx_python_bindings`` + ``run_on_npu2``).
+an on-hardware test (gated by ``hrx_python_bindings`` + ``hrx_npu2``).
 """
 
 import os

--- a/test/python/npu-hrx/test_multiprocess_hrx.py
+++ b/test/python/npu-hrx/test_multiprocess_hrx.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-# RUN: %run_on_npu2% %pytest %s
-# REQUIRES: hrx_python_bindings
+# RUN: env NPU_RUNTIME=hrx %pytest %s
+# REQUIRES: hrx_python_bindings, hrx_npu2
 
 """Multi-process HRX dispatch (review comment r3623840141).
 

--- a/utils/run_on_npu.py
+++ b/utils/run_on_npu.py
@@ -17,7 +17,6 @@ TAIL_LINES = 200
 
 
 # Logging and diagnostics helpers
-# TODO: update or disable for a future Windows NPU runner.
 def log(message: str) -> None:
     print(f"[run_on_npu.py] {message}", file=sys.stderr, flush=True)
 
@@ -37,9 +36,28 @@ def find_xrt_smi(xrt_dir: str) -> str | None:
     if xrt_smi is not None:
         return xrt_smi
 
-    candidate = os.path.join(os.environ.get("XILINX_XRT") or xrt_dir, "bin", "xrt-smi")
-    if os.path.isfile(candidate):
-        return candidate
+    xrt_root = os.environ.get("XILINX_XRT") or xrt_dir
+    candidates = [
+        os.path.join(xrt_root, "xrt-smi"),
+        os.path.join(xrt_root, "bin", "xrt-smi"),
+    ]
+    if os.name == "nt":
+        candidates.extend(
+            [
+                os.path.join(xrt_root, "xrt-smi.exe"),
+                os.path.join(xrt_root, "bin", "xrt-smi.exe"),
+                os.path.join(
+                    os.environ.get("SystemRoot", r"C:\Windows"),
+                    "System32",
+                    "AMD",
+                    "xrt-smi.exe",
+                ),
+            ]
+        )
+
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
 
     return None
 
@@ -47,15 +65,16 @@ def find_xrt_smi(xrt_dir: str) -> str | None:
 def emit_failure_diagnostics(xrt_dir: str, attempt: int) -> None:
     log(f"Device-enumeration failure on attempt {attempt}/{MAX_ATTEMPTS}.")
 
-    device_node = "/dev/accel/accel0"
-    if os.path.exists(device_node):
-        log(f"{device_node} exists")
-        try:
-            log(f"stat: {os.stat(device_node)}")
-        except OSError as error:
-            log(f"stat({device_node}) failed: {error}")
-    else:
-        log(f"{device_node} does not exist")
+    if sys.platform.startswith("linux"):
+        device_node = "/dev/accel/accel0"
+        if os.path.exists(device_node):
+            log(f"{device_node} exists")
+            try:
+                log(f"stat: {os.stat(device_node)}")
+            except OSError as error:
+                log(f"stat({device_node}) failed: {error}")
+        else:
+            log(f"{device_node} does not exist")
 
     xrt_smi = find_xrt_smi(xrt_dir)
     if xrt_smi is None:


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

This follows from the side discussion in #3407 after a hardware runner repeatedly failed to expose its NPU during direct invocation of a test.

The lit setup, as it exists now, treats a missing NPU as an unsupported configuration, skipping all tests that were intended to run on it. There can be circumstances where that makes sense locally, but it is **not** acceptable for a CI runner whose job is *specifically* to test on hardware. 

For instance, if a machine suddenly loses access to its NPU more than just transiently (perhaps due to a persistent deadlock or hardware failure), it will inadvertently **pass** hardware tests that might otherwise have failed *for every run or GitHub action that takes place using that physical host after the loss* unless it is manually reset. The smoke test run was previously the only reliable way to discover that problem.

This patch makes each hardware job declare its expected NPU. At the start of a test run, lit retries device discovery three times, then fails configuration if the expected device is missing or inaccessible. Runs without an explicit hardware expectation keep the existing behavior. 

It also:

* finishes the native-Windows diagnostic path in `run_on_npu.py`;
* fixes the pure-HRX tests so they use HRX-specific NPU gating instead of the XRT-backed `%run_on_npu2%` substitution.
> I believe the HRX tests weren't actually running during CI before, because they were not exposing themselves as actual hardware tests. This should fulfill that intent, although it might expose other problems I haven't considered.

As a result of this, an NPU CI job (regardless of backend) cannot pass merely because its hardware disappeared and its tests became `UNSUPPORTED`.

