### PR TITLE
docs: fix strict mkdocs build broken by IRON Runtime rework (#3387)

### DIFF
--- a/docs/api/iron.md
+++ b/docs/api/iron.md
@@ -184,3 +184,7 @@ Lower-level runtime task types scheduled by the
 ::: iron.runtime.dmatask
     options:
       show_root_heading: false
+
+::: iron.runtime.dmataskhandle
+    options:
+      show_root_heading: false

--- a/programming_guide/README.md
+++ b/programming_guide/README.md
@@ -143,7 +143,7 @@ The vocabulary IRON and this documentation use, grouped by topic. Where a term m
 | [**TensorAccessPattern (TAP)**](../docs/api/taplib.md) | A description of how a tensor is sliced and streamed to/from the NPU across multiple DMA transfers. Passed as `tap=` to `fifo.fill()` / `fifo.drain()`. |
 | [**Flow**](../docs/api/iron.md#iron.dataflow.flow.Flow) / [**PacketFlow**](../docs/api/iron.md#iron.dataflow.flow.PacketFlow) | Lower-level explicit-routing primitives: `Flow` for circuit-switched routes, `PacketFlow` for packet-switched routes with caller-controlled packet IDs. |
 | [**TileDma**](../docs/api/iron.md#iron.dataflow.tile_dma.TileDma) | A lower-level explicit per-tile DMA program, used when the ObjectFifo abstraction hides too much. |
-| [**Runtime sequence**](../docs/api/iron.md#iron.runtime.runtime.Runtime.sequence) | The sequence body passed to `Runtime(seq, inputs, fn_args)` in which `fill` / `drain` operations are declared. |
+| [**Runtime sequence**](../docs/api/iron.md#iron.runtime.runtime.Runtime) | The sequence body passed to `Runtime(seq, inputs, fn_args)` in which `fill` / `drain` operations are declared. |
 
 ### Compilation
 

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -740,8 +740,7 @@ class ObjectFifoHandle(Resolvable):
         """Fill this producer ObjectFifo with data from the ``source`` runtime buffer.
 
         Call from within a [`Runtime`][iron.Runtime] sequence body on a producer
-        handle. See [`_emit_transfer`][iron.dataflow.objectfifo.ObjectFifoHandle._emit_transfer]
-        for the shared arguments; returns a
+        handle. See ``_emit_transfer`` for the shared arguments; returns a
         [`Task`][iron.runtime.dmataskhandle.Task] handle to the transfer.
         """
         if not self._is_prod:
@@ -778,8 +777,7 @@ class ObjectFifoHandle(Resolvable):
         """Drain this consumer ObjectFifo, writing data to the ``dest`` runtime buffer.
 
         Call from within a [`Runtime`][iron.Runtime] sequence body on a consumer
-        handle. See [`_emit_transfer`][iron.dataflow.objectfifo.ObjectFifoHandle._emit_transfer]
-        for the shared arguments; returns a
+        handle. See ``_emit_transfer`` for the shared arguments; returns a
         [`Task`][iron.runtime.dmataskhandle.Task] handle to the transfer.
         """
         if self._is_prod:

--- a/python/iron/runtime/dmatask.py
+++ b/python/iron/runtime/dmatask.py
@@ -52,9 +52,14 @@ class DMATask(RuntimeTask):
                 downstream packet-switched routing (e.g. ObjectFifos
                 lowered with `--packet-sw-objFifos` or an explicit
                 [`PacketFlow`][iron.PacketFlow]). Defaults to None.
-            sizes/strides/offset/transfer_len (optional): Explicit access-pattern
-                operands whose entries may be runtime SSA values. Used instead of
+            sizes (optional): Explicit access-pattern sizes whose entries may be
+                runtime SSA values. Used instead of ``tap`` for the dynamic path.
+            strides (optional): Explicit access-pattern strides, paired with
+                ``sizes``. Used instead of ``tap`` for the dynamic path.
+            offset (optional): Explicit access-pattern offset. Used instead of
                 ``tap`` for the dynamic path.
+            transfer_len (optional): Explicit access-pattern transfer length.
+                Used instead of ``tap`` for the dynamic path.
         """
         if tap is not None and any(
             v is not None for v in (sizes, strides, offset, transfer_len)

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -61,8 +61,8 @@ class ActiveSequence:
 
     The body's data-movement verbs (``fifo.fill``/``fifo.drain``) and
     ``TaskGroup`` reach this object through the active-sequence ContextVar
-    (see [`_context`][iron.runtime._context]) rather than a threaded ``rt``
-    reference, so the body signature carries only the runtime buffers.
+    (see ``_context``) rather than a threaded ``rt`` reference, so the body
+    signature carries only the runtime buffers.
 
     The body runs exactly once, inside the ``runtime_sequence`` op: each verb
     both binds its ObjectFifo's shim endpoint and emits the shim DMA. The DMA
@@ -156,15 +156,14 @@ class ActiveSequence:
 
 
 class Runtime(Resolvable):
-    """The host-side sequence of data-movement and worker-start operations that
-    execute an IRON design.
+    """The host-side sequence of data-movement operations that execute an
+    IRON design.
 
     A Runtime describes what the host does at runtime: filling input
     [`ObjectFifo`][iron.ObjectFifo]s with data and draining results back to host
-    buffers. The sequence is a callback registered with
-    [`sequence`][iron.runtime.runtime.Runtime.sequence]; its body reads the
-    runtime buffers as parameters and moves data with ``fifo.fill(...)`` /
-    ``fifo.drain(...)``.
+    buffers. The sequence is the ``seq_fn`` callback passed to the
+    constructor; its body reads the runtime buffers as parameters and moves
+    data with ``fifo.fill(...)`` / ``fifo.drain(...)``.
     """
 
     def __init__(
@@ -305,9 +304,15 @@ class Runtime(Resolvable):
         runtime endpoint -- including those on link siblings -- is already bound.
 
         Args:
-            trace_size/reuse_output_buffer/egress_shim_col: Forwarded from
+            trace_size: Forwarded from
                 [`Program.enable_trace`][iron.program.Program.enable_trace]; see
-                there. ``trace_size`` of ``None``/``0`` disables tracing.
+                there. ``None``/``0`` disables tracing.
+            reuse_output_buffer: Forwarded from
+                [`Program.enable_trace`][iron.program.Program.enable_trace]; see
+                there.
+            egress_shim_col: Forwarded from
+                [`Program.enable_trace`][iron.program.Program.enable_trace]; see
+                there.
             load_pdi_device_ref: On the full-ELF path (no xclbin configures the
                 device), the device symbol to load via ``npu_load_pdi`` as the
                 first op in the sequence. ``None`` on the xclbin path.


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

PR #3387 (IRON Runtime rework) broke the "Generate GitHub Pages" workflow's strict `mkdocs build` — it's been failing on every push to `main` since. The rework renamed `Runtime.sequence` away and left a few dead doc cross-references and malformed docstring param lists that `mkdocs build --strict` treats as fatal.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
