### PR TITLE
[python] JIT cache: key on the aiecc the compile actually runs

### DIFF
--- a/python/utils/compile/jit/_hash.py
+++ b/python/utils/compile/jit/_hash.py
@@ -181,13 +181,19 @@ def _compute_artifact_hash(
                 peano_mtime = "absent"
 
         try:
-            import shutil as _shutil
+            from aie.utils import config as _config
 
-            _aiecc_path = _shutil.which("aiecc")
-            aiecc_mtime = (
-                str(Path(_aiecc_path).stat().st_mtime) if _aiecc_path else "absent"
-            )
-        except (FileNotFoundError, OSError) as exc:
+            # Resolve aiecc the way the compile does.  Probing PATH instead
+            # misses the bundled bin/aiecc that _run_aiecc actually invokes,
+            # and then every aiecc aliases onto the constant below.
+            aiecc_mtime = str(Path(_config.aiecc_path()).stat().st_mtime)
+        except (
+            ImportError,
+            AttributeError,
+            FileNotFoundError,
+            OSError,
+            RuntimeError,
+        ) as exc:
             logger.warning("_compute_artifact_hash: aiecc absent (%s)", exc)
             aiecc_mtime = "absent"
 

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -299,6 +299,21 @@ def test_hash_for_existing_source_file_includes_mtime(tmp_path):
     assert h1 != hash(d2)
 
 
+def test_hash_keys_on_the_aiecc_the_compile_uses(monkeypatch):
+    """aiecc must be resolved as compilation resolves it, not via PATH."""
+    import aie.utils.config as config
+
+    seen = []
+
+    def fake_aiecc_path():
+        seen.append(True)
+        return config.__file__  # any real file; only its mtime is consumed
+
+    monkeypatch.setattr(config, "aiecc_path", fake_aiecc_path)
+    CompilableDesign(_gemm_gen())._compute_cache_hash()
+    assert seen, "artifact hash did not consult config.aiecc_path()"
+
+
 def test_hash_is_24_hex_chars():
     d = CompilableDesign(_gemm_gen())
     hex_str = d._compute_cache_hash()


### PR DESCRIPTION
## Problem

`_compute_artifact_hash` records which aiecc a design was built with by locating
it on `PATH`:

```python
_aiecc_path = _shutil.which("aiecc")
aiecc_mtime = str(Path(_aiecc_path).stat().st_mtime) if _aiecc_path else "absent"
```

Compilation does not resolve it that way. `_run_aiecc` calls
`config.aiecc_path()`, which prefers the bundled `<root>/bin/aiecc` and only
falls back to `PATH`:

```python
def aiecc_path():
    bundled_aiecc = os.path.join(root_path(), "bin", _executable_name("aiecc"))
    if os.path.isfile(bundled_aiecc):
        return bundled_aiecc
    path_aiecc = shutil.which(_executable_name("aiecc"))
    ...
```

In an ordinary install aiecc is not on `PATH`, so `which` returns `None` and the
hash takes the `"absent"` branch -- a constant. Observed on a standard build:

```
compile invokes : <root>/bin/aiecc
key probes PATH : None
key component   : "absent"      (a constant)
```

Every aiecc therefore aliases onto the same key. Upgrading the compiler
invalidates nothing, and a design built by the previous one is served from cache
indefinitely.

This is unconditional -- it does not depend on `source_files`, on the design, or
on anything the caller passes. A default design with no configuration at all is
keyed against a constant where it should be keyed against the compiler.

## Fix

Resolve aiecc the way the compile resolves it.

`aiecc_path()` raises when it finds nothing, so the existing `"absent"` fallback
stays as the genuinely-missing case rather than as the normal one.

## Test

`test_hash_keys_on_the_aiecc_the_compile_uses` in
`test/python/test_compilabledesign.py` asserts the artifact hash consults
`config.aiecc_path()`. It fails on `main`.

## Validation

Host-side only; no device involved. Verified directly that a default design --
no `source_files`, no flags -- now invalidates when aiecc changes and does not on
`main`.

`test/python/test_compilabledesign.py`, same tree, before and after:

| | passed | failed |
|---|---|---|
| `main` | 81 | 2 |
| with this change | 82 | 1 |

The delta is exactly the new test flipping to pass. The remaining failure is
common to both runs, unrelated to this change, and an artifact of the local
harness rather than of `main`.

`black` (26.5.1, the pinned pre-commit revision) reports both files unchanged.

## Consequence worth stating

Because aiecc's mtime now participates, rebuilding the toolchain invalidates
cached artifacts where previously it did not. That is the intent -- a rebuilt
aiecc can produce a different artifact, and today's behaviour is to serve the old
one -- but it does mean a no-op rebuild also discards the cache, since mtime
moves whether or not the binary's contents did.

`aiecc --version` reports a git SHA, which would survive a no-op rebuild where
mtime cannot. Keying on identity rather than on timestamps is a larger question
than this fix, and is left alone here.
