### PR TITLE
[AIE] getTargetModel: reject an unknown AIEDevice instead of answering VC1902

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -239,7 +239,13 @@ const AIETargetModel &xilinx::AIE::getTargetModel(AIEDevice device) {
   case AIEDevice::npu2_7col:
     return NPU2model7col;
   }
-  return VC1902model;
+  // The switch above is exhaustive over AIEDevice, so no default: -- that keeps
+  // -Wswitch reporting a newly added device. A value outside the enum can still
+  // arrive through the C API, which casts an unchecked uint32_t
+  // (aieGetTargetModel), so fail loudly rather than silently answering with an
+  // unrelated device family.
+  llvm::report_fatal_error("getTargetModel: unknown AIEDevice value " +
+                           llvm::Twine(static_cast<uint32_t>(device)));
 }
 
 // Walk the operation hierarchy until we find a containing TileElement.

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -239,11 +239,9 @@ const AIETargetModel &xilinx::AIE::getTargetModel(AIEDevice device) {
   case AIEDevice::npu2_7col:
     return NPU2model7col;
   }
-  // The switch above is exhaustive over AIEDevice, so no default: -- that keeps
-  // -Wswitch reporting a newly added device. A value outside the enum can still
-  // arrive through the C API, which casts an unchecked uint32_t
-  // (aieGetTargetModel), so fail loudly rather than silently answering with an
-  // unrelated device family.
+  // No default: label above, so -Wswitch still reports a newly added device.
+  // This handles values that are not enumerators at all, which
+  // aieGetTargetModel admits by casting an unchecked uint32_t.
   llvm::report_fatal_error("getTargetModel: unknown AIEDevice value " +
                            llvm::Twine(static_cast<uint32_t>(device)));
 }

--- a/test/CppTests/CMakeLists.txt
+++ b/test/CppTests/CMakeLists.txt
@@ -8,9 +8,11 @@ include(CTest)
 
 add_executable(target_model  target_model.cpp)
 add_executable(target_model_rtti  target_model_rtti.cpp)
+add_executable(target_model_unknown_device  target_model_unknown_device.cpp)
 add_executable(register_database  register_database.cpp)
 add_test(NAME TargetModel COMMAND target_model)
 add_test(NAME TargetModelRtti COMMAND target_model_rtti)
