### PR TITLE
Windows CI: smoke-test wheels + build via shared build-from-wheels script

### DIFF
--- a/.github/workflows/buildAndTestRyzenAIWindows.yml
+++ b/.github/workflows/buildAndTestRyzenAIWindows.yml
@@ -107,40 +107,24 @@ jobs:
           python -c "import zipfile,glob; zipfile.ZipFile(glob.glob('mlir-*.whl')[0]).extractall('.')"
           if errorlevel 1 exit /b 1
 
-          REM Diagnostic: LLVMExports.cmake references llvm-debuginfod.exe,
-          REM which has previously gone missing post-extraction on this
-          REM runner (possibly quarantined by endpoint security software,
-          REM since it's a symbol-fetching tool that heuristic scanners
-          REM sometimes flag). Fail here with a clear message instead of a
-          REM confusing CMake error deeper in configure.
+          REM llvm-debuginfod.exe has gone missing post-extraction here (likely
+          REM AV quarantine); fail early with a clear message, not a later
+          REM confusing CMake error.
           if not exist "mlir\bin\llvm-debuginfod.exe" (
             echo ##[error]mlir\bin\llvm-debuginfod.exe is missing after wheel extraction - check endpoint security/antivirus quarantine logs on the runner
             dir mlir\bin\llvm-debuginfod* 2>nul
             exit /b 1
           )
 
-          REM The wheel's LLVMExports.cmake bakes in the absolute diaguids.lib
-          REM (DIA SDK) path from whatever VS edition built it (Enterprise),
-          REM which won't exist on this runner (BuildTools). Reuse the repo's
-          REM own fixup to rewrite it to this machine's DIA SDK path.
+          REM LLVMExports.cmake bakes in a diaguids.lib (DIA SDK) path from the
+          REM VS edition that built the wheel; rewrite it for this runner.
           python -c "import sys; sys.path.insert(0, r'..\utils\mlir_aie_wheels\scripts'); from pathlib import Path; import download_mlir; download_mlir._fixup_llvm_diaguids(Path('mlir'))"
           if errorlevel 1 exit /b 1
 
-          REM Mirrors build-mlir-aie-from-wheels.sh: a freshly extracted wheel
-          REM can carry future-dated timestamps (build-time clock skew), which
-          REM makes ninja loop forever re-checking dependencies. Stamp every
-          REM extracted file to a fixed point in the past.
+          REM Future-dated wheel timestamps make ninja loop; stamp them to the past.
           python -c "import os,time; [os.utime(os.path.join(r,f),(315600000,315600000)) for r,_,fs in os.walk('mlir') for f in fs]"
           if errorlevel 1 exit /b 1
           popd
-
-          for /f "usebackq delims=" %%p in (`python -c "import sys; print(sys.executable)"`) do set PYTHON_EXE=%%p
-          for /f "usebackq delims=" %%p in (`python -c "import shutil; print(shutil.which('lit'))"`) do set LIT_EXE=%%p
-          if not defined LIT_EXE exit /b 1
-
-          mkdir build
-          mkdir install
-          pushd build
 
           if not defined PEANO_INSTALL_DIR (
             echo ##[error]PEANO_INSTALL_DIR is not set - ensure the runner is provisioned per the runner setup guide
@@ -159,16 +143,6 @@ jobs:
             exit /b 1
           )
 
-          REM CMake treats backslashes in -D string args as C-style escapes
-          REM (e.g. "\W" isn't valid, and "\a"/"\t"/etc. would be silently
-          REM misinterpreted), so pass every path with forward slashes,
-          REM which CMake accepts natively on Windows.
-          set "CD_FWD=%CD:\=/%"
-          set "PEANO_INSTALL_DIR_FWD=%PEANO_INSTALL_DIR:\=/%"
-          set "XRT_ROOT_FWD=%XRT_ROOT:\=/%"
-          set "PYTHON_EXE_FWD=%PYTHON_EXE:\=/%"
-          set "LIT_EXE_FWD=%LIT_EXE:\=/%"
-
           REM tools/bootgen unconditionally requires OpenSSL (used by aiecc
           REM for in-process PDI generation). Per docs/buildHostWinNative.md
           REM Addendum B.1, this must be the full Win64 OpenSSL package from
@@ -179,30 +153,23 @@ jobs:
             exit /b 1
           )
 
