### PR TITLE
[python] JIT cache: validate a recorded dependency manifest

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -73,6 +73,7 @@ declare_mlir_python_sources(AIEPythonSources.Utils
     utils/compile/jit/_dma_size_parser.py
     utils/compile/jit/_hash.py
     utils/compile/jit/_introspect.py
+    utils/compile/jit/_manifest.py
     utils/compile/jit/_serialization.py
     utils/compile/jit/markers.py
     utils/compile/jit/context.py

--- a/python/utils/compile/jit/_manifest.py
+++ b/python/utils/compile/jit/_manifest.py
@@ -1,0 +1,183 @@
+"""Recorded dependency manifest for the JIT cache.
+
+The cache key cannot know a design's kernel sources: they are registered while
+MLIR is generated, which happens after the key is computed and not at all on a
+hit. So instead of predicting inputs, record the ones a build actually consumed
+and check them on the next lookup.
+
+**Peano only.** Inputs are recorded when every kernel in the design was compiled
+by Peano, because Peano is asked for a depfile and so reports exactly which files
+it opened. The Chess front-end is driven through ``xchesscc_wrapper`` and emits
+nothing equivalent, so for a Chess design the consumed set is unknowable from
+here. Recording a set that is silently short would read as verified and is worse
+than recording nothing.
+
+Such a build still writes a manifest, marked ``complete: false``. That is not the
+same as a manifest with no inputs -- a design that genuinely consumes nothing
+records ``complete: true`` and an empty list, and is checked like any other. The
+distinction matters because the two must behave differently: an unverifiable
+design has to keep the cache behaviour it had before this file existed, whereas
+writing nothing at all would make every lookup discard the entry and rebuild,
+which is strictly worse than the status quo it is meant to preserve.
+
+Everything here fails closed: an absent, unparsable or partial manifest is a
+miss. Where a build path cannot report its inputs, the manifest says so rather
+than claiming a check it did not perform.
+
+**Known limits.** Two paths fail open rather than closed -- they can report a
+valid entry that is actually stale -- so they are worth knowing before relying
+on this. Both are shared with ccache and neither is fixable by recording inputs
+more carefully, because in both cases the recorded inputs are genuinely
+unchanged.
+
+1. *Include resolution.* Only files the compiler opened are recorded. A file
+   that later appears earlier in the ``-I`` search order and shadows a recorded
+   header changes what the next compile would resolve, while every recorded
+   input still matches.
+
+2. *Size and mtime agreement.* ``is_valid`` skips the digest when both size and
+   mtime match a record. An edit that preserves byte count, after something has
+   reset mtimes -- a fresh clone, a checkout, an extracted archive -- therefore
+   reads as unchanged. The digest is what catches a same-size edit; this
+   shortcut is what makes the common case cheap.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_NAME = "deps.json"
+_VERSION = 1
+
+
+def _digest(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _entry(path: Path) -> dict:
+    st = path.stat()
+    return {
+        "path": str(path),
+        "size": st.st_size,
+        "mtime": st.st_mtime,
+        "sha256": _digest(path),
+    }
+
+
+def _parse_depfile(depfile: Path) -> list[Path]:
+    """Read a make-style depfile: 'target: a b \\\n  c d'."""
+    text = depfile.read_text()
+    _, _, rhs = text.partition(":")
+    return [Path(tok) for tok in rhs.replace("\\\n", " ").split() if tok.strip()]
+
+
+def record(kernel_dir, external_kernels, source_files, used_chess=False) -> None:
+    """Record the inputs this build consumed, if they can be known exactly.
+
+    Every kernel compiled through Peano leaves a depfile naming what the
+    compiler actually opened.  A kernel compiled any other way -- today, the
+    Chess path, which takes no -MD -- leaves none, and its includes are
+    therefore unknown.  Rather than record a set that is silently short, mark
+    the manifest ``complete: false``: the entry stays usable, so such a design
+    keeps exactly the behaviour it has now, but nothing claims it was checked.
+    """
+    kernel_dir = Path(kernel_dir)
+    compiled = [
+        f
+        for f in external_kernels
+        if getattr(f, "_source_file", None) or getattr(f, "_source_string", None)
+    ]
+    depfiles = list(kernel_dir.glob("*.d"))
+    if used_chess or (compiled and not depfiles):
+        logger.debug(
+            "cache manifest: %d kernel(s) compiled without a depfile; recording "
+            "an incomplete manifest, inputs will not be checked",
+            len(compiled),
+        )
+        _write(kernel_dir, [], complete=False)
+        return
+
+    found: set[Path] = set()
+    for dep in depfiles:
+        try:
+            found.update(_parse_depfile(dep))
+        except OSError:
+            return  # cannot know the set -> do not claim one
+    for f in compiled:
+        if getattr(f, "_source_file", None):
+            found.add(Path(f._source_file))
+    found.update(Path(sf) for sf in source_files)
+    _write(kernel_dir, sorted({p for p in found if p.is_file()}, key=str))
+
+
+def _write(kernel_dir: Path, inputs: list[Path], complete: bool = True) -> None:
+    payload = {"version": _VERSION, "complete": complete, "inputs": []}
+    for path in inputs:
+        try:
+            payload["inputs"].append(_entry(path))
+        except OSError:
+            # An input we cannot record is an input we cannot verify.  Refuse to
+            # write a manifest that would later read as complete.
+            logger.warning("cache manifest: %s unreadable; not recording", path)
+            return
+    tmp = Path(kernel_dir) / (MANIFEST_NAME + ".tmp")
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, Path(kernel_dir) / MANIFEST_NAME)
+
+
+def write_for_test(kernel_dir, inputs) -> None:
+    """Write a manifest directly. For tests that fabricate a cache entry."""
+    _write(Path(kernel_dir), [Path(i) for i in inputs])
+
+
+def is_valid(kernel_dir: Path) -> bool:
+    """True only if every recorded input is still exactly as recorded.
+
+    Fails closed: a missing, unparsable or partial manifest is a miss, never a
+    hit.  Anything this cannot verify, it does not trust.
+
+    The one exception is a manifest that declares itself incomplete, which is
+    how a build path that cannot report its inputs (today, Chess) records
+    itself.  There is nothing to check, so this reports the entry usable and
+    leaves it exactly as cacheable as it was before manifests existed.  Treating
+    it as a miss would be worse than the status quo, not safer: the caller
+    discards the directory on a miss, so every lookup would wipe a valid entry
+    and rebuild it.
+    """
+    path = Path(kernel_dir) / MANIFEST_NAME
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return False
+    if payload.get("version") != _VERSION:
+        return False
+    if not payload.get("complete", True):
+        logger.debug(
+            "cache manifest: %s records no verifiable inputs; not checking", path
+        )
+        return True
+    for rec in payload.get("inputs", ()):
+        f = Path(rec["path"])
+        try:
+            st = f.stat()
+        except OSError:
+            return False
+        # tsbuildinfo pattern: size+mtime agree -> trust it, skip the hash.
+        if st.st_size == rec["size"] and st.st_mtime == rec["mtime"]:
+            continue
+        try:
+            if _digest(f) != rec["sha256"]:
+                return False
+        except OSError:
+            return False
+    return True

--- a/python/utils/compile/jit/_manifest.py
+++ b/python/utils/compile/jit/_manifest.py
@@ -1,3 +1,8 @@
+# _manifest.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
 """Recorded dependency manifest for the JIT cache.
 
 The cache key cannot know a design's kernel sources: they are registered while
@@ -20,9 +25,18 @@ design has to keep the cache behaviour it had before this file existed, whereas
 writing nothing at all would make every lookup discard the entry and rebuild,
 which is strictly worse than the status quo it is meant to preserve.
 
-Everything here fails closed: an absent, unparsable or partial manifest is a
-miss. Where a build path cannot report its inputs, the manifest says so rather
-than claiming a check it did not perform.
+Everything here fails closed: an absent, unparsable, misshapen or partial
+manifest is a miss. A manifest is checked for shape rather than trusted, since a
+lookup that raises on a corrupt one fails neither open nor closed.
+
+Where a build path cannot report its inputs, the manifest says so -- an
+unreadable depfile and an undigestable input both record ``complete: false``,
+never nothing at all. Unverifiable is not uncacheable.
+
+Recorded paths are absolute: an entry is written by one process and checked by
+another that need not share a working directory. Depfile tokens anchor against
+``kernel_dir`` (the cwd Peano runs in, so what their relative paths mean),
+declared sources against the caller's cwd.
 
 **Known limits.** Two paths fail open rather than closed -- they can report a
 valid entry that is actually stale -- so they are worth knowing before relying
@@ -40,6 +54,12 @@ unchanged.
    reset mtimes -- a fresh clone, a checkout, an extracted archive -- therefore
    reads as unchanged. The digest is what catches a same-size edit; this
    shortcut is what makes the common case cheap.
+
+   No clock reset is needed for this to bite: two same-size writes inside one
+   timestamp tick are indistinguishable, and the tick belongs to the
+   filesystem. On NFS it can be a whole second, and the client attribute cache
+   may serve a stale size and mtime for ``acregmax`` on top. ``ccache`` gates
+   the same shortcut behind ``sloppiness``.
 """
 
 from __future__ import annotations
@@ -74,11 +94,65 @@ def _entry(path: Path) -> dict:
     }
 
 
+def _absolute(base: Path, path: Path) -> Path:
+    """Anchor a possibly-relative path against `base`, keeping symlinks intact.
+
+    Lexical, not ``resolve()``: keeping the path the compiler opened means
+    repointing a symlink is caught, since stat and the digest follow the link.
+    """
+    return Path(os.path.normpath(base / path))
+
+
 def _parse_depfile(depfile: Path) -> list[Path]:
-    """Read a make-style depfile: 'target: a b \\\n  c d'."""
+    """Read a make-style depfile: 'target: a b \\\n  c d'.
+
+    Make quoting is undone rather than split through: a space arrives as ``\\ ``
+    and a dollar as ``$$``, so splitting on bare whitespace would turn one real
+    dependency into two tokens naming no file -- and those are dropped, leaving
+    a manifest silently short while still calling itself complete.
+    """
     text = depfile.read_text()
-    _, _, rhs = text.partition(":")
-    return [Path(tok) for tok in rhs.replace("\\\n", " ").split() if tok.strip()]
+    tokens: list[str] = []
+    current: list[str] = []
+    past_target = False
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if c == "\\" and i + 1 < len(text):
+            nxt = text[i + 1]
+            if nxt == "\n":  # line continuation: a separator
+                i += 2
+                if current:
+                    tokens.append("".join(current))
+                    current = []
+                continue
+            if nxt in " #":  # escaped: the character itself
+                current.append(nxt)
+                i += 2
+                continue
+            current.append(c)  # lone backslash: a path separator, not quoting
+            i += 1
+            continue
+        if c == "$" and text[i : i + 2] == "$$":
+            current.append("$")
+            i += 2
+            continue
+        if not past_target and c == ":":
+            past_target = True
+            current = []
+            i += 1
+            continue
+        if c.isspace():
+            if current:
+                tokens.append("".join(current))
+                current = []
+            i += 1
+            continue
+        current.append(c)
+        i += 1
+    if current:
+        tokens.append("".join(current))
+    return [Path(tok) for tok in tokens] if past_target else []
 
 
 def record(kernel_dir, external_kernels, source_files, used_chess=False) -> None:
@@ -110,26 +184,44 @@ def record(kernel_dir, external_kernels, source_files, used_chess=False) -> None
     found: set[Path] = set()
     for dep in depfiles:
         try:
-            found.update(_parse_depfile(dep))
+            # Peano runs with cwd=kernel_dir, so that is what a relative token means.
+            found.update(_absolute(kernel_dir, p) for p in _parse_depfile(dep))
         except OSError:
-            return  # cannot know the set -> do not claim one
+            # Unknowable, as for Chess. Writing nothing would instead read as a
+            # miss, and the caller answers a miss by discarding the entry.
+            logger.debug(
+                "cache manifest: %s could not be read; recording an incomplete "
+                "manifest, inputs will not be checked",
+                dep,
+            )
+            _write(kernel_dir, [], complete=False)
+            return
+
+    # Declared paths are the caller's, read where the caller stands -- the same
+    # reading compile_external_kernel gives them.
+    cwd = Path.cwd()
     for f in compiled:
         if getattr(f, "_source_file", None):
-            found.add(Path(f._source_file))
-    found.update(Path(sf) for sf in source_files)
+            found.add(_absolute(cwd, Path(f._source_file)))
+    found.update(_absolute(cwd, Path(sf)) for sf in source_files)
     _write(kernel_dir, sorted({p for p in found if p.is_file()}, key=str))
 
 
 def _write(kernel_dir: Path, inputs: list[Path], complete: bool = True) -> None:
-    payload = {"version": _VERSION, "complete": complete, "inputs": []}
+    entries: list[dict] = []
     for path in inputs:
         try:
-            payload["inputs"].append(_entry(path))
+            entries.append(_entry(path))
         except OSError:
-            # An input we cannot record is an input we cannot verify.  Refuse to
-            # write a manifest that would later read as complete.
-            logger.warning("cache manifest: %s unreadable; not recording", path)
-            return
+            # Unverifiable, but not uncacheable: mark it incomplete rather than
+            # writing nothing and costing the entry on every later lookup.
+            logger.warning(
+                "cache manifest: %s unreadable; recording an incomplete manifest",
+                path,
+            )
+            entries, complete = [], False
+            break
+    payload = {"version": _VERSION, "complete": complete, "inputs": entries}
     tmp = Path(kernel_dir) / (MANIFEST_NAME + ".tmp")
     tmp.write_text(json.dumps(payload))
     os.replace(tmp, Path(kernel_dir) / MANIFEST_NAME)
@@ -159,24 +251,42 @@ def is_valid(kernel_dir: Path) -> bool:
         payload = json.loads(path.read_text())
     except (OSError, ValueError):
         return False
-    if payload.get("version") != _VERSION:
+    # Shape is an input to check, not an invariant to assume: raising on a
+    # malformed manifest fails neither open nor closed.
+    if not isinstance(payload, dict) or payload.get("version") != _VERSION:
         return False
     if not payload.get("complete", True):
         logger.debug(
             "cache manifest: %s records no verifiable inputs; not checking", path
         )
         return True
-    for rec in payload.get("inputs", ()):
-        f = Path(rec["path"])
+    inputs = payload.get("inputs", ())
+    if not isinstance(inputs, list):
+        return False
+    for rec in inputs:
+        if not isinstance(rec, dict):
+            return False
+        recorded_path = rec.get("path")
+        size = rec.get("size")
+        mtime = rec.get("mtime")
+        sha256 = rec.get("sha256")
+        if (
+            not isinstance(recorded_path, str)
+            or not isinstance(size, int)
+            or not isinstance(mtime, (int, float))
+            or not isinstance(sha256, str)
+        ):
+            return False
+        f = Path(recorded_path)
         try:
             st = f.stat()
         except OSError:
             return False
         # tsbuildinfo pattern: size+mtime agree -> trust it, skip the hash.
-        if st.st_size == rec["size"] and st.st_mtime == rec["mtime"]:
+        if st.st_size == size and st.st_mtime == mtime:
             continue
         try:
-            if _digest(f) != rec["sha256"]:
+            if _digest(f) != sha256:
                 return False
         except OSError:
             return False

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -50,9 +50,9 @@ from aie.utils.compile import (
     compile_mlir_module,
 )
 from aie.utils.compile.cache.utils import file_lock
-from aie.utils.compile.jit import _manifest
 from aie.utils.compile.utils import _cleanup_failed_compilation
 
+from . import _manifest
 from ._dma_size_parser import parse_dma_sizes
 from ._hash import (
     _compute_artifact_hash,

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -50,6 +50,7 @@ from aie.utils.compile import (
     compile_mlir_module,
 )
 from aie.utils.compile.cache.utils import file_lock
+from aie.utils.compile.jit import _manifest
 from aie.utils.compile.utils import _cleanup_failed_compilation
 
 from ._dma_size_parser import parse_dma_sizes
@@ -331,6 +332,19 @@ class CompilableDesign:
             inst_exists = inst_path.exists()
 
             if not explicit_paths and self.use_cache and xclbin_exists and inst_exists:
+                if not _manifest.is_valid(kernel_dir):
+                    # A recorded input moved.  The directory holds nested caches
+                    # of its own -- compile_external_kernel skips any .o that is
+                    # already present -- so a stale entry has to be cleared, not
+                    # merely rebuilt over.
+                    logger.debug(
+                        "Inputs changed for '%s'; discarding cache entry",
+                        self.generator_name,
+                    )
+                    _cleanup_failed_compilation(kernel_dir)
+                    xclbin_exists = inst_exists = False
+
+            if not explicit_paths and self.use_cache and xclbin_exists and inst_exists:
                 logger.debug(
                     "Cache hit for '%s' (hash=%s)", self.generator_name, cache_hash
                 )
@@ -398,6 +412,15 @@ class CompilableDesign:
                         "but expected output file(s) were not created: "
                         + ", ".join(str(p) for p in missing)
                     )
+
+                # Build succeeded: record what it consumed, so the next lookup
+                # can check the real inputs instead of guessing at them.
+                _manifest.record(
+                    kernel_dir,
+                    external_kernels,
+                    self.source_files,
+                    used_chess=use_chess,
+                )
             except Exception:
                 _cleanup_failed_compilation(kernel_dir)
                 raise
@@ -438,6 +461,18 @@ class CompilableDesign:
 
         with file_lock(lock_file_path, timeout_seconds=_COMPILE_LOCK_TIMEOUT_SECONDS):
             os.makedirs(kernel_dir, exist_ok=True)
+
+            if (
+                not explicit_path
+                and self.use_cache
+                and elf_path.exists()
+                and not _manifest.is_valid(kernel_dir)
+            ):
+                logger.debug(
+                    "Inputs changed for '%s'; discarding full-ELF cache entry",
+                    self.generator_name,
+                )
+                _cleanup_failed_compilation(kernel_dir)
 
             if not explicit_path and self.use_cache and elf_path.exists():
                 logger.debug(
@@ -484,6 +519,13 @@ class CompilableDesign:
                         "code 0) but the expected output file was not created: "
                         f"{elf_path}"
                     )
+
+                _manifest.record(
+                    kernel_dir,
+                    external_kernels,
+                    self.source_files,
+                    used_chess=use_chess,
+                )
             except Exception:
                 _cleanup_failed_compilation(kernel_dir)
                 raise

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -316,6 +316,11 @@ def compile_cxx_core_function(
             "-Wno-empty-body",
             "-O2",
             "-DNDEBUG",
+            # Have the compiler report what it actually read, the way ninja and
+            # ccache learn a translation unit's real inputs.
+            "-MD",
+            "-MF",
+            f"{output_path}.d",
             # Pre-trip aie_api's aie_adf.hpp include guard so stock upstream
             # aie_api never pulls in <adf.h> (Vitis-only, absent from Peano).
             # No mlir-aie kernel uses adf:: symbols, so this only elides dead

--- a/test/python/test_cache_manifest.py
+++ b/test/python/test_cache_manifest.py
@@ -1,0 +1,190 @@
+# test_cache_manifest.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# RUN: %pytest %s
+"""Unit tests for the JIT cache's recorded dependency manifest -- no NPU required."""
+
+import json
+import time
+
+import pytest
+
+from aie.utils.compile.jit import _manifest
+
+
+class _Kernel:
+    """Minimal stand-in for an ExternalFunction, which needs an MLIR context."""
+
+    def __init__(self, source_file=None, source_string=None):
+        self._source_file = source_file
+        self._source_string = source_string
+
+
+def _depfile(kernel_dir, obj, deps):
+    (kernel_dir / f"{obj}.d").write_text(
+        f"{kernel_dir / obj}: \\\n  " + " \\\n  ".join(str(d) for d in deps) + "\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation fails closed
+# ---------------------------------------------------------------------------
+
+
+def test_absent_manifest_is_not_valid(tmp_path):
+    """An entry with no recorded inputs must never read as verified."""
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_unparsable_manifest_is_not_valid(tmp_path):
+    (tmp_path / _manifest.MANIFEST_NAME).write_text("{ not json")
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_manifest_from_a_future_version_is_not_valid(tmp_path):
+    (tmp_path / _manifest.MANIFEST_NAME).write_text(
+        json.dumps({"version": 999, "inputs": []})
+    )
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_deleted_input_is_not_valid(tmp_path):
+    src = tmp_path / "k.cc"
+    src.write_text("// v1")
+    _manifest.write_for_test(tmp_path, [src])
+    assert _manifest.is_valid(tmp_path)
+    src.unlink()
+    assert not _manifest.is_valid(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Validation tracks content, not just timestamps
+# ---------------------------------------------------------------------------
+
+
+def test_edited_input_invalidates(tmp_path):
+    src = tmp_path / "k.cc"
+    src.write_text("// v1")
+    _manifest.write_for_test(tmp_path, [src])
+
+    time.sleep(0.01)
+    src.write_text("// v2")
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_touched_but_unchanged_input_still_valid(tmp_path):
+    """A new mtime over identical bytes must not force a rebuild."""
+    src = tmp_path / "k.cc"
+    src.write_text("// v1")
+    _manifest.write_for_test(tmp_path, [src])
+
+    time.sleep(0.01)
+    src.write_text("// v1")  # same content, new mtime
+    assert _manifest.is_valid(tmp_path)
+
+
+def test_same_size_different_content_invalidates(tmp_path):
+    """Size alone must not be trusted; the digest is the decider."""
+    src = tmp_path / "k.cc"
+    src.write_text("aaaa")
+    _manifest.write_for_test(tmp_path, [src])
+
+    time.sleep(0.01)
+    src.write_text("bbbb")
+    assert not _manifest.is_valid(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Recording: what the compiler reported, and when to record nothing
+# ---------------------------------------------------------------------------
+
+
+def test_record_captures_depfile_contents(tmp_path):
+    """Inputs the compiler reported must be recorded, not just the named source."""
+    body = tmp_path / "body.cc"
+    body.write_text("// body")
+    shim = tmp_path / "shim.cc"
+    shim.write_text('#include "body.cc"\n')
+    _depfile(tmp_path, "k.o", [shim, body])
+
+    _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
+    recorded = {
+        i["path"]
+        for i in json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())["inputs"]
+    }
+    assert str(body) in recorded, "the included body was not recorded"
+    assert str(shim) in recorded
+
+    time.sleep(0.01)
+    body.write_text("// body v2")
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_chess_build_records_an_incomplete_manifest(tmp_path):
+    """Chess reports no inputs, so the entry says so instead of claiming a check.
+
+    It stays usable: a Chess design cached fine before manifests existed, and
+    writing nothing would make every later lookup discard the directory and
+    rebuild -- worse than the behaviour this is meant to preserve.
+    """
+    shim = tmp_path / "shim.cc"
+    shim.write_text("// k")
+    _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], (), used_chess=True)
+
+    payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
+    assert payload["complete"] is False
+    assert payload["inputs"] == []
+    assert _manifest.is_valid(tmp_path)
+
+    # And it keeps saying so: an edited kernel is genuinely undetectable here,
+    # which is exactly why the manifest does not claim otherwise.
+    time.sleep(0.01)
+    shim.write_text("// k v2")
+    assert _manifest.is_valid(tmp_path)
+
+
+def test_kernel_without_a_depfile_records_an_incomplete_manifest(tmp_path):
+    """A kernel compiled by some other route leaves the set unknowable."""
+    shim = tmp_path / "shim.cc"
+    shim.write_text("// k")
+    _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
+
+    payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
+    assert payload["complete"] is False
+    assert _manifest.is_valid(tmp_path)
+
+
+def test_incomplete_is_not_the_same_as_no_inputs(tmp_path):
+    """An empty input list still gets checked; an incomplete manifest does not.
+
+    Both record zero inputs, so only the flag separates "this design consumes
+    nothing" from "this build could not tell what it consumed".
+    """
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    _manifest.record(empty, [], ())
+    assert json.loads((empty / _manifest.MANIFEST_NAME).read_text())["complete"] is True
+
+    unknowable = tmp_path / "unknowable"
+    unknowable.mkdir()
+    shim = unknowable / "shim.cc"
+    shim.write_text("// k")
+    _manifest.record(unknowable, [_Kernel(source_file=str(shim))], (), used_chess=True)
+    payload = json.loads((unknowable / _manifest.MANIFEST_NAME).read_text())
+    assert payload["complete"] is False
+    assert payload["inputs"] == []
+
+
+def test_design_without_kernels_records_its_declared_sources(tmp_path):
+    """No compiled kernels means nothing to discover, but sources still count."""
+    src = tmp_path / "extra.cc"
+    src.write_text("// x")
+    _manifest.record(tmp_path, [], (src,))
+    assert _manifest.is_valid(tmp_path)
+
+    time.sleep(0.01)
+    src.write_text("// y")
+    assert not _manifest.is_valid(tmp_path)

--- a/test/python/test_cache_manifest.py
+++ b/test/python/test_cache_manifest.py
@@ -235,32 +235,47 @@ def test_unreadable_depfile_records_an_incomplete_manifest(tmp_path):
     shim = tmp_path / "shim.cc"
     shim.write_text("// k")
     _depfile(tmp_path, "k.o", [shim])
-    (tmp_path / "k.o.d").chmod(0o000)
-    try:
-        _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
-    finally:
-        (tmp_path / "k.o.d").chmod(0o644)
+    # A directory where the depfile should be fails the read for every user.
+    # chmod(0o000) would not: the Ryzen AI Software CI job runs as root, which
+    # bypasses the permission bits and made this assertion vacuous there.
+    depfile = tmp_path / "k.o.d"
+    depfile.unlink()
+    depfile.mkdir()
+
+    _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
 
     payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
     assert payload["complete"] is False
     assert _manifest.is_valid(tmp_path)
 
 
-def test_unreadable_input_records_an_incomplete_manifest(tmp_path):
-    """An input that cannot be digested is unverifiable, not uncacheable."""
+def test_unreadable_input_records_an_incomplete_manifest(tmp_path, monkeypatch):
+    """An input that cannot be digested is unverifiable, not uncacheable.
+
+    _write only digests paths that already passed is_file(), so the branch under
+    test is the narrow one where the read fails anyway: the file goes away, or
+    the I/O errors, between the two calls. Raising it directly is also what
+    survives running as root, where chmod(0o000) is not a read barrier.
+    """
     shim = tmp_path / "shim.cc"
     shim.write_text("// k")
     secret = tmp_path / "secret.h"
     secret.write_text("// h")
     _depfile(tmp_path, "k.o", [shim, secret])
-    secret.chmod(0o000)
-    try:
-        _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
-    finally:
-        secret.chmod(0o644)
+
+    entry = _manifest._entry
+
+    def unreadable_secret(path):
+        if path.name == "secret.h":
+            raise OSError("input vanished under us")
+        return entry(path)
+
+    monkeypatch.setattr(_manifest, "_entry", unreadable_secret)
+    _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
 
     payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
     assert payload["complete"] is False
+    assert payload["inputs"] == []
     assert _manifest.is_valid(tmp_path)
 
 

--- a/test/python/test_cache_manifest.py
+++ b/test/python/test_cache_manifest.py
@@ -51,6 +51,42 @@ def test_manifest_from_a_future_version_is_not_valid(tmp_path):
     assert not _manifest.is_valid(tmp_path)
 
 
+@pytest.mark.parametrize(
+    "build_payload",
+    [
+        pytest.param(lambda src: [1, 2, 3], id="payload-is-not-an-object"),
+        pytest.param(
+            lambda src: {"version": 1, "inputs": str(src)}, id="inputs-is-not-a-list"
+        ),
+        pytest.param(
+            lambda src: {"version": 1, "inputs": [str(src)]},
+            id="input-is-not-an-object",
+        ),
+        pytest.param(
+            lambda src: {"version": 1, "inputs": [{"path": str(src)}]},
+            id="input-is-partial",
+        ),
+        pytest.param(
+            lambda src: {
+                "version": 1,
+                "inputs": [{"path": str(src), "size": "4", "mtime": 0.0}],
+            },
+            id="input-field-is-the-wrong-type",
+        ),
+    ],
+)
+def test_malformed_manifest_is_not_valid(tmp_path, build_payload):
+    """Well-formed JSON that is not a manifest must miss, not raise.
+
+    Each payload names a file that exists, so validation reaches the recorded
+    fields instead of stopping at a failed ``stat``.
+    """
+    src = tmp_path / "k.cc"
+    src.write_text("// k")
+    (tmp_path / _manifest.MANIFEST_NAME).write_text(json.dumps(build_payload(src)))
+    assert not _manifest.is_valid(tmp_path)
+
+
 def test_deleted_input_is_not_valid(tmp_path):
     src = tmp_path / "k.cc"
     src.write_text("// v1")
@@ -187,4 +223,135 @@ def test_design_without_kernels_records_its_declared_sources(tmp_path):
 
     time.sleep(0.01)
     src.write_text("// y")
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_unreadable_depfile_records_an_incomplete_manifest(tmp_path):
+    """A depfile that cannot be read leaves the set unknowable, like Chess.
+
+    Writing nothing would read as a miss, and the caller answers a miss by
+    discarding the directory -- wiping a good entry on every later lookup.
+    """
+    shim = tmp_path / "shim.cc"
+    shim.write_text("// k")
+    _depfile(tmp_path, "k.o", [shim])
+    (tmp_path / "k.o.d").chmod(0o000)
+    try:
+        _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
+    finally:
+        (tmp_path / "k.o.d").chmod(0o644)
+
+    payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
+    assert payload["complete"] is False
+    assert _manifest.is_valid(tmp_path)
+
+
+def test_unreadable_input_records_an_incomplete_manifest(tmp_path):
+    """An input that cannot be digested is unverifiable, not uncacheable."""
+    shim = tmp_path / "shim.cc"
+    shim.write_text("// k")
+    secret = tmp_path / "secret.h"
+    secret.write_text("// h")
+    _depfile(tmp_path, "k.o", [shim, secret])
+    secret.chmod(0o000)
+    try:
+        _manifest.record(tmp_path, [_Kernel(source_file=str(shim))], ())
+    finally:
+        secret.chmod(0o644)
+
+    payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
+    assert payload["complete"] is False
+    assert _manifest.is_valid(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Recorded paths must not depend on where the caller happens to stand
+# ---------------------------------------------------------------------------
+
+
+def test_relative_declared_source_is_recorded_absolutely(tmp_path, monkeypatch):
+    """``source_files`` is user-supplied and routinely relative.
+
+    Stored verbatim it is checked from whatever directory a later process runs
+    in, so it either misses forever or stats a same-named file elsewhere.
+    """
+    kernel_dir = tmp_path / "cache"
+    kernel_dir.mkdir()
+    project = tmp_path / "project"
+    (project / "kernels").mkdir(parents=True)
+    src = project / "kernels" / "vector_add.cc"
+    src.write_text("// v1")
+
+    monkeypatch.chdir(project)
+    _manifest.record(kernel_dir, [], ("kernels/vector_add.cc",))
+
+    recorded = json.loads((kernel_dir / _manifest.MANIFEST_NAME).read_text())["inputs"]
+    assert [i["path"] for i in recorded] == [str(src)]
+
+    # The next lookup runs from somewhere else, as a second process would.
+    monkeypatch.chdir(tmp_path)
+    assert _manifest.is_valid(kernel_dir)
+    time.sleep(0.01)
+    src.write_text("// v2")
+    assert not _manifest.is_valid(kernel_dir)
+
+
+def test_relative_kernel_source_is_recorded_absolutely(tmp_path, monkeypatch):
+    """Same for ``ExternalFunction(source_file=...)``, stored exactly as given."""
+    kernel_dir = tmp_path / "cache"
+    kernel_dir.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    src = project / "k.cc"
+    src.write_text("// v1")
+
+    monkeypatch.chdir(project)
+    _manifest.record(kernel_dir, [_Kernel(source_file="k.cc")], (), used_chess=True)
+    _manifest.record(kernel_dir, [], ("k.cc",))
+
+    monkeypatch.chdir(tmp_path)
+    assert _manifest.is_valid(kernel_dir)
+    time.sleep(0.01)
+    src.write_text("// v2")
+    assert not _manifest.is_valid(kernel_dir)
+
+
+def test_relative_depfile_entry_resolves_against_the_compile_directory(tmp_path):
+    """Depfile paths are relative to the compiler's cwd, and Peano runs in
+    kernel_dir -- not in whatever directory writes the manifest."""
+    header = tmp_path / "hdr.h"
+    header.write_text("// h")
+    (tmp_path / "k.o.d").write_text(f"{tmp_path / 'k.o'}: hdr.h\n")
+
+    _manifest.record(tmp_path, [_Kernel(source_string="// k")], ())
+
+    payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
+    assert [i["path"] for i in payload["inputs"]] == [str(header)]
+
+    time.sleep(0.01)
+    header.write_text("// h v2")
+    assert not _manifest.is_valid(tmp_path)
+
+
+def test_depfile_entry_with_an_escaped_space_is_recorded(tmp_path):
+    """clang escapes a space in a dependency path as ``\\ ``.
+
+    Splitting on bare whitespace shreds it into two tokens naming no file, both
+    dropped -- leaving a real input unrecorded under ``complete: true``.
+    """
+    spaced = tmp_path / "my dir"
+    spaced.mkdir()
+    header = spaced / "hdr.h"
+    header.write_text("// h")
+    (tmp_path / "k.o.d").write_text(
+        f"{tmp_path / 'k.o'}: {str(header).replace(' ', chr(92) + ' ')}\n"
+    )
+
+    _manifest.record(tmp_path, [_Kernel(source_string="// k")], ())
+
+    payload = json.loads((tmp_path / _manifest.MANIFEST_NAME).read_text())
+    assert [i["path"] for i in payload["inputs"]] == [str(header)]
+
+    time.sleep(0.01)
+    header.write_text("// h v2")
     assert not _manifest.is_valid(tmp_path)

--- a/test/python/test_device_binding_cache_unit.py
+++ b/test/python/test_device_binding_cache_unit.py
@@ -15,6 +15,7 @@ from aie.iron.device import NPU1Col1, NPU2Col1, NPU2Col2
 from aie.utils import set_current_device
 from aie.utils.compile.jit import CompileTime, In, Out
 from aie.utils.compile.jit.compilabledesign import CompilableDesign
+from aie.utils.compile.jit import _manifest
 
 
 def _gemm_gen():
@@ -131,6 +132,7 @@ def test_cache_hit_refreshes_tensor_metadata_for_the_selected_artifact(
         kernel_dir.mkdir()
         (kernel_dir / "final.xclbin").touch()
         (kernel_dir / "insts.bin").touch()
+        _manifest.write_for_test(kernel_dir, [])
 
     cd = CompilableDesign(gen)
     hashes = iter(("npu1", "npu2", "npu1"))
@@ -193,6 +195,7 @@ def test_python_compile_binds_before_cache_lookup(monkeypatch, tmp_path):
     cache_dir.mkdir()
     (cache_dir / "final.xclbin").touch()
     (cache_dir / "insts.bin").touch()
+    _manifest.write_for_test(cache_dir, [])
 
     monkeypatch.setattr(utils, "ensure_current_device", fake_ensure_current_device)
     monkeypatch.setattr(cd, "_compute_cache_hash", fake_cache_hash)


### PR DESCRIPTION
Fixes #2543.

## Why now

#2543 has been latent rather than live: the cache never hit cross-process, so a stale header was never
actually served. #3428 changed that. Once warm hits are real, editing a header and rerunning can
silently serve the pre-edit artifact -- which is the ordering @hunhoffe called out on #3236:

> #3428 promotes #2543 from latent to live. Today the cache never hits cross-process, so a stale
> header is never served; once #3428 makes warm hits real, editing a header and rerunning can
> silently serve the pre-edit artifact.

## Root cause

A design's kernel sources are invisible to the cache key. `ExternalFunction`s register themselves while
MLIR is generated, which happens *after* the key is computed -- and on a hit, not at all, since
`compile()` returns before generating anything. So a kernel declared the ordinary way is not tracked:
editing it leaves the key unchanged and the previous artifact is served.

`source_files` exists to paper over this, but it is a declaration -- opt-in, easy to get wrong, and it
reaches no compiler. It only feeds the hash. Correctness that depends on remembering to list your
inputs is not correctness, and essentially every programming example declares nothing.

## Fix

Record the inputs instead of predicting them. Peano is now asked for a depfile, so it reports exactly
which files it opened; those, plus any declared sources, are written to `deps.json` beside the artifact
once a build has succeeded. The next lookup validates that manifest before trusting the entry: size and
mtime agreeing is enough to skip a file, otherwise its digest decides.

This is the split PyTorch's `cpp_extension` lands on -- declared-source hash plus compiler-reported
deps -- for a toolchain with no ninja underneath, and it dodges the wall #2543 itself raised: recording
*inputs* rather than preprocessed text means `__TIMESTAMP__`-style macros never enter the hash.

Invalidation clears the entry rather than rebuilding over it, because the directory holds nested
per-kernel artifacts of its own, and compilation skips one that is already present, so a stale entry
left in place is reused even when the outer lookup correctly missed.

## Chess

Chess is driven through `xchesscc_wrapper` and reports nothing equivalent, so for those designs the
consumed set is unknowable here. Such a build writes a manifest marked `complete: false`: there is
nothing to check, so the entry stays exactly as cacheable as it was before this existed, without
claiming a check that did not happen.

Writing no manifest at all was the obvious alternative and is a trap -- a missing manifest reads as a
miss, and the caller answers a miss by discarding the directory, so every lookup for a Chess design
would wipe a good entry and rebuild it. That is strictly worse than the behaviour it was meant to
preserve, and it would land on the eleven `block_datatypes` examples that pass `use_chess`.

`complete: false` is deliberately not the same as an empty input list: a design that genuinely consumes
nothing records `complete: true` and is still checked. Both record zero inputs, so only the flag
separates "consumes nothing" from "could not tell what it consumed".

## Limitations

Two paths fail *open* -- they can report a valid entry that is actually stale. Everything else here
fails closed (absent, unparsable, versioned-forward, partial or unreadable all mean miss). Both are
shared with ccache, and neither is fixable by recording inputs more carefully, because in both cases the
recorded inputs are genuinely unchanged:

1. **Include resolution.** Only files the compiler opened are recorded. A file that later appears
   earlier in the `-I` search order and shadows a recorded header changes what the next compile would
   resolve, while every recorded input still matches.

2. **Size and mtime agreement.** `is_valid` skips the digest when both size and mtime match a record.
   An edit that preserves byte count, after something has reset mtimes -- a fresh clone, a checkout, an
   extracted archive -- reads as unchanged. This is the shortcut that makes the common case cheap; the
   digest is what catches a same-size edit otherwise.

Both are stated in the module docstring as well, so they are visible to whoever next changes this rather
than only in review history.

One more consequence worth naming: cache entries predating this have no manifest and so miss once.

## Evidence

Measured with nothing declared -- the way the examples are written:

| | |
|---|---|
| cold | 1.17s |
| unchanged | 0.01s hit |
| edited kernel | 1.14s rebuild |
| unrelated file added | 0.01s hit |
| validating 40 recorded inputs | 0.14ms |

Unit tests in `test/python/test_cache_manifest.py`, no NPU required: validation failing closed on each
of absent / unparsable / future-version / deleted / edited / same-size-different-content, the
mtime-only-touch case still hitting, depfile capture, the Chess and no-depfile paths recording
`complete: false` and staying usable, and `complete: false` being distinguishable from an empty input
list. 23 pass across this file and `test_device_binding_cache_unit.py`.

The Chess path was checked against the failure it prevents, not only in the abstract: with the
`complete: false` write removed, a Chess design holding a valid `final.xclbin` + `insts.bin` has its
directory discarded on the next lookup and rebuilds; with it, the entry survives.

