### PR TITLE
[aiecc] Fix the legal start-column set for virtualized NPU partitions

### DIFF
--- a/test/aiecc/cpp_partition_npu2_4col.mlir
+++ b/test/aiecc/cpp_partition_npu2_4col.mlir
@@ -1,27 +1,29 @@
-//===- cpp_partition_npu1_1col.mlir ------------------------------*- MLIR -*-===//
+//===- cpp_partition_npu2_4col.mlir ---------------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 
-// Tests that partition JSON has column_width=1 for npu1_1col.
+// Tests the legal start columns for a 4-column partition of the 8-column NPU2
+// array. A 4-wide partition fits at every offset up to 8 - 4.
 
 // REQUIRES: peano
 
 // RUN: aiecc --no-xchesscc --no-xbridge --get-xclbin %s
-// RUN: FileCheck %s --input-file=cpp_partition_npu1_1col.mlir.prj/partition_main.json
+// RUN: FileCheck %s --input-file=cpp_partition_npu2_4col.mlir.prj/partition_main.json
 
-// CHECK: "column_width": 1
+// CHECK: "column_width": 4
 // CHECK: "start_columns": [
 // CHECK-NEXT: 0
 // CHECK-NEXT: 1
 // CHECK-NEXT: 2
 // CHECK-NEXT: 3