-          cmake .. -G Ninja ^
-            -DCMAKE_PREFIX_PATH="%CD_FWD%/../my_install/mlir" ^
-            -DCMAKE_MODULE_PATH="%CD_FWD%/../cmake/modulesXilinx" ^
-            -DCMAKE_INSTALL_PREFIX="%CD_FWD%/../install" ^
-            -DCMAKE_BUILD_TYPE=Release ^
-            -DLLVM_ENABLE_ASSERTIONS=ON ^
-            -DAIE_ENABLE_BINDINGS_PYTHON=ON ^
-            -DAIE_ENABLE_PYTHON_PASSES=OFF ^
-            -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON ^
-            -DAIE_RUNTIME_TARGETS=x86_64 ^
-            -DAIE_RUNTIME_TEST_TARGET=x86_64 ^
-            -DPEANO_INSTALL_DIR="%PEANO_INSTALL_DIR_FWD%" ^
-            -DXRT_ROOT="%XRT_ROOT_FWD%" ^
-            -DPython3_EXECUTABLE="%PYTHON_EXE_FWD%" ^
-            -DLLVM_EXTERNAL_LIT="%LIT_EXE_FWD%" ^
-            -DOPENSSL_ROOT_DIR="C:/Program Files/OpenSSL-Win64" ^
-            -DOPENSSL_USE_STATIC_LIBS=TRUE
-          if errorlevel 1 exit /b 1
+          for /f "usebackq delims=" %%p in (`python -c "import sys; print(sys.executable)"`) do set PYTHON_EXE=%%p
 
-          ninja
+          REM Build with the same script as the Linux job (one source of truth).
+          REM Wheel is already prepped above, so pass it as arg 1 to skip the
+          REM script's own download. EXTRA_CMAKE_ARGS carries the Windows-only
+          REM -D flags; paths are forward-slashed and space-free (OpenSSL via 8.3
+          REM short name) since the script expands args unquoted.
+          set "XRT_ROOT_FWD=%XRT_ROOT:\=/%"
+          set "PYTHON_EXE_FWD=%PYTHON_EXE:\=/%"
+          set "PEANO_INSTALL_DIR_FWD=%PEANO_INSTALL_DIR:\=/%"
+          for %%I in ("C:\Program Files\OpenSSL-Win64") do set "OPENSSL_ROOT=%%~sI"
+          set "OPENSSL_ROOT_FWD=%OPENSSL_ROOT:\=/%"
+          set "EXTRA_CMAKE_ARGS=-DAIE_ENABLE_PYTHON_PASSES=OFF -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON -DXRT_ROOT=%XRT_ROOT_FWD% -DPython3_EXECUTABLE=%PYTHON_EXE_FWD% -DOPENSSL_ROOT_DIR=%OPENSSL_ROOT_FWD% -DOPENSSL_USE_STATIC_LIBS=TRUE"
+
+          REM arg 4 = provisioned Peano, else the script derives its own.
+          "C:\Program Files\Git\bin\bash.exe" utils/build-mlir-aie-from-wheels.sh my_install/mlir build install "%PEANO_INSTALL_DIR_FWD%"
           if errorlevel 1 exit /b 1
-          ninja install
-          if errorlevel 1 exit /b 1
-          popd
 
       - name: Run tests and examples
         shell: cmd

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -637,8 +637,8 @@ jobs:
     name: Smoke-Test Wheel on Ryzen AI (Windows)
     # Windows analogue of smoke-test-npu: install the same-commit 3.13/RTTI-ON
     # build-windows wheel via iron_setup.py (runtime mode, so the installed
-    # wheel is exercised, not a from-source build) and run a make-free @iron.jit
-    # example on the self-hosted Windows NPU. Only npu2 Windows runners exist.
+    # wheel is exercised, not a from-source build) and run a few @iron.jit
+    # designs on the self-hosted Windows NPU. Only npu2 Windows runners exist.
     # 3.13 matches the runner's pre-provisioned interpreter (docs/buildHostWinNative.md).
     needs: build-windows
     runs-on: [self-hosted, windows, ryzenai, npu2]
@@ -671,11 +671,28 @@ jobs:
           mkdir "%NPU_CACHE_HOME%"
           set XRT_CONTEXT_CACHE_SIZE=2
 
