### PR TITLE
aie2p: round to nearest even for the bfp16 mmul emulation

### DIFF
--- a/aie_kernels/aie2p/mm.cc
+++ b/aie_kernels/aie2p/mm.cc
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <type_traits>
 
 #define REL_WRITE 0
 #define REL_READ 1
@@ -84,6 +85,21 @@ static inline void matmul_vectorized_2x2_mmul(const T_in *__restrict pA,
   using MMUL = aie::mmul<r, s, t, T_in, T_in, accauto>;
 
   event0();
+
+#ifdef AIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
+  // The bfp16 emulation converts every A and B tile from bf16 to bfp16 before
+  // the MAC, and that conversion follows the core rounding mode. The default
+  // mode is rounding_mode::floor, which rounds toward negative infinity, so
+  // each converted element is biased low and the bias accumulates over the K
+  // reduction rather than cancelling. Select round-to-nearest-even for the
+  // duration of the kernel and restore the caller's mode before returning. Only
+  // the bf16 shapes convert, so the integer shapes keep whatever mode the
+  // caller set.
+  constexpr bool emulated_bf16 = std::is_same_v<T_in, bfloat16>;
+  aie::rounding_mode saved_rounding = aie::rounding_mode::floor;
+  if constexpr (emulated_bf16)
+    saved_rounding = aie::swap_rounding(aie::rounding_mode::conv_even);
+#endif
 
   for (unsigned z = 0; z < rowA; z += 2)
     chess_prepare_for_pipelining chess_loop_range(4, ) {
@@ -206,6 +222,11 @@ static inline void matmul_vectorized_2x2_mmul(const T_in *__restrict pA,
           }
         }
     }
+
+#ifdef AIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
+  if constexpr (emulated_bf16)
+    aie::set_rounding(saved_rounding);
+#endif
 
   event1();
 }


### PR DESCRIPTION
`AIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16` makes `aie::mmul` convert each A and B tile from bf16
to bfp16 before the MAC (`to_v64bfp16ebs8`, in
`third_party/aie_api/include/aie_api/detail/aie2p/mmul_bf16_bf16.hpp`). That conversion follows the
core rounding mode. aie_api documents the default as `rounding_mode::floor`, and neither this
kernel nor aie_api selects anything else, so every converted element rounds toward negative
infinity.

A single rounding is half an ulp. What makes it worth fixing is that it is the same direction every
time, so it does not cancel across the K reduction.

Measured on Strix (npu4), 512x1024x4096 bf16 matmul, 64x32x128 tile, 8 columns, inputs zero-mean
and symmetric, against an fp32 reference computed on the same bf16-rounded inputs. The matmul is
isolated here by using the identity epilogue, so nothing but the MAC path is in the number:

|                  | rel L2 vs fp32 | ms/dispatch |
|------------------|----------------|-------------|
| current          | 9.83e-3        | 0.920       |
| with this change | 7.42e-3        | 0.923       |

End to end, the same kernel serving every GEMM of a 24-layer conformer encoder over 17 real
utterances: mean rel L2 against an fp32 reference goes 0.0891 to 0.0750, wall clock unchanged.

So this is a modest accuracy improvement that costs nothing, not a dramatic one. Two caveats I
would rather state than have you find:

- the size of the gain depends on the input distribution. A same-signed reduction flatters it a lot
  (I first measured 40x with an accidentally all-positive generator, which is not representative and
  is not the number above). Zero-mean data is the honest case and gives ~1.3x.
- end to end the mean improves but the per-utterance max moves the other way, 0.1356 to 0.1996. I do
  not have an explanation for that yet.

### Why in the kernel and not in aie_api

The conversion is aie_api's, so that is arguably where this belongs, and aie_api already has the
idiom in `aie::print` (`utils.hpp`, `swap_rounding` then restore around a `to_vector` on an
overlapping accumulator).

The problem is granularity. In aie_api the conversion sits inside `mac()`/`mul()`, which run in the
innermost loop, so a swap and restore there costs two control register writes per MAC. At kernel
scope it is two per tile, which is why the timing above does not move. If you would rather carry it
in aie_api anyway I am happy to send it there instead, but I did not want to put a register write in
the inner loop without asking first.

### Scope

`aie_kernels/aie2p/mm_bfp_mixed.cc` has the same problem and this patch does not fix it. Its
`to_vector<bfp16ebs8>()` calls are not gated by the emulation macro, so that kernel converts
unconditionally and is always floor-biased. I left it out because I have no bench for that shape and
did not want to ship an unmeasured change beside a measured one. Say the word and I will add it here
or in a follow-up.

The other in-tree `aie::mmul` callers (`conv2dk*`) are int8/uint8 and do not convert, so they are
unaffected.

I restore the caller's mode rather than leaving it set, which differs from `conv2dk*.cc` where
`set_rounding` is called once and never restored. Those kernels own the core for their whole
dispatch; this matmul is composed with an epilogue and with other kernels on the same core, and the
mode is global state, so leaving it changed would silently retune whoever runs next. That is not
hypothetical: an ambient mode set by a neighbouring kernel is how I noticed this at all.
