### PR TITLE
[python] JIT cache: wait for the lock instead of spinning on it

### DIFF
--- a/python/utils/compile/cache/utils.py
+++ b/python/utils/compile/cache/utils.py
@@ -9,6 +9,8 @@ import contextlib
 import hashlib
 import os
 import pickle
+import queue
+import threading
 import time
 
 # Cross-platform file locking:
@@ -20,6 +22,10 @@ else:
     import fcntl
 
 from aie.utils.hostruntime.tensor_class import Tensor
+
+# Windows has no indefinite blocking lock -- msvcrt.locking's LK_LOCK gives up
+# after ~10s -- so that platform waits by retrying.  See _wait_for_lock.
+_LOCK_POLL_SECONDS = 0.005
 
 
 def _cell_val_to_key(val):
@@ -198,6 +204,77 @@ def _create_function_cache_key(function, args, kwargs, *, extra_key=()):
     return (*key, extra_key) if extra_key else key
 
 
+def _blocking_acquire(lock_file_path):
+    """Block until the lock is ours, returning the holding file object.
+
+    POSIX only: `flock` without LOCK_NB parks the caller in the kernel until the
+    holder releases, so there is nothing to poll and no handoff delay.
+    """
+    lock_file = open(lock_file_path, "a+")
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        lock_file.close()
+        raise
+    return lock_file
+
+
+def _wait_for_lock(lock_file_path, timeout_seconds):
+    """Wait out a held lock, honouring `timeout_seconds`, and return the lock.
+
+    On POSIX the wait happens inside a blocking `flock` on a helper thread, so
+    the kernel wakes us the instant the holder releases rather than us guessing
+    when to look. The timeout then applies to the handoff instead of to a poll
+    interval. Windows has no indefinite blocking lock, so it retries.
+    """
+    if os.name == "nt":
+        deadline = time.time() + timeout_seconds
+        lock_file = open(lock_file_path, "a+")
+        while not _try_acquire_lock(lock_file):
+            if time.time() > deadline:
+                lock_file.close()
+                raise TimeoutError(
+                    f"Could not acquire lock on {lock_file_path} within "
+                    f"{timeout_seconds} seconds"
+                )
+            time.sleep(_LOCK_POLL_SECONDS)
+        return lock_file
+
+    handoff = queue.Queue()
+    cancelled = threading.Event()
+    # The waiter's cancelled-check and its handoff must be atomic against the
+    # timeout below.  Otherwise the thread can win the lock in the instant the
+    # caller gives up, hand it to nobody, and hold it until the process exits.
+    state = threading.Lock()
+
+    def waiter():
+        try:
+            acquired = _blocking_acquire(lock_file_path)
+        except OSError:
+            return
+        with state:
+            if not cancelled.is_set():
+                handoff.put(acquired)
+                return
+        _release_lock(acquired)
+        acquired.close()
+
+    threading.Thread(target=waiter, name="aie-jit-cache-lock", daemon=True).start()
+    try:
+        return handoff.get(timeout=timeout_seconds)
+    except queue.Empty:
+        with state:
+            cancelled.set()
+            while not handoff.empty():  # it may have landed as we gave up
+                late = handoff.get_nowait()
+                _release_lock(late)
+                late.close()
+        raise TimeoutError(
+            f"Could not acquire lock on {lock_file_path} within "
+            f"{timeout_seconds} seconds"
+        )
+
+
 @contextlib.contextmanager
 def file_lock(lock_file_path, timeout_seconds=60):
     """
@@ -217,19 +294,12 @@ def file_lock(lock_file_path, timeout_seconds=60):
             pass  # File already exists
         lock_file = open(lock_file_path, "a+")
 
-        # Try to acquire exclusive lock with timeout
-        start_time = time.time()
-        while True:
-            try:
-                if _try_acquire_lock(lock_file):
-                    break
-            except OSError:
-                # Lock is held by another process
-                if time.time() - start_time > timeout_seconds:
-                    raise TimeoutError(
-                        f"Could not acquire lock on {lock_file_path} within {timeout_seconds} seconds"
-                    )
-                time.sleep(0.1)
+        if not _try_acquire_lock(lock_file):
+            # Drop our handle before waiting, and clear it first: the waiter can
+            # raise, and the cleanup below must not touch a closed file.
+            closed, lock_file = lock_file, None
+            closed.close()
+            lock_file = _wait_for_lock(lock_file_path, timeout_seconds)
 
         yield lock_file
 

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -66,6 +66,12 @@ from ._serialization import _TensorPlaceholder, _decode_kwarg, _encode_kwarg
 from .context import compile_context
 from .markers import CompileTime, In, InOut, Out
 
+# A waiter on this lock is waiting out someone else's *compile*, not just an
+# acquisition, so the bound has to exceed a full build rather than a handshake.
+# file_lock's own 60s default is well under the AIE compiles this guards -- CI
+# budgets individual tests 600-1200s for exactly that reason.
+_COMPILE_LOCK_TIMEOUT_SECONDS = 1800
+
 logger = logging.getLogger(__name__)
 
 
@@ -317,7 +323,7 @@ class CompilableDesign:
             xclbin_path = kernel_dir / "final.xclbin"
             inst_path = kernel_dir / "insts.bin"
 
-        with file_lock(lock_file_path):
+        with file_lock(lock_file_path, timeout_seconds=_COMPILE_LOCK_TIMEOUT_SECONDS):
             os.makedirs(kernel_dir, exist_ok=True)
 
             xclbin_exists = xclbin_path.exists()
@@ -429,7 +435,7 @@ class CompilableDesign:
             elf_path = kernel_dir / "design.elf"
         lock_file_path = kernel_dir / ".lock"
 
-        with file_lock(lock_file_path):
+        with file_lock(lock_file_path, timeout_seconds=_COMPILE_LOCK_TIMEOUT_SECONDS):
             os.makedirs(kernel_dir, exist_ok=True)
 
             if not explicit_path and self.use_cache and elf_path.exists():

--- a/test/python/test_cache_file_lock.py
+++ b/test/python/test_cache_file_lock.py
@@ -1,0 +1,133 @@
+# test_cache_file_lock.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# RUN: %pytest %s
+"""Unit tests for the JIT cache's file_lock — no NPU required."""
+
+import multiprocessing
+import os
+import time
+
+import pytest
+
+from aie.utils.compile.cache.utils import file_lock
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="test/python/ has no Windows pytest job to run under"
+)
+
+
+def _hold_then_release(lock_path, hold_seconds, ready):
+    """Hold the lock the way a peer process would, then let it go."""
+    with file_lock(lock_path, timeout_seconds=30):
+        ready.set()
+        time.sleep(hold_seconds)
+
+
+def _contend(lock_path, timeout_seconds, result):
+    started = time.time()
+    try:
+        with file_lock(lock_path, timeout_seconds=timeout_seconds):
+            result["outcome"] = "acquired"
+    except TimeoutError:
+        result["outcome"] = "timeout"
+    result["wall"] = time.time() - started
+
+
+def _run_contender(lock_path, timeout_seconds, join_after):
+    ctx = multiprocessing.get_context("spawn")
+    manager = ctx.Manager()
+    result = manager.dict()
+    ready = ctx.Event()
+
+    holder = ctx.Process(target=_hold_then_release, args=(lock_path, join_after, ready))
+    holder.start()
+    assert ready.wait(30), "holder never acquired the lock"
+
+    contender = ctx.Process(target=_contend, args=(lock_path, timeout_seconds, result))
+    contender.start()
+    contender.join(60)
+    holder.join(60)
+    assert not contender.is_alive(), "contender never returned"
+    return dict(result)
+
+
+def test_contended_lock_times_out(tmp_path):
+    """A lock held past the deadline must raise TimeoutError, not wait forever."""
+    result = _run_contender(str(tmp_path / ".lock"), timeout_seconds=1, join_after=10)
+    assert result["outcome"] == "timeout"
+    assert result["wall"] < 8, f"timeout fired late: {result['wall']:.1f}s"
+
+
+def test_contended_lock_does_not_busy_wait(tmp_path):
+    """Waiting must park, not retry -- no CPU burned while the lock is held."""
+    lock_path = str(tmp_path / ".lock")
+    ctx = multiprocessing.get_context("spawn")
+    ready = ctx.Event()
+    holder = ctx.Process(target=_hold_then_release, args=(lock_path, 2.0, ready))
+    holder.start()
+    assert ready.wait(30), "holder never acquired the lock"
+
+    # In-process so CPU is attributable: a retry loop charges this thread for
+    # the whole wait, a blocking flock charges it nothing.
+    cpu_before = time.process_time()
+    started = time.time()
+    with file_lock(lock_path, timeout_seconds=30):
+        pass
+    waited = time.time() - started
+    burned = time.process_time() - cpu_before
+    holder.join(30)
+    assert waited > 0.5, "did not actually contend"
+    assert burned < waited / 10, f"burned {burned:.3f}s CPU over {waited:.3f}s wait"
+
+
+def test_abandoned_waiter_does_not_keep_the_lock(tmp_path):
+    """A waiter that gives up must never end up holding the lock.
+
+    The wait parks on a helper thread. If that thread wins the lock after the
+    caller has timed out, it has to release rather than hand it to nobody --
+    otherwise the lock stays held until the process exits.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    hold = 1.5
+    # Sweep the deadline across the holder's release so some iterations time out
+    # mid-hold and some land in the instant the lock changes hands.
+    for timeout_seconds in (0.2, 0.6, 1.0, 1.4, 1.45, 1.5, 1.55):
+        lock_path = str(tmp_path / f"lock-{timeout_seconds}" / ".lock")
+        ready = ctx.Event()
+        holder = ctx.Process(target=_hold_then_release, args=(lock_path, hold, ready))
+        holder.start()
+        assert ready.wait(30), "holder never acquired the lock"
+
+        try:
+            with file_lock(lock_path, timeout_seconds=timeout_seconds):
+                pass
+        except TimeoutError:
+            pass
+        holder.join(30)
+
+        # Whatever happened above, the lock must be free now.
+        with file_lock(lock_path, timeout_seconds=5):
+            pass
+
+
+def test_uncontended_lock_is_acquired(tmp_path):
+    """The happy path still works."""
+    lock_path = str(tmp_path / ".lock")
+    with file_lock(lock_path, timeout_seconds=5):
+        pass
+    with file_lock(lock_path, timeout_seconds=5):
+        pass
+
+
+def test_lock_is_released_on_exception(tmp_path):
+    """An exception inside the block must not leave the lock held."""
+    lock_path = str(tmp_path / ".lock")
+    with pytest.raises(ValueError):
+        with file_lock(lock_path, timeout_seconds=5):
+            raise ValueError("boom")
+    with file_lock(lock_path, timeout_seconds=5):
+        pass


### PR DESCRIPTION
## Problem

`file_lock` is documented to wait up to `timeout_seconds` for the cache lock and
then raise. It does neither. On a held lock it spins.

`_try_acquire_lock` signals contention by **returning False** -- it catches the
`OSError` from `flock` / `msvcrt.locking` itself:

```python
try:
    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
    return True
except OSError:
    return False
```

but the wait loop puts the sleep *and* the deadline check inside an `except
OSError` that nothing raises into:

```python
while True:
    try:
        if _try_acquire_lock(lock_file):
            break
    except OSError:                      # unreachable
        if time.time() - start_time > timeout_seconds:
            raise TimeoutError(...)      # unreachable
        time.sleep(0.1)                  # unreachable
```

So a contended `file_lock` retries with no delay and no deadline. Measured
against a held lock, the waiter makes **15,329,952 acquisition attempts per
second** and never returns until the holder releases. `timeout_seconds` has no
effect at any value.

## Concretely

The waiter's own latency is not the problem -- it gets the lock as soon as it is
free either way. The cost lands on everything else running on the machine.

Ten processes queued on a held lock, with ten unrelated CPU-bound jobs running
alongside them, on a 20-core host:

| | wall for the unrelated jobs |
|---|---|
| no waiters at all (control) | 1.01 s / 0.99 s |
| ten waiters, spinning (today) | 1.51 s / 1.73 s |
| ten waiters, with this change | 1.07 s / 0.99 s |

Two repeats of each. A queued build currently taxes every concurrently running
job by 50-75%; with this change the tax is gone and unrelated work runs as fast
as if nothing were waiting at all.

Measured from the waiters' side instead: 8 waiters over a 10 s hold burn
**81.3 s of CPU today and 6.3 s after**, for identical wall time (10.06 s vs
10.07 s). The waiting was never slow -- it was expensive.

That is worst exactly where it is least affordable: behind a long compile, on
shared runners.

## Fix

Wait on the kernel instead of repairing the retry loop.

`flock` without `LOCK_NB` parks the caller until the holder releases, which is
the event the loop was approximating. Running it on a helper thread lets
`timeout_seconds` apply to the handoff rather than to a poll interval. The
uncontended path is unchanged: one non-blocking attempt, no thread.

Windows has no indefinite blocking lock -- `msvcrt.locking`'s `LK_LOCK` gives up
after about ten seconds -- so that platform keeps a retry, now with a reachable
deadline.

Handoff, with 16 waiters over a cache-hit-sized critical section:

| wait strategy | handoff | polls during a 1 s wait |
|---|---|---|
| spin (today) | 11.3 ms | 15,329,952 |
| fixed 100 ms poll | 531 ms | 17 |
| 1 ms -> 5 ms backoff | 35 ms | 200 |
| blocking (this change) | 7.5 ms | 0 |

Faster than the spin it replaces, with no polling at all. Single-waiter handoff
after a 300 ms hold is 0.2 ms.

**A waiter that gives up must not go on to win the lock and hold it.** The helper
thread can acquire in the same instant the caller times out; if it hands the lock
to nobody, it stays held until the process exits. The thread's handoff and the
caller's timeout are therefore serialised, and whichever loses releases.

## The timeout this switches on

Repairing the loop makes `timeout_seconds` load-bearing for the first time, and
both call sites in `compilabledesign` took the 60 s default. A waiter there is
waiting out another process' entire **compile**, not an acquisition handshake,
and AIE compiles run long enough that CI budgets individual tests 600-1200 s.
Left alone, making the timeout work would convert "slow but eventually correct"
into a spurious `TimeoutError` whenever a concurrent build ran over a minute.
Both sites now pass a bound sized for a build.

## Test

Adds `test/python/test_cache_file_lock.py`:

- `test_contended_lock_times_out` -- a lock held past the deadline must raise,
  not block indefinitely.
- `test_contended_lock_does_not_busy_wait` -- the wait must park rather than
  retry, asserted as CPU consumed against time spent waiting, measured in-process
  so it is attributable.
- `test_abandoned_waiter_does_not_keep_the_lock` -- sweeps the caller's deadline
  across the holder's release, including the instant the lock changes hands, and
  asserts the lock is free afterwards in every case.
- the uncontended path, and release-on-exception.

The first two fail on `main`; all five pass with this change.

## Validation

Host-side only; no device involved. `test/python/` excluding the `npu-xrt` and
`npu-hrx` device directories, same tree, before and after:

| | passed | failed |
|---|---|---|
| `main` | 578 | 7 |
| with this change | 580 | 5 |

The delta is exactly the two new contention tests flipping to pass; no other test
changes state. The failures common to both runs are unrelated to this change and
are artifacts of the local harness, not of `main`.

A full `@iron.jit` design was compiled end to end before and after to confirm the
ordinary path is unaffected: 1.4 s cold, cache hit at 0.00 s, identical xclbin
size.

`black` (26.5.1, the pinned pre-commit revision) reports all three files
unchanged.

## Two things left alone

A permanent, non-contention failure -- `ENOLCK`, `EBADF`, a mount without working
advisory locks -- is swallowed by `_try_acquire_lock` and surfaces as a
`TimeoutError` after the full wait rather than as the underlying errno. Still
better than spinning on it forever, but it is a diagnostic the caller does not
get. Narrowing `_try_acquire_lock` to treat only `EACCES`/`EAGAIN` as contention
and re-raise the rest would fix it; that is left out here because the Windows
branch cannot be exercised from this change's test job, which is also why these
tests skip on Windows.

`TimeoutError` now propagates out of `compile()` where the code previously
blocked indefinitely, and nothing in the tree catches it. A timed-out waiter
raises before `file_lock` yields, so it never enters the body and cannot disturb
the holder's in-progress build or its cache directory.

## Why it has been quiet

Both call sites lock a per-design directory under `$NPU_CACHE_HOME`, so
contention needs two processes building the *same* design concurrently. The
on-device lit group runs at capacity 1 and each CI run gets its own cache
directory, which keeps that rare today. It stops being rare as soon as
compilation is fanned out in parallel against a shared cache root.