-          REM Make-free @iron.jit example (Windows has no make on PATH).
+          REM A few representative @iron.jit designs: an elementwise kernel, a
+          REM vector-vector op, a reduction, and a 2D data-movement design. Each
+          REM resolves the device via iron.get_current_device(), so they target
+          REM this npu2 runner.
           REM Use the venv interpreter explicitly: bare "python" picked up the
           REM system 3.13, which has no numpy.
           set "IRON_PY=%CD%\ironenv\Scripts\python.exe"
+
+          echo ===== basic/passthrough_kernel =====
           "%IRON_PY%" utils\run_on_npu.py npu2 "%IRON_PY%" programming_examples\basic\passthrough_kernel\passthrough_kernel.py --in1_size 4096
+          if errorlevel 1 exit /b 1
+
+          echo ===== basic/vector_vector_add =====
+          "%IRON_PY%" utils\run_on_npu.py npu2 "%IRON_PY%" programming_examples\basic\vector_vector_add\vector_vector_add.py
+          if errorlevel 1 exit /b 1
+
+          echo ===== basic/vector_reduce_add =====
+          "%IRON_PY%" utils\run_on_npu.py npu2 "%IRON_PY%" programming_examples\basic\vector_reduce_add\vector_reduce_add.py
+          if errorlevel 1 exit /b 1
+
+          echo ===== basic/matrix_scalar_add =====
+          "%IRON_PY%" utils\run_on_npu.py npu2 "%IRON_PY%" programming_examples\basic\matrix_scalar_add\matrix_scalar_add.py
           if errorlevel 1 exit /b 1
 
       - name: Cleanup NPU_CACHE_HOME

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -671,8 +671,21 @@ jobs:
           mkdir "%NPU_CACHE_HOME%"
           set XRT_CONTEXT_CACHE_SIZE=2
 
+          REM TEMP diagnostics: confirm iron_env.cmd activated the venv.
+          echo ----- iron_env.cmd -----
+          type iron_env.cmd
+          echo ------------------------
+          echo VIRTUAL_ENV=%VIRTUAL_ENV%
+          echo PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR%
+          echo XRT_ROOT=%XRT_ROOT%
+          echo NPU2=%NPU2%
+          where python
+
           REM Make-free @iron.jit example (Windows has no make on PATH).
-          python utils\run_on_npu.py npu2 python programming_examples\basic\passthrough_kernel\passthrough_kernel.py --in1_size 4096
+          REM Use the venv interpreter explicitly: bare "python" picked up the
+          REM system 3.13, which has no numpy.
+          set "IRON_PY=%CD%\ironenv\Scripts\python.exe"
+          "%IRON_PY%" utils\run_on_npu.py npu2 "%IRON_PY%" programming_examples\basic\passthrough_kernel\passthrough_kernel.py --in1_size 4096
           if errorlevel 1 exit /b 1
 
       - name: Cleanup NPU_CACHE_HOME

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -585,6 +585,54 @@ jobs:
           path: wheelhouse/repaired_wheel/mlir_aie*whl
           name: mlir_aie_windows_rtti_${{ matrix.ENABLE_RTTI }}-${{ matrix.python_version }}
 
+  smoke-test-wheels-windows:
+    name: Smoke-test wheel (Windows)
+    # Import the build-windows wheel in a clean venv on a toolchain-free runner
+    # (Windows analogue of the Linux venv smoke test). Import-only; NPU runs are
+    # covered by smoke-test-npu.
+    needs: build-windows
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python_version: "3.11"
+            ENABLE_RTTI: ON
+          - python_version: "3.11"
+            ENABLE_RTTI: OFF
+          - python_version: "3.12"
+            ENABLE_RTTI: ON
+          - python_version: "3.12"
+            ENABLE_RTTI: OFF
+          - python_version: "3.13"
+            ENABLE_RTTI: ON
+          - python_version: "3.13"
+            ENABLE_RTTI: OFF
+          - python_version: "3.14"
+            ENABLE_RTTI: ON
+          - python_version: "3.14"
+            ENABLE_RTTI: OFF
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: ${{ matrix.python_version }}
+          allow-prereleases: true
+
+      - name: Download same-commit mlir_aie wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: mlir_aie_windows_rtti_${{ matrix.ENABLE_RTTI }}-${{ matrix.python_version }}
+          path: wheelhouse
+
+      - name: Smoke test wheel in clean venv
+        shell: bash
+        run: |
+          python -m venv /tmp/smoke-venv
+          /tmp/smoke-venv/Scripts/python -m pip install --upgrade pip
+          /tmp/smoke-venv/Scripts/python -m pip install wheelhouse/mlir_aie*whl
+          /tmp/smoke-venv/Scripts/python -c 'import aie.ir; import aie.extras; import aie.helpers'
+
   publish:
     name: Publish wheels
     if: |

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -671,16 +671,6 @@ jobs:
           mkdir "%NPU_CACHE_HOME%"
           set XRT_CONTEXT_CACHE_SIZE=2
 
