### PR TITLE
Fix remaining Windows NPU lit failures

### DIFF
--- a/programming_examples/basic/matrix_multiplication/common.h
+++ b/programming_examples/basic/matrix_multiplication/common.h
@@ -12,14 +12,25 @@
 #define MATRIX_MULTIPLICATION_H
 
 #include <algorithm>
-#include <bits/stdc++.h>
-#include <cassert> // for assert(); not guaranteed via other headers
+#include <cassert>
+#include <cfloat>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <ostream>
+#include <random>
+#include <ranges>
+#include <string>
+#include <tuple>
 #include <type_traits>
+#include <vector>
 
 #include "test_utils.h"
 
@@ -138,20 +149,20 @@ static inline Tacc accum_add_product(Tacc running_sum, Tin lhs, Tin rhs) {
 
 template <>
 std::int16_t get_random<std::int16_t>() {
-  return (std::int16_t)rand() % 0x10000;
+  return static_cast<std::int16_t>(std::rand()) % 0x10000;
 }
 
 template <>
-int8_t get_random<int8_t>() {
-  return (int8_t)rand() % 0x100;
+std::int8_t get_random<std::int8_t>() {
+  return static_cast<std::int8_t>(std::rand()) % 0x100;
 }
 
 template <>
 test_utils::bfloat16_t get_random<test_utils::bfloat16_t>() {
   // Random numbers should NOT be uniformly between 0 and 1, because that
   // would make the matrix product AB always close to 1.
-  return test_utils::bfloat16_from_float(4.0f * (float)rand() /
-                                         (float)(RAND_MAX));
+  return test_utils::bfloat16_from_float(
+      4.0f * static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX));
 }
 
 template <typename Tin, typename Tout, typename Tacc>
@@ -243,7 +254,7 @@ float get_abs_tol<float>() {
 }
 
 template <>
-float get_abs_tol<int8_t>() {
+float get_abs_tol<std::int8_t>() {
   return 0;
 }
 
@@ -268,7 +279,7 @@ float get_rel_tol<float>() {
 }
 
 template <>
-float get_rel_tol<int8_t>() {
+float get_rel_tol<std::int8_t>() {
   return 0;
 }
 
@@ -282,7 +293,7 @@ void print_matrix(const std::vector<T> matrix, int n_cols,
 
   auto maxima = std::minmax_element(matrix.begin(), matrix.end());
   T max_val = std::max(*maxima.first, (T)std::abs(*maxima.second));
-  size_t n_digits = log10(max_val);
+  std::size_t n_digits = std::log10(max_val);
   if (w == -1) {
     w = n_digits;
   }
@@ -295,7 +306,7 @@ void print_matrix(const std::vector<T> matrix, int n_cols,
   const bool elide_cols = n_printable_cols < n_cols;
 
   if (elide_rows || elide_cols) {
-    w = std::max((int)w, (int)strlen(elide_sym));
+    w = std::max((int)w, (int)std::strlen(elide_sym));
   }
 
   w += 3; // for decimal point and two decimal digits
@@ -332,16 +343,16 @@ void print_matrix(const std::vector<T> matrix, int n_cols,
 #undef print_row
 }
 
-// int8_t aka char will not print as a number but as a character; specialize
-// print_matrix<int8_t> to cast to int16_t first so everything prints as numbers
+// std::int8_t streams as a character. Cast to std::int16_t so matrix
+// entries print numerically.
 template <>
-void print_matrix(const std::vector<int8_t> matrix, int n_cols,
+void print_matrix(const std::vector<std::int8_t> matrix, int n_cols,
                   int n_printable_rows, int n_printable_cols,
                   std::ostream &ostream, const char col_sep[],
                   const char elide_sym[], int w) {
-  std::vector<int16_t> cast_matrix(matrix.size());
-  for (uint i = 0; i < matrix.size(); i++) {
-    cast_matrix[i] = (int16_t)matrix[i];
+  std::vector<std::int16_t> cast_matrix(matrix.size());
+  for (std::size_t i = 0; i < matrix.size(); i++) {
+    cast_matrix[i] = static_cast<std::int16_t>(matrix[i]);
   }
   print_matrix(cast_matrix, n_cols, n_printable_rows, n_printable_cols, ostream,
                col_sep, elide_sym, w);
@@ -469,7 +480,7 @@ int verify_stochastic(int M, int N, int K, std::vector<Tin> A,
   std::vector<struct error<Tout>> errors;
   float max_rel_error = 0.0f;
   double progress = 0;
-  for (std::tuple<size_t, std::tuple<int &, int &>> cell :
+  for (std::tuple<std::size_t, std::tuple<int &, int &>> cell :
        std::views::enumerate(std::views::zip(sampled_rows, sampled_cols))) {
     int i = std::get<0>(cell);
     int row = std::get<0>(std::get<1>(cell));
@@ -513,9 +524,10 @@ int verify_stochastic(int M, int N, int K, std::vector<Tin> A,
 // --------------------------------------------------------------------------
 // Tracing
 // --------------------------------------------------------------------------
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
+void write_out_trace(char *traceOutPtr, std::size_t trace_size,
+                     std::string path) {
   std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
+  auto *traceOut = reinterpret_cast<std::uint32_t *>(traceOutPtr);
   for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
     fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
     fout << std::endl;

--- a/programming_examples/basic/matrix_multiplication/test.cpp
+++ b/programming_examples/basic/matrix_multiplication/test.cpp
@@ -6,15 +6,20 @@
 //===----------------------------------------------------------------------===//
 
 #include "cxxopts.hpp"
-#include <bits/stdc++.h>
+
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
@@ -66,7 +71,7 @@ int main(int argc, const char *argv[]) {
   int c_col_maj = vm["c_col_maj"].as<int>();
 
   // Fix the seed to ensure reproducibility in CI.
-  srand(1726250518); // srand(time(NULL));
+  std::srand(1726250518);
 
   int M = vm["M"].as<int>();
   int K = vm["K"].as<int>();
@@ -82,11 +87,11 @@ int main(int argc, const char *argv[]) {
   int B_VOLUME = N * K;
   int C_VOLUME = M * N;
 
-  size_t A_SIZE = (A_VOLUME * sizeof(A_DATATYPE));
-  size_t B_SIZE = (B_VOLUME * sizeof(B_DATATYPE));
-  size_t C_SIZE = (C_VOLUME * sizeof(C_DATATYPE));
+  std::size_t A_SIZE = (A_VOLUME * sizeof(A_DATATYPE));
+  std::size_t B_SIZE = (B_VOLUME * sizeof(B_DATATYPE));
+  std::size_t C_SIZE = (C_VOLUME * sizeof(C_DATATYPE));
 
-  std::vector<uint32_t> instr_v =
+  std::vector<std::uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   if (verbosity >= 1)
@@ -160,7 +165,7 @@ int main(int argc, const char *argv[]) {
   for (int i = 0; i < A_VOLUME; i++) {
     AVec[i] = matmul_common::get_random<A_DATATYPE>();
   }
-  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
+  std::memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
   B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
   std::vector<B_DATATYPE> BVec(B_VOLUME);
   for (int i = 0; i < B_VOLUME; i++) {
@@ -172,17 +177,17 @@ int main(int argc, const char *argv[]) {
     //   BVec[i] = 0.0;
     // }
   }
-  memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
+  std::memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
 
   // Initialize outputs; bufOut is results matrix plus tracing info
   char *bufOut = bo_out.map<char *>();
   std::vector<C_DATATYPE> CVec(C_VOLUME);
-  memset(bufOut, 0, C_SIZE);
+  std::memset(bufOut, 0, C_SIZE);
 
   char *bufTrace = nullptr;
   if (trace_size > 0) {
     bufTrace = bo_trace.map<char *>();
-    memset(bufTrace, 0, trace_size);
+    std::memset(bufTrace, 0, trace_size);
   }
 
   if (verbosity >= 2) {
@@ -198,7 +203,7 @@ int main(int argc, const char *argv[]) {
 
   // Instruction buffer for DMA configuration
   void *bufInstr = bo_instr.map<void *>();
-  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+  std::memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
 
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
@@ -251,7 +256,7 @@ int main(int argc, const char *argv[]) {
     }
 
     if (do_verify) {
-      memcpy(CVec.data(), bufOut, (CVec.size() * sizeof(C_DATATYPE)));
+      std::memcpy(CVec.data(), bufOut, (CVec.size() * sizeof(C_DATATYPE)));
       if (verbosity >= 1) {
         if (do_verify_stochastic) {
           std::cout << "Verifying " << verify_stochastic_n_samples

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -595,9 +595,10 @@ class LitConfigHelper:
     def setup_host_link_substitution(config_obj) -> None:
         """Add host linker flags for tests that build XRT host executables.
 
-        Linux-hosted tests need librt/libstdc++. Windows-hosted tests link
-        against CMake-built dynamic MSVC libraries, matching CMake's default
-        /MD runtime selection.
+        Linux-hosted tests link librt, libstdc++, and libm explicitly because
+        the host compiler substitution resolves to clang rather than clang++.
+        Windows-hosted tests link against CMake-built dynamic MSVC libraries,
+        matching CMake's default /MD runtime selection.
         """
         if os.name == "nt":
             host_link_flags = " ".join(
@@ -610,7 +611,7 @@ class LitConfigHelper:
                 ]
             )
         else:
-            host_link_flags = "-lrt -lstdc++"
+            host_link_flags = "-lrt -lstdc++ -lm"
         config_obj.substitutions.append(("%host_link_flags", host_link_flags))
 
     @staticmethod

--- a/python/helpers/util.py
+++ b/python/helpers/util.py
@@ -72,10 +72,13 @@ _np_dtype_to_mlir_type_ctor = defaultdict(
         # Index Types
         # Not strictly correct, but numpy casts Python scalars to these types by
         # default, so we map them to index type to support passing lists of ints.
-        np.longlong: T.index,
         np.uintp: T.index,
     },
 )
+
+# np.longlong aliases np.int64 on Windows. Keep the explicit i64 mapping
+# authoritative there while preserving the distinct index mapping elsewhere.
+_np_dtype_to_mlir_type_ctor.setdefault(np.longlong, T.index)
 
 NpuDType = (
     np.int8

--- a/test/npu-xrt/add_multi_arg_runlist/test.cpp
+++ b/test/npu-xrt/add_multi_arg_runlist/test.cpp
@@ -23,7 +23,7 @@
 // run1 (ADDTWO) adds 2, taking run0's three outputs as its three inputs. Final
 // result for a correctly executed in-order chain is input + 3.
 
-constexpr int SIZE = 64;
+constexpr int BUF_SIZE = 64;
 constexpr int LANES = 3;
 
 int main(int argc, const char *argv[]) {
@@ -66,18 +66,18 @@ int main(int argc, const char *argv[]) {
   // Data buffers: 3 inputs to run0, 3 shared (run0 out -> run1 in), 3 outputs.
   std::vector<xrt::bo> bo_in0, bo_mid, bo_out1;
   for (int l = 0; l < LANES; l++) {
-    bo_in0.push_back(xrt::bo(device, SIZE * sizeof(int32_t),
+    bo_in0.push_back(xrt::bo(device, BUF_SIZE * sizeof(int32_t),
                              XRT_BO_FLAGS_HOST_ONLY, kernel0.group_id(3)));
-    bo_mid.push_back(xrt::bo(device, SIZE * sizeof(int32_t),
+    bo_mid.push_back(xrt::bo(device, BUF_SIZE * sizeof(int32_t),
                              XRT_BO_FLAGS_HOST_ONLY, kernel0.group_id(4)));
-    bo_out1.push_back(xrt::bo(device, SIZE * sizeof(int32_t),
+    bo_out1.push_back(xrt::bo(device, BUF_SIZE * sizeof(int32_t),
                               XRT_BO_FLAGS_HOST_ONLY, kernel1.group_id(4)));
   }
 
   // Initialize inputs: lane l holds i + l.
   for (int l = 0; l < LANES; l++) {
     uint32_t *p = bo_in0[l].map<uint32_t *>();
-    for (int i = 0; i < SIZE; i++)
+    for (int i = 0; i < BUF_SIZE; i++)
       p[i] = i + l;
     bo_in0[l].sync(XCL_BO_SYNC_BO_TO_DEVICE);
   }
@@ -121,7 +121,7 @@ int main(int argc, const char *argv[]) {
   for (int l = 0; l < LANES; l++) {
     bo_out1[l].sync(XCL_BO_SYNC_BO_FROM_DEVICE);
     uint32_t *p = bo_out1[l].map<uint32_t *>();
-    for (int i = 0; i < SIZE; i++) {
+    for (int i = 0; i < BUF_SIZE; i++) {
       uint32_t ref = (i + l) + 1 + 2;
       if (p[i] != ref) {
         if (errors < 16)

--- a/test/npu-xrt/dynamic_conditional_passthrough/run.lit
+++ b/test/npu-xrt/dynamic_conditional_passthrough/run.lit
@@ -30,7 +30,7 @@
 // RUN: aie-translate --aie-npu-to-cpp %t.lowered.mlir > %t.gen.h
 //
 // RUN: %host_clang %S/test.cpp -o %t.exe -std=c++17 -Wall \
-// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%t.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%/t.xclbin")' \
 // RUN:   -I%S/../../../include %xrt_flags %host_link_flags %test_utils_flags
 //
 // argv: [n] [do_copy]. Exercise the taken branch (do_copy=1) at a couple of tile

--- a/test/npu-xrt/dynamic_pingpong_passthrough/run.lit
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/run.lit
@@ -32,7 +32,7 @@
 // RUN: aie-translate --aie-npu-to-cpp %t.lowered.mlir > %t.gen.h
 //
 // RUN: %host_clang %S/test.cpp -o %t.exe -std=c++17 -Wall \
-// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%t.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%/t.xclbin")' \
 // RUN:   -I%S/../../../include %xrt_flags %host_link_flags %test_utils_flags
 //
 // The runtime tile count is the last host argument: exercise several values

--- a/test/npu-xrt/dynamic_pingpong_trace/run.lit
+++ b/test/npu-xrt/dynamic_pingpong_trace/run.lit
@@ -29,7 +29,7 @@
 // RUN: aie-translate --aie-npu-to-cpp %t.lowered.mlir > %t.gen.h
 //
 // RUN: %host_clang %S/test.cpp -o %t.exe -std=c++17 -Wall \
-// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%t.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%/t.xclbin")' \
 // RUN:   -I%S/../../../include %xrt_flags %host_link_flags %test_utils_flags
 //
 // The runtime tile count is the host argument; exercise a couple of values.

--- a/test/npu-xrt/local_reset/dma/test.cpp
+++ b/test/npu-xrt/local_reset/dma/test.cpp
@@ -21,7 +21,7 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-constexpr int SIZE = 8;
+constexpr int BUF_SIZE = 8;
 constexpr int DISPATCHES = 8;
 
 int main(int argc, const char *argv[]) {
@@ -42,8 +42,8 @@ int main(int argc, const char *argv[]) {
 
   auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
                           XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
-  auto bo_out = xrt::bo(device, SIZE * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
-                        kernel.group_id(3));
+  auto bo_out = xrt::bo(device, BUF_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
   memcpy(bo_instr.map<void *>(), instr_v.data(), instr_v.size() * sizeof(int));
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
@@ -52,7 +52,7 @@ int main(int argc, const char *argv[]) {
     // Sentinel-fill the output so a hung or partial transfer reads as garbage
     // rather than as a valid (possibly stale-correct) result.
     uint32_t *out = bo_out.map<uint32_t *>();
-    for (int i = 0; i < SIZE; i++)
+    for (int i = 0; i < BUF_SIZE; i++)
       out[i] = 0xdeadbeef;
     bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
@@ -62,7 +62,7 @@ int main(int argc, const char *argv[]) {
       return 1;
     }
     bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-    for (int i = 0; i < SIZE; i++) {
+    for (int i = 0; i < BUF_SIZE; i++) {
       uint32_t want = 100 + i;
       if (out[i] != want) {
         std::cout << "dispatch " << d << " out[" << i << "] = " << out[i]

--- a/test/npu-xrt/matmul_whole_array_dynamic/run.lit
+++ b/test/npu-xrt/matmul_whole_array_dynamic/run.lit
@@ -53,10 +53,10 @@
 // RUN:   %t.1.prj/input_with_addresses.mlir -o %t.1.lowered.mlir
 // RUN: aie-translate --aie-npu-to-cpp %t.1.lowered.mlir > %t.1.gen.h
 // RUN: %host_clang %S/test.cpp -o %t.1.exe -std=c++23 -Wall \
-// RUN:   -DGEN_HDR='"%t.1.gen.h"' -DXCLBIN='std::string("%t.1.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.1.gen.h"' -DXCLBIN='std::string("%/t.1.xclbin")' \
 // RUN:   -I%S/../../../include \
 // RUN:   -I%S/../../../programming_examples/basic/matrix_multiplication \
-// RUN:   %xrt_flags %host_link_flags %test_utils_flags -lm
+// RUN:   %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu2% %t.1.exe 512 512 512
 // RUN: %run_on_npu2% %t.1.exe 256 512 1024
 //
@@ -76,10 +76,10 @@
 // RUN:   %t.2.prj/input_with_addresses.mlir -o %t.2.lowered.mlir
 // RUN: aie-translate --aie-npu-to-cpp %t.2.lowered.mlir > %t.2.gen.h
 // RUN: %host_clang %S/test.cpp -o %t.2.exe -std=c++23 -Wall \
-// RUN:   -DGEN_HDR='"%t.2.gen.h"' -DXCLBIN='std::string("%t.2.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.2.gen.h"' -DXCLBIN='std::string("%/t.2.xclbin")' \
 // RUN:   -I%S/../../../include \
 // RUN:   -I%S/../../../programming_examples/basic/matrix_multiplication \
-// RUN:   %xrt_flags %host_link_flags %test_utils_flags -lm
+// RUN:   %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu2% %t.2.exe 512 512 512
 // RUN: %run_on_npu2% %t.2.exe 256 512 1024
 //
@@ -99,9 +99,9 @@
 // RUN:   %t.4.prj/input_with_addresses.mlir -o %t.4.lowered.mlir
 // RUN: aie-translate --aie-npu-to-cpp %t.4.lowered.mlir > %t.4.gen.h
 // RUN: %host_clang %S/test.cpp -o %t.4.exe -std=c++23 -Wall \
-// RUN:   -DGEN_HDR='"%t.4.gen.h"' -DXCLBIN='std::string("%t.4.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.4.gen.h"' -DXCLBIN='std::string("%/t.4.xclbin")' \
 // RUN:   -I%S/../../../include \
 // RUN:   -I%S/../../../programming_examples/basic/matrix_multiplication \
-// RUN:   %xrt_flags %host_link_flags %test_utils_flags -lm
+// RUN:   %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu2% %t.4.exe 512 512 512
 // RUN: %run_on_npu2% %t.4.exe 768 512 768

--- a/test/npu-xrt/matmul_whole_array_dynamic/run_npu1.lit
+++ b/test/npu-xrt/matmul_whole_array_dynamic/run_npu1.lit
@@ -44,10 +44,10 @@
 // RUN:   %t.1.prj/input_with_addresses.mlir -o %t.1.lowered.mlir
 // RUN: aie-translate --aie-npu-to-cpp %t.1.lowered.mlir > %t.1.gen.h
 // RUN: %host_clang %S/test.cpp -o %t.1.exe -std=c++23 -Wall \
-// RUN:   -DGEN_HDR='"%t.1.gen.h"' -DXCLBIN='std::string("%t.1.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.1.gen.h"' -DXCLBIN='std::string("%/t.1.xclbin")' \
 // RUN:   -I%S/../../../include \
 // RUN:   -I%S/../../../programming_examples/basic/matrix_multiplication \
-// RUN:   %xrt_flags %host_link_flags %test_utils_flags -lm
+// RUN:   %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu1% %t.1.exe 512 512 512
 // RUN: %run_on_npu1% %t.1.exe 256 512 1024
 //
@@ -67,10 +67,10 @@
 // RUN:   %t.2.prj/input_with_addresses.mlir -o %t.2.lowered.mlir
 // RUN: aie-translate --aie-npu-to-cpp %t.2.lowered.mlir > %t.2.gen.h
 // RUN: %host_clang %S/test.cpp -o %t.2.exe -std=c++23 -Wall \
-// RUN:   -DGEN_HDR='"%t.2.gen.h"' -DXCLBIN='std::string("%t.2.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.2.gen.h"' -DXCLBIN='std::string("%/t.2.xclbin")' \
 // RUN:   -I%S/../../../include \
 // RUN:   -I%S/../../../programming_examples/basic/matrix_multiplication \
-// RUN:   %xrt_flags %host_link_flags %test_utils_flags -lm
+// RUN:   %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu1% %t.2.exe 512 512 512
 // RUN: %run_on_npu1% %t.2.exe 256 512 1024
 //
@@ -90,9 +90,9 @@
 // RUN:   %t.4.prj/input_with_addresses.mlir -o %t.4.lowered.mlir
 // RUN: aie-translate --aie-npu-to-cpp %t.4.lowered.mlir > %t.4.gen.h
 // RUN: %host_clang %S/test.cpp -o %t.4.exe -std=c++23 -Wall \
-// RUN:   -DGEN_HDR='"%t.4.gen.h"' -DXCLBIN='std::string("%t.4.xclbin")' \
+// RUN:   -DGEN_HDR='"%t.4.gen.h"' -DXCLBIN='std::string("%/t.4.xclbin")' \
 // RUN:   -I%S/../../../include \
 // RUN:   -I%S/../../../programming_examples/basic/matrix_multiplication \
-// RUN:   %xrt_flags %host_link_flags %test_utils_flags -lm
+// RUN:   %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu1% %t.4.exe 512 512 512
 // RUN: %run_on_npu1% %t.4.exe 768 512 768

--- a/test/npu-xrt/xrt_handle_lifetime/test.cpp
+++ b/test/npu-xrt/xrt_handle_lifetime/test.cpp
@@ -152,8 +152,10 @@ static int run_mode(const cxxopts::ParseResult &vm,
   }
 
   if (mode == "stale-io-bos") {
-    auto io_device = xrt::device(0);
-    auto buffers = make_buffers(device, io_device, *kernel, instr_v);
+    // Isolate BO lifetime from cross-handle ownership: every object belongs to
+    // the same XRT device, while the I/O BOs deliberately outlive the kernel
+    // and hardware context.
+    auto buffers = make_buffers(device, device, *kernel, instr_v);
     initialize_buffers(buffers, instr_v);
 
     int result = run_and_check(*kernel, buffers, instr_v.size());


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Designed to be merge compatible with #3401.

However, please note that this replaces the Windows XFAIL for `matmul_whole_array_dynamic` with a source-level fix.

This addresses the remaining Windows host-side failures not covered by #3401:

- preserve the `np.int64` to `i64` mapping when `np.longlong` aliases it on Windows, without changing the existing `np.uintp` index mapping;
- replace GNU-only `<bits/stdc++.h>` dependencies in the shared matrix multiplication host code with the standard headers and types it actually uses;
- include `libm` in the non-Windows host-link substitution instead of asking Windows clang to resolve `m.lib`; and
- keep `stale-io-bos` focused on BO destruction order by creating the kernel and I/O BOs through the same `xrt::device` handle.

Fixes #3437.

Only the >5-buffer `many_buffers` and `test_jit_many_args.py` failures (#3438) remain outside this change.

## Checklist

- [X] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see `CONTRIBUTING.md`)