+// CHECK-NEXT: 4
 // CHECK-NEXT: ]
 
 module {
-  aie.device(npu1_1col) {
+  aie.device(npu2_4col) {
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_2 = aie.tile(0, 2)
     aie.objectfifo @of(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>

--- a/test/aiecc/cpp_partition_npu2_5col.mlir
+++ b/test/aiecc/cpp_partition_npu2_5col.mlir
@@ -1,18 +1,19 @@
-//===- cpp_partition_npu1_1col.mlir ------------------------------*- MLIR -*-===//
+//===- cpp_partition_npu2_5col.mlir ---------------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 
-// Tests that partition JSON has column_width=1 for npu1_1col.
+// Tests the legal start columns for a 5-column partition of the 8-column NPU2
+// array. A 5-wide partition fits at every offset up to 8 - 5.
 
 // REQUIRES: peano
 
 // RUN: aiecc --no-xchesscc --no-xbridge --get-xclbin %s
-// RUN: FileCheck %s --input-file=cpp_partition_npu1_1col.mlir.prj/partition_main.json
+// RUN: FileCheck %s --input-file=cpp_partition_npu2_5col.mlir.prj/partition_main.json
 
-// CHECK: "column_width": 1
+// CHECK: "column_width": 5
 // CHECK: "start_columns": [
 // CHECK-NEXT: 0
 // CHECK-NEXT: 1
@@ -21,7 +22,7 @@
 // CHECK-NEXT: ]
 
 module {
-  aie.device(npu1_1col) {
+  aie.device(npu2_5col) {
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_2 = aie.tile(0, 2)
     aie.objectfifo @of(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>

--- a/tools/aiecc/SidecarFiles.h
+++ b/tools/aiecc/SidecarFiles.h
@@ -202,19 +202,42 @@ inline std::string generatePdiUUID() {
                        ((uint64_t)(data[2] & 0xFFFF) << 32) | data[3]);
 }
 
+/// Physical width of the array a (possibly virtualized) device is carved from.
+/// A virtualized device's own `columns()` is its PARTITION width, not the array
+/// width, so the set of legal start columns cannot be derived from it alone.
+inline int physicalColumns(xilinx::AIE::AIEDevice device) {
+  switch (device) {
+  case xilinx::AIE::AIEDevice::npu1:
+  case xilinx::AIE::AIEDevice::npu1_1col:
+  case xilinx::AIE::AIEDevice::npu1_2col:
+  case xilinx::AIE::AIEDevice::npu1_3col:
+    return 4;
+  case xilinx::AIE::AIEDevice::npu2:
+  case xilinx::AIE::AIEDevice::npu2_1col:
+  case xilinx::AIE::AIEDevice::npu2_2col:
+  case xilinx::AIE::AIEDevice::npu2_3col:
+  case xilinx::AIE::AIEDevice::npu2_4col:
+  case xilinx::AIE::AIEDevice::npu2_5col:
+  case xilinx::AIE::AIEDevice::npu2_6col:
+  case xilinx::AIE::AIEDevice::npu2_7col:
+    return 8;
+  default:
+    return 0; // not an NPU partition; emit no start columns
+  }
+}
+
 inline llvm::json::Value makePartitionJson(xilinx::AIE::DeviceOp devOp,
                                            llvm::StringRef pdiPath,
                                            llvm::StringRef kernelId) {
   using O = llvm::json::Object;
   int numCols = devOp.getTargetModel().columns();
   auto device = devOp.getDevice();
+  // Every offset at which a numCols-wide partition still fits on the array. The
+  // full-device cases fall out of this as the degenerate numCols == physCols.
   llvm::json::Array startColumns;
-  if (device == xilinx::AIE::AIEDevice::npu1 ||
-      device == xilinx::AIE::AIEDevice::npu2)
-    startColumns.push_back(0);
-  else
-    for (int i = 1; i < 6 - numCols; ++i)
-      startColumns.push_back(i);
+  int physCols = physicalColumns(device);
+  for (int i = 0; i + numCols <= physCols; ++i)
+    startColumns.push_back(i);
   return O{
       {"aie_partition",
        O{{"name", "QoS"},


### PR DESCRIPTION
## Problem

`makePartitionJson` derives the set of columns a partition may legally start at
from a literal:

```cpp
llvm::json::Array startColumns;
if (device == xilinx::AIE::AIEDevice::npu1 ||
    device == xilinx::AIE::AIEDevice::npu2)
  startColumns.push_back(0);
else
  for (int i = 1; i < 6 - numCols; ++i)
    startColumns.push_back(i);
```

`6 - numCols` is only a sensible bound on a 5-column array, and neither NPU
family has one. `AIEDevice::npu1` maps to `VirtualizedNPU1TargetModel(4)` and
`npu2` to `NPU2TargetModel` with `columns() == 8`:

| device | emitted | array | first bad entry |
|---|---|---|---|
| `npu1_1col` | 1, 2, 3, 4 | 4 wide | start 4 is off the array |
| `npu1_2col` | 1, 2, 3 | 4 wide | start 3 leaves 1 column for 2 |
| `npu1_3col` | 1, 2 | 4 wide | start 2 leaves 1 column for 3 |
| `npu2_1col` | 1, 2, 3, 4 | 8 wide | stops 3 short of column 7 |
| `npu2_2col` | 1, 2, 3 | 8 wide | stops at 3 of 6 |
| `npu2_3col` | 1, 2 | 8 wide | stops at 2 of 5 |
| `npu2_4col` | 1 | 8 wide | one placement of 5 |
| `npu2_5col` | (empty) | 8 wide | no placement at all |
| `npu2_6col` | (empty) | 8 wide | no placement at all |
| `npu2_7col` | (empty) | 8 wide | no placement at all |

Every virtualized device is wrong, in one of two directions.

## Concretely

The empty rows are the sharp case. From 5 columns up the loop bound goes
non-positive, so `npu2_5col`, `npu2_6col` and `npu2_7col` ship an
`aie_partition` that advertises no legal start column whatsoever, a partition
the resource solver has nowhere to put.

It is worse than that in practice, and I have now measured it rather than
predicted it: `aiecc` never reaches the solver. `xclbinutil` rejects the empty
list at build time with `xclbinutil: Error: Missing start columns for the AIE
partition.` So on npu2 from 5 columns up this is a hard build failure today,
not a wrong `partition_main.json` that something downstream has to cope with.

The `npu1` rows are the other direction: a start of 4 on a 4-column array names
a column that does not exist, and 2 or 3 name columns with too little room left
behind them.

The bound cannot be recovered from the target model alone. A virtualized
device's `columns()` is its **partition** width, not the width of the array it
is carved from, so `numCols` on its own cannot say where the partition fits.

## Fix

State the rule directly: every offset at which a `numCols`-wide partition still
fits on the array.

```cpp
llvm::json::Array startColumns;
int physCols = physicalColumns(device);
for (int i = 0; i + numCols <= physCols; ++i)
  startColumns.push_back(i);
```

`physicalColumns` supplies the array width the target model does not carry.

The `npu1` / `npu2` special case is gone because it is the degenerate
`numCols == physCols`: both yield exactly `[0]`, which is what the existing
`cpp_partition_npu1` and `cpp_partition_npu2` tests already assert. That the
special case falls out of the general rule, rather than having to be preserved
against it, is what convinced me this is the intended semantics and not a
behaviour change.

One judgement call worth flagging: `physicalColumns` encodes array widths that
arguably belong on `AIETargetModel` as a method. I kept it local rather than
touch the dialect for a JSON fix, but I am happy to move it if you would prefer
it there.

## Is column 0 a legal start?

It is, and the change depends on it, so I checked rather than assumed.

I rewrote the `AIE_PARTITION` section of two 4-column xclbins with `xclbinutil`
to advertise `0, 1, 2, 3, 4` in place of the emitted `1`, and ran them on Strix.
Both load and dispatch. Independently, the full-device partitions already start
at 0 and use column 0 for both compute and shim tiles, so nothing is reserved
there.

## Test

- `cpp_partition_npu2_5col.mlir` - new, covers a device that emitted an empty
  list. Fails on `main`.
- `cpp_partition_npu2_4col.mlir` - new, covers the widened range, `0` through
  `4` where `main` emits only `1`. Fails on `main`.
- `cpp_partition_npu1_1col.mlir` - tightened. It asserted a single loose
  `CHECK: 1`, which passes against both the old list and the new one; it now
  pins the full `0, 1, 2, 3`.
- `cpp_partition_npu1.mlir` and `cpp_partition_npu2.mlir` are unchanged and
  still pass, which is the check that the removed special case changed nothing.

## Validation

I have now built and tested this branch; the full before/after table is in the
comment below. All five partition lit tests pass with the fix. Reverting only
`SidecarFiles.h` reproduces the bug in 3 of 5: `npu1_1col` emits 1, 2, 3, 4 and
drops start column 0, `npu2_4col` emits only 1, and `npu2_5col` fails the build
outright. Built the `aiecc` target alone against the pinned MLIR distro;
`aiecc.cpp` has since moved in #3399, which does not touch the start-column
logic, so these numbers are against the pre-#3399 tree.

Hardware here is Strix (npu2); I cannot exercise the `npu1` rows on device.