-          REM TEMP diagnostics: confirm iron_env.cmd activated the venv.
-          echo ----- iron_env.cmd -----
-          type iron_env.cmd
-          echo ------------------------
-          echo VIRTUAL_ENV=%VIRTUAL_ENV%
-          echo PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR%
-          echo XRT_ROOT=%XRT_ROOT%
-          echo NPU2=%NPU2%
-          where python
-
           REM Make-free @iron.jit example (Windows has no make on PATH).
           REM Use the venv interpreter explicitly: bare "python" picked up the
           REM system 3.13, which has no numpy.

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -588,8 +588,8 @@ jobs:
   smoke-test-wheels-windows:
     name: Smoke-test wheel (Windows)
     # Import the build-windows wheel in a clean venv on a toolchain-free runner
-    # (Windows analogue of the Linux venv smoke test). Import-only; NPU runs are
-    # covered by smoke-test-npu.
+    # (Windows analogue of the Linux venv smoke test). Import-only; NPU
+    # execution is covered by smoke-test-wheels-npu-windows below.
     needs: build-windows
     runs-on: windows-2022
     strategy:
@@ -632,6 +632,54 @@ jobs:
           /tmp/smoke-venv/Scripts/python -m pip install --upgrade pip
           /tmp/smoke-venv/Scripts/python -m pip install wheelhouse/mlir_aie*whl
           /tmp/smoke-venv/Scripts/python -c 'import aie.ir; import aie.extras; import aie.helpers'
+
+  smoke-test-wheels-npu-windows:
+    name: Smoke-Test Wheel on Ryzen AI (Windows)
+    # Windows analogue of smoke-test-npu: install the same-commit 3.12/RTTI-ON
+    # build-windows wheel via iron_setup.py (runtime mode, so the installed
+    # wheel is exercised, not a from-source build) and run a make-free @iron.jit
+    # example on the self-hosted Windows NPU. Only npu2 Windows runners exist.
+    needs: build-windows
+    runs-on: [self-hosted, windows, ryzenai, npu2]
+    env:
+      NPU_CACHE_HOME: ${{ github.workspace }}\iron-cache-${{ github.run_id }}
+      PIP_CACHE_DIR: ${{ github.workspace }}\.pip-cache-${{ github.run_id }}
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          submodules: "true"
+
+      - name: Download same-commit mlir_aie wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: mlir_aie_windows_rtti_ON-3.12
+          path: wheelhouse
+
+      - name: Install wheel and run an example on the NPU
+        shell: cmd
+        run: |
+          REM iron_setup --wheelhouse installs the downloaded same-commit wheel
+          REM (runtime env, no --dev), so this exercises the published wheel.
+          python utils\iron_setup.py --wheelhouse wheelhouse
+          if errorlevel 1 exit /b 1
+          call .\iron_env.cmd
+          if errorlevel 1 exit /b 1
+
+          if exist "%NPU_CACHE_HOME%" rmdir /s /q "%NPU_CACHE_HOME%"
+          mkdir "%NPU_CACHE_HOME%"
+          set XRT_CONTEXT_CACHE_SIZE=2
+
+          REM Make-free @iron.jit example (Windows has no make on PATH).
+          python utils\run_on_npu.py npu2 python programming_examples\basic\passthrough_kernel\passthrough_kernel.py --in1_size 4096
+          if errorlevel 1 exit /b 1
+
+      - name: Cleanup NPU_CACHE_HOME
+        if: always()
+        shell: cmd
+        run: |
+          if exist "%NPU_CACHE_HOME%" rmdir /s /q "%NPU_CACHE_HOME%"
+          if exist "%PIP_CACHE_DIR%" rmdir /s /q "%PIP_CACHE_DIR%"
 
   publish:
     name: Publish wheels

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -635,10 +635,11 @@ jobs:
 
   smoke-test-wheels-npu-windows:
     name: Smoke-Test Wheel on Ryzen AI (Windows)
