### PR TITLE
[AIE] LockAnalysis: skip locks that have no ID yet

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -57,6 +57,11 @@ public:
     // go over the locks created for each tile and update the index in
     // locksPerTile
     device.walk([&](LockOp lockOp) {
+      // A lock without an ID does not reserve a particular ID yet, so it does
+      // not make one unavailable here. AIEAssignLockIDs runs later and gives
+      // it one of the IDs still free on the tile.
+      if (!lockOp.getLockID().has_value())
+        return;
       auto tile = lockOp.getTile();
       auto lockID = lockOp.getLockIDValue();
       locksPerTile[{tile, lockID}] = 1;

--- a/test/objectFifo-stateful-transform/base/lock_analysis_unassigned_test.mlir
+++ b/test/objectFifo-stateful-transform/base/lock_analysis_unassigned_test.mlir
@@ -1,0 +1,52 @@
+//===- lock_analysis_unassigned_test.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A lock without an ID is a legal state: aie.lock's lockID is an OptionalAttr and
+// AIEAssignLockIDs exists to fill it in later. LockAnalysis must therefore tolerate one,
+// and must not treat it as reserving an ID. lock_analysis_test.mlir covers the other half
+// (pre-existing locks that DO have IDs are respected).
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" %s | FileCheck %s
+// RUN: aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" --aie-assign-lock-ids %s | FileCheck --check-prefix=ASSIGNED %s
+
+// The unassigned locks reserve nothing, so the objectFifo takes the lowest free IDs on tile(1, 2).
+// CHECK: aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK: aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK: aie.lock(%{{.*}}tile_1_2) {init = 1 : i32, sym_name = "test_prod_lock"}
+// CHECK: aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "test_cons_lock"}
+
+// ...and once AIEAssignLockIDs runs, they get IDs that do not collide with the objectFifo's.
+// ASSIGNED-DAG: aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// ASSIGNED-DAG: aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// ASSIGNED-DAG: aie.lock(%{{.*}}tile_1_2, 2) {init = 1 : i32, sym_name = "test_prod_lock"}
+// ASSIGNED-DAG: aie.lock(%{{.*}}tile_1_2, 3) {init = 0 : i32, sym_name = "test_cons_lock"}
+
+module @lockAnalysisUnassigned {
+   aie.device(xcve2302) {
+      %tile12 = aie.tile(1, 2)
+      %tile33 = aie.tile(3, 3)
+
+      %test_buff = aie.buffer(%tile12) {sym_name = "test_buff"} : memref<16xi32>
+
+      aie.objectfifo @of1 (%tile12, {%tile33}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+      %mem_1_2 = aie.mem(%tile12) {
+         %test_prod_lock = aie.lock(%tile12) {init = 1 : i32, sym_name = "test_prod_lock"}
+         %test_cons_lock = aie.lock(%tile12) {init = 0 : i32, sym_name = "test_cons_lock"}
+         %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
+         ^bb1:
+            %c1_ul1 = arith.constant 1 : i32
+            aie.use_lock(%test_prod_lock, AcquireGreaterEqual, %c1_ul1)
+            aie.dma_bd(%test_buff : memref<16xi32> offset = 0 len = 16)
+            %c1_ul2 = arith.constant 1 : i32
+            aie.use_lock(%test_cons_lock, Release, %c1_ul2)
+            aie.next_bd ^bb1
+         ^bb2:
+            aie.end
+      }
+   }
+}


### PR DESCRIPTION

`aie.lock`'s `lockID` is an `OptionalAttr` and `AIEAssignLockIDs` exists to fill it in later, so a
lock without an ID is a legal state rather than malformed IR. The op's own description spells this
out:

```
    Case when LockID is not assigned:
      Before AIEAssignLockIDs: `%tile33 = aie.tile(3)`
      After AIEAssignLockIDs: `%tile33 = aie.tile(3, $assigned_value)`
```

It is not only a state the ODS permits, it is one this repo's own passes produce.
`AIELowerScratchpadParameters` creates locks with `/*lockID=*/IntegerAttr{}` and says why in a
comment (`lib/Dialect/AIEX/Transforms/AIELowerScratchpadParameters.cpp:170` and `:183`):

```
// create an aie.lock (no lockID; AIEAssignLockIDs will assign one later)
```

`LockAnalysis` in `AIEObjectFifoStatefulTransform` reads the attribute unconditionally, through
`getLockIDValue()`, which is `assert(getLockID().has_value()); return getLockID().value();`. So on a
module that carries an unassigned lock the pass aborts:

```
aie-opt: include/aie/Dialect/AIE/IR/AIEOps.h.inc:
  int xilinx::AIE::LockOp::getLockIDValue():
  Assertion `getLockID().has_value() && "Lock has no ID value"' failed.
```

with a stack trace and no source location. In a release build the assert is gone and the `.value()`
call aborts instead; with exceptions disabled, as the pinned MLIR distro is built, that abort carries
no message at all.

I hit this running `--aie-place-tiles --aie-objectFifo-stateful-transform` over IRON-generated MLIR
to inspect a design's per-tile lock and BD usage. That module has 32 unassigned locks in it, so this
reproduces on unmodified generator output, not on hand-written IR. The workaround is to put
`--aie-assign-lock-ids` first, but the failure presents as a compiler crash rather than as a missing
prerequisite.

### The fix

Skip locks with no ID when recording which IDs a tile has taken. Nothing collides in either pass
order: `AIEAssignLockIDs` recomputes its "assigned" set from a live walk, and every lock this pass
creates already carries a concrete ID, so those land in that set and are never reassigned. Verified
both directions on real binaries.

Note the canonical pipeline (`tools/aiecc/IRTransforms.h`, `getInputWithAddressesPipeline`) runs
`AIEAssignLockIDs` BEFORE this pass, so there no lock is ID-less by the time `LockAnalysis` walks and
the change is a no-op. That is why the severity is low: the crash is reachable when `aie-opt` is
driven directly, which is what I was doing.

This is also how the rest of the codebase reads the attribute. `AIEAssignLockIDs` separates locks
into `assigned` and `unassigned` on exactly this check; the `UsesOneLockInDMABlock` trait guards with
`has_value()` before comparing; and `AIEX::SetLockOp::verify()` returns success early with the
comment "the lockID may not be assigned initially, so lets wait until it is". `LockAnalysis` was the
outlier. Of the other `getLockIDValue()` callers, `AIELowerSetLock` already guards independently;
`AIELocalizeLocks`, `AIERT` and `AIETargetXAIEV2` are all downstream of assignment. I have left them
alone.

### Why diagnose-and-fail is not the right answer here

#3317 made this same pass diagnose unplaced tiles instead of crashing, and `check_errors.mlir` says
"An unplaced logical_tile producer must be diagnosed, not crash the pass". That is the right call for
that case and the wrong one for this, because the two inputs differ in kind. An unplaced
`logical_tile` is invalid input with no defined meaning, so the pass has nothing to do but reject it.
An ID-less lock has a defined meaning, is documented on the op, is produced deliberately by
`AIELowerScratchpadParameters`, and is already tolerated by `SetLockOp::verify()`. Rejecting it would
make this pass stricter than the dialect and stricter than its own verifier.

### Related work

I checked what else is in flight here before writing this, and it is worth stating up front rather
than leaving a reviewer to find it:

- **#3377** ("Remove Lock ID Allocation out of ObjectFIFO pass") deletes `LockAnalysis` outright,
  including the line this patch guards. If that lands, this becomes unnecessary and I am happy for it
  to be closed unmerged. It is a draft, so I am offering this as an interim fix for anyone driving
  `aie-opt` against current main, not as an argument about where lock allocation belongs. Your call
  entirely if you would rather carry the crash until #3377 is ready.
- **#3281** reports the same assertion from a different call site: a lock fabricated inside
  `unrollForLoops` during unrolling, after `LockAnalysis` has already walked. **This patch does not
  fix #3281.** I reproduced that one separately and it still crashes with this applied, now on an
  empty `std::optional<APInt>` at `getStaticTripCount()` rather than on the lock ID, so the assert
  named in that issue no longer matches what a current build produces. #3298 appears to delete that
  line, so I have not touched it.

### Test

`test/objectFifo-stateful-transform/base/lock_analysis_unassigned_test.mlir` is the missing half of
the existing `lock_analysis_test.mlir`, which covers pre-existing locks that DO have IDs. Two RUN
lines, because not crashing is the weaker half of the property:

1. the pass completes and gives the objectFIFO the lowest free IDs on the tile (0 and 1)
2. running `--aie-assign-lock-ids` afterwards assigns the unassigned locks 2 and 3, i.e. no collision

Verified locally against a build of this branch's base: both RUN lines pass, and the rest of
`test/objectFifo-stateful-transform` is unchanged (154 pass; `access_patterns/AIE2_dynamic_locks.mlir`
fails identically with and without this patch, so it is pre-existing at this commit and not something
I have touched).