+add_test(NAME TargetModelUnknownDevice COMMAND target_model_unknown_device)
 add_test(NAME RegisterDatabase COMMAND register_database WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Exercises the uint16 fallback path of test_utils::bfloat16_t on every
@@ -27,7 +29,7 @@ add_test(NAME Bfloat16Fallback COMMAND bfloat16_fallback_test)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
-set(EXECUTABLES target_model target_model_rtti register_database)
+set(EXECUTABLES target_model target_model_rtti target_model_unknown_device register_database)
 
 add_custom_target(check-aie-cpp COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${EXECUTABLES} bfloat16_fallback_test)
 

--- a/test/CppTests/target_model_unknown_device.cpp
+++ b/test/CppTests/target_model_unknown_device.cpp
@@ -1,0 +1,49 @@
+//===- target_model_unknown_device.cpp --------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// getTargetModel() used to fall out of its switch and return the VC1902 model
+// for any value outside AIEDevice, so a bad device silently answered with an
+// unrelated device family instead of failing. aieGetTargetModel() casts an
+// unchecked uint32_t, so such a value is reachable from the C API and from the
+// Python get_target_model() binding built on it.
+//
+// report_fatal_error would abort the process, which CTest reports as a failure
+// regardless of PASS_REGULAR_EXPRESSION, so intercept it with a fatal-error
+// handler and check the message in-process. That keeps this a plain exit-status
+// test like its siblings here, and keeps it portable to MSVC.
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include <cstdlib>
+
+using namespace xilinx;
+
+static void expectUnknownDevice(void *, const char *reason, bool) {
+  // Exit from the handler: returning from it lets report_fatal_error abort.
+  std::exit(llvm::StringRef(reason).contains("unknown AIEDevice value 16") ? 0
+                                                                          : 1);
+}
+
+int main() {
+  llvm::install_fatal_error_handler(expectUnknownDevice);
+
+  // One past the last enumerator (npu2_7col). Deriving the value from the
+  // enumerator keeps the test out of range as devices are added. Zero is out of
+  // range too -- the cases start at 1 -- so a default-initialized device value
+  // reaches this path as well.
+  auto bad = static_cast<AIE::AIEDevice>(
+      static_cast<int>(AIE::AIEDevice::npu2_7col) + 1);
+  AIE::getTargetModel(bad);
+
+  // Only reached if getTargetModel returned a model for an unknown device,
+  // which is the regression under test.
+  return 1;
+}

--- a/test/CppTests/target_model_unknown_device.cpp
+++ b/test/CppTests/target_model_unknown_device.cpp
@@ -5,16 +5,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-// getTargetModel() used to fall out of its switch and return the VC1902 model
-// for any value outside AIEDevice, so a bad device silently answered with an
-// unrelated device family instead of failing. aieGetTargetModel() casts an
-// unchecked uint32_t, so such a value is reachable from the C API and from the
-// Python get_target_model() binding built on it.
+// getTargetModel(AIEDevice) used to answer an out-of-range device with the
+// VC1902 model instead of failing. Reachable from Python, since
+// aieGetTargetModel() casts an unchecked uint32_t.
 //
-// report_fatal_error would abort the process, which CTest reports as a failure
-// regardless of PASS_REGULAR_EXPRESSION, so intercept it with a fatal-error
-// handler and check the message in-process. That keeps this a plain exit-status
-// test like its siblings here, and keeps it portable to MSVC.
+// Checked through a fatal-error handler, not CTest's PASS_REGULAR_EXPRESSION,
+// which does not override the failure CTest reports for a signal-aborted child.
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
@@ -27,23 +23,17 @@
 using namespace xilinx;
 
 static void expectUnknownDevice(void *, const char *reason, bool) {
-  // Exit from the handler: returning from it lets report_fatal_error abort.
-  std::exit(llvm::StringRef(reason).contains("unknown AIEDevice value 16") ? 0
-                                                                          : 1);
+  bool named = llvm::StringRef(reason).contains("unknown AIEDevice value 0");
+  // Returning from the handler would let report_fatal_error abort.
+  std::exit(named ? 0 : 1);
 }
 
 int main() {
   llvm::install_fatal_error_handler(expectUnknownDevice);
 
-  // One past the last enumerator (npu2_7col). Deriving the value from the
-  // enumerator keeps the test out of range as devices are added. Zero is out of
-  // range too -- the cases start at 1 -- so a default-initialized device value
-  // reaches this path as well.
-  auto bad = static_cast<AIE::AIEDevice>(
-      static_cast<int>(AIE::AIEDevice::npu2_7col) + 1);
-  AIE::getTargetModel(bad);
+  // 0 stays out of range whatever devices are added: the enumerators start
+  // at 1. It is also what a default-initialized device carries.
+  AIE::getTargetModel(static_cast<AIE::AIEDevice>(0));
 
-  // Only reached if getTargetModel returned a model for an unknown device,
-  // which is the regression under test.
-  return 1;
+  return 1; // Only reached if an unknown device resolved to a model.
 }


### PR DESCRIPTION
## Root cause

`getTargetModel(AIEDevice)` switches over all 15 enumerators and then ends with:

```c++
  case AIEDevice::npu2_7col:
    return NPU2model7col;
  }
  return VC1902model;
```

The switch is exhaustive, so `-Wswitch` stays quiet and the trailing `return` is dead for every
valid enumerator. It is live for anything that is not an enumerator at all, and it answers with a
different device family -- Versal VC1902, 50 columns x 9 rows -- rather than reporting an error.

## Why it is reachable

The enum is not the only entry point. `aieGetTargetModel` casts a raw `uint32_t`:

```c++
AieTargetModel aieGetTargetModel(uint32_t device) {
  return wrap(
      xilinx::AIE::getTargetModel(static_cast<xilinx::AIE::AIEDevice>(device)));
}
```

`python/AIEMLIRModule.cpp` binds that as `aie.dialects.aie.get_target_model`, and
`python/iron/device/device.py` passes its `device` parameter straight through. So an out-of-range
device integer yields VC1902 column and row counts instead of raising.

`AIEDevice` values run 1..15 contiguously, so both `0` and anything above `15` land here. Zero is
the value a default-initialized device carries.

## Fix

Replace the silent fallback with `llvm::report_fatal_error`, naming the offending value.
`report_fatal_error` is already the idiom in this file (four existing call sites).

No `default:` label is added. Keeping the switch exhaustive is what makes `-Wswitch` report a newly
added device, which is a separate and useful signal; the fallthrough exists only for values that are
not enumerators, and those cannot be covered by a case label anyway.

## Evidence

New `test/CppTests/target_model_unknown_device.cpp`, alongside the existing `target_model.cpp` /
`target_model_rtti.cpp`. It installs a fatal-error handler and checks the message in-process, so it
stays a plain exit-status test like its siblings.

A first version asserted the abort with CTest's `PASS_REGULAR_EXPRESSION` instead. That does not
work: CTest reports a signal-terminated child as `Subprocess aborted` and fails the test regardless
of the property. The handler approach also keeps this portable to MSVC.

```
$ ctest --test-dir build/test/CppTests
    Start 1: TargetModel                    Passed
    Start 2: TargetModelRtti                Passed
    Start 3: TargetModelUnknownDevice       Passed
    Start 4: RegisterDatabase               Passed
    Start 5: Bfloat16Fallback               Passed
100% tests passed out of 5
```

Reverting only the `AIEDialect.cpp` hunk and rebuilding makes the new test exit 1, so it fails on
the unfixed compiler rather than passing either way.

## What this does not change

`getTargetModel(Operation *)` keeps its documented VCK190 fallback for an op with no enclosing
`AIETarget` -- that one is deliberate and marked "for backward compatibility". Only the `AIEDevice`
overload changes.