-    # Windows analogue of smoke-test-npu: install the same-commit 3.12/RTTI-ON
+    # Windows analogue of smoke-test-npu: install the same-commit 3.13/RTTI-ON
     # build-windows wheel via iron_setup.py (runtime mode, so the installed
     # wheel is exercised, not a from-source build) and run a make-free @iron.jit
     # example on the self-hosted Windows NPU. Only npu2 Windows runners exist.
+    # 3.13 matches the runner's pre-provisioned interpreter (docs/buildHostWinNative.md).
     needs: build-windows
     runs-on: [self-hosted, windows, ryzenai, npu2]
     env:
@@ -653,7 +654,7 @@ jobs:
       - name: Download same-commit mlir_aie wheel
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: mlir_aie_windows_rtti_ON-3.12
+          name: mlir_aie_windows_rtti_ON-3.13
           path: wheelhouse
 
       - name: Install wheel and run an example on the NPU

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -851,7 +851,7 @@ class LitConfigHelper:
 
         # Let a headless caller force matplotlib's non-interactive backend so
         # taplib visualize()'s plt.show() doesn't block a display-less runner.
-        llvm_config.with_system_environment("MPLBACKEND")
+        llvm_config.with_system_environment(["MPLBACKEND"])
 
         # JIT cache for compiled designs. NPU_CACHE_HOME is the current name;
         # IRON_CACHE_HOME is kept as a no-op safety for any straggler caller.

--- a/utils/build-mlir-aie-from-wheels.sh
+++ b/utils/build-mlir-aie-from-wheels.sh
@@ -19,6 +19,27 @@
 #
 ##===----------------------------------------------------------------------===##
 
+# Windows (Git-for-Windows/MSYS) bash: gate off Linux-only assumptions.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+  *) IS_WINDOWS=0 ;;
+esac
+
+# On Windows rewrite MSYS /c/... to CMake's C:/... form; pass through on Linux.
+winpath() {
+  if [ "$IS_WINDOWS" = "1" ] && [ -n "$1" ]; then cygpath -m "$1"; else printf '%s' "$1"; fi
+}
+
+# Stamp unpacked wheel files to a fixed past time (see below).
+stamp_mlir_past() {
+  if [ "$IS_WINDOWS" = "1" ]; then
+    # find -exec touch blows MSYS's env-block limit; one python pass instead.
+    python -c "import os, pathlib; ts = 1314108314; [os.utime(p, (ts, ts)) for p in pathlib.Path('mlir').rglob('*')]"
+  else
+    find mlir -exec touch -a -m -t 201108231405.14 {} \;
+  fi
+}
+
 if [ "$#" -lt 1 ] || [ -z "$1" ]; then
     VERSION=$(utils/clone-llvm.sh --get-wheel-version)
 
@@ -31,25 +52,25 @@ if [ "$#" -lt 1 ] || [ -z "$1" ]; then
     # freshly unzipped wheel ends up with files whose timestamps are in the
     # future. That makes ninja loop forever when configuring. Stamp them to an
     # arbitrary time in the past to be safe.
-    find mlir -exec touch -a -m -t 201108231405.14 {} \;
+    stamp_mlir_past
     popd
-    WHL_MLIR_DIR=`realpath my_install/mlir`
+    WHL_MLIR_DIR=$(winpath "$(realpath my_install/mlir)")
     echo "WHL_MLIR DIR: $WHL_MLIR_DIR"
 else
-    WHL_MLIR_DIR=`realpath $1`
+    WHL_MLIR_DIR=$(winpath "$(realpath "$1")")
     echo "WHL_MLIR DIR: $WHL_MLIR_DIR"
 fi
 
 BASE_DIR=`realpath $(dirname $0)/..`
-CMAKEMODULES_DIR=$BASE_DIR/cmake
+CMAKEMODULES_DIR=$(winpath "$BASE_DIR/cmake")
 echo "CMAKEMODULES_DIR: $CMAKEMODULES_DIR"
 
 BUILD_DIR=${2:-"build"}
 INSTALL_DIR=${3:-"install"}
-LLVM_ENABLE_RTTI=${LLVM_ENABLE_RTTI:OFF}
+LLVM_ENABLE_RTTI=${LLVM_ENABLE_RTTI:-OFF}
 
 if [ "$#" -ge 4 ]; then
-  PEANO_INSTALL_DIR=`realpath $4`
+  PEANO_INSTALL_DIR=$(winpath "$(realpath "$4")")
   echo "PEANO_INSTALL_DIR DIR: $PEANO_INSTALL_DIR"
   export PEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}
 else
@@ -60,7 +81,7 @@ else
     echo "       Or pass an existing Peano install dir as the 4th argument to this script." >&2
     exit 1
   fi
-  export PEANO_INSTALL_DIR="${PEANO_LOCATION}/llvm-aie"
+  export PEANO_INSTALL_DIR=$(winpath "${PEANO_LOCATION}/llvm-aie")
   echo "PEANO_INSTALL_DIR DIR: $PEANO_INSTALL_DIR"
 fi
 
@@ -72,38 +93,45 @@ cd $BUILD_DIR
 #set -o pipefail
 #set -e
 
-CMAKE_CONFIGS="\
-    -GNinja \
-    -DCMAKE_PREFIX_PATH=${WHL_MLIR_DIR} \
-    -DVITIS_VPP=$(which  v++) \
-    -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/modulesXilinx \
-    -DLLVM_EXTERNAL_LIT=$(which lit) \
-    -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-    -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DAIE_ENABLE_BINDINGS_PYTHON=ON \
-    -DLLVM_ENABLE_RTTI=$LLVM_ENABLE_RTTI \
-    -DAIE_VITIS_COMPONENTS=AIE2;AIE2P \
-    -DAIE_RUNTIME_TARGETS=x86_64 \
-    -DAIE_RUNTIME_TEST_TARGET=x86_64 "
+# Build the -D list as an array so paths with spaces survive as single args.
+CMAKE_CONFIGS=(
+    -GNinja
+    -DCMAKE_PREFIX_PATH="${WHL_MLIR_DIR}"
+    -DCMAKE_MODULE_PATH="${CMAKEMODULES_DIR}/modulesXilinx"
+    -DLLVM_EXTERNAL_LIT="$(winpath "$(which lit)")"
+    -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}"
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+    -DLLVM_ENABLE_ASSERTIONS=ON
+    -DAIE_ENABLE_BINDINGS_PYTHON=ON
+    -DLLVM_ENABLE_RTTI="$LLVM_ENABLE_RTTI"
+    "-DAIE_VITIS_COMPONENTS=AIE2;AIE2P"
+    -DAIE_RUNTIME_TARGETS=x86_64
+    -DAIE_RUNTIME_TEST_TARGET=x86_64
+    -DPEANO_INSTALL_DIR="${PEANO_INSTALL_DIR}"
+)
 
-CMAKE_CONFIGS="${CMAKE_CONFIGS} -DPEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}"
+# Vitis (v++) is Linux-only; skip the flag when it's absent (e.g. Windows).
+if command -v v++ >/dev/null 2>&1; then
+  CMAKE_CONFIGS+=(-DVITIS_VPP="$(winpath "$(which v++)")")
+fi
 
 if [ -x "$(command -v lld)" ]; then
-  CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_USE_LINKER=lld"
+  CMAKE_CONFIGS+=(-DLLVM_USE_LINKER=lld)
 fi
 
 if [ -x "$(command -v ccache)" ]; then
-  CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_CCACHE_BUILD=ON"
+  CMAKE_CONFIGS+=(-DLLVM_CCACHE_BUILD=ON)
 fi
 
 # Allow callers (e.g. CI) to inject additional -D options without editing this
-# script. Appended last so they can override the defaults set above.
+# script. Appended last so they can override the defaults above. Values with
+# spaces can't survive this flat env var; callers must pass space-free paths.
 if [ -n "${EXTRA_CMAKE_ARGS}" ]; then
-  CMAKE_CONFIGS="${CMAKE_CONFIGS} ${EXTRA_CMAKE_ARGS}"
+  read -ra _extra_cmake_args <<< "${EXTRA_CMAKE_ARGS}"
+  CMAKE_CONFIGS+=("${_extra_cmake_args[@]}")
 fi
 
-cmake $CMAKE_CONFIGS .. 2>&1 | tee cmake.log
+cmake "${CMAKE_CONFIGS[@]}" .. 2>&1 | tee cmake.log
 ninja 2>&1 | tee mlir-aie-ninja.log
 ninja install 2>&1 | tee mlir-aie-ninja-install.log
 success=$?


### PR DESCRIPTION
## Motivation

Follow-up to the native-Windows Ryzen AI CI work in #3401. In his approval,
@andrej suggested two future directions:

> Maybe as future direction, we could also
> - add a "smoke-test wheels" job for Windows
> - make the `./utils/build-mlir-aie-from-wheels.sh` script work on Windows as well? (probably very low prio)

This PR implements both. Now that #3401 has merged, this branch is rebased
directly on `main` as 4 focused commits.

## Task 1 — smoke-test-wheels-windows job (done)

Adds a `smoke-test-wheels-windows` job to `buildRyzenWheels.yml` that
`needs: build-windows`. For each `{python_version, ENABLE_RTTI}` matrix
element it:
- runs on a clean GitHub-hosted `windows-2022` runner (no MSVC / vcpkg /
  build toolchain),
- downloads the same-run wheel artifact
  (`mlir_aie_windows_rtti_<RTTI>-<py>`, matching `build-windows`'s upload name),
- creates a clean venv, `pip install`s the wheel, and runs
  `python -c 'import aie.ir; import aie.extras; import aie.helpers'`.

This is the Windows analogue of the existing in-job Linux venv smoke test in
`build-repo` and mirrors `mlirDistro.yml`'s `smoke_test_wheels` job. It is
import-only by design; NPU execution requires the self-hosted runners and stays
on the existing `smoke-test-npu` job. Uses the same pinned action SHAs already
present in the file (`actions/setup-python` v6, `actions/download-artifact`
v8.0.1).

## Task 2 — build-mlir-aie-from-wheels.sh on Windows (done, wired up)

Andrej's second point was to make `utils/build-mlir-aie-from-wheels.sh` work on
Windows. Before this PR, `buildAndTestRyzenAIWindows.yml` hand-inlined its own
copy of the cmake/ninja/install logic while the Linux Ryzen AI job called the
script — two divergent copies of the same build. This PR makes the script
portable **and** switches the Windows workflow to call it, so the build logic
lives in one place.

**1. Make the script portable** — minimal, OS-guarded changes so it runs under
Git-for-Windows bash without regressing Linux (all Windows branches gated on
`case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*)`):
- `winpath()` converts MSYS `/c/...` paths to CMake's mixed `C:/...` form for
  every path-valued `-D` arg (`CMAKE_PREFIX_PATH`, `CMAKE_MODULE_PATH`,
  `LLVM_EXTERNAL_LIT`, `PEANO_INSTALL_DIR`, `VITIS_VPP`). On Linux it is a pure
  pass-through, so Linux behavior is byte-for-byte unchanged.
- `stamp_mlir_past()` replaces the per-file `find -exec touch` (which blows
  MSYS bash's env-block limit on the Windows runner) with a single
  `python os.utime` pass; Linux keeps the original `find` path.
- Skip `-DVITIS_VPP` when `v++` is not on PATH (Vitis is Linux-only).

**2. Wire the Windows workflow to call it** — `buildAndTestRyzenAIWindows.yml`
now invokes `build-mlir-aie-from-wheels.sh` (via Git-for-Windows bash) in place
of its inlined cmake/ninja block (net −22 lines). The Windows-specific wheel
prep (python `zipfile` extract, the `llvm-debuginfod.exe` presence check, and
the `_fixup_llvm_diaguids` DIA-SDK path rewrite) stays inline, then the
already-extracted `mlir` dir is passed as arg 1 so the script skips its own
download. Windows-only `-D` options (`XRT_ROOT`, `Python3_EXECUTABLE`,
`OPENSSL_ROOT_DIR`+static, XRT python bindings, python-passes off) are passed
through `EXTRA_CMAKE_ARGS` — forward-slashed and space-free (OpenSSL via its 8.3
short path) so the script's unquoted arg expansion doesn't split them; the
provisioned Peano is passed as arg 4.

The script is therefore now **exercised end-to-end on real hardware** by the
self-hosted Windows Ryzen AI job, not just groundwork.

### Notes
- `lld`/`ccache` branches in the script only fire when those tools are on PATH;
  they are absent on the current Windows runner, so they stay no-ops there.

## Test plan
- [x] `smoke-test-wheels-windows` passes on CI for all py/RTTI matrix elements
- [x] Downloaded artifact name matches `build-windows`'s upload name
- [x] Windows Ryzen AI job (self-hosted) builds green via the script and the
      full lit suite still passes on the NPU (equivalent to the pre-rewire
      inline build)
- [x] Linux Ryzen AI job still builds via the script unchanged (no regression
      from the `uname`-gated edits)

Refs #3401

