### PR TITLE
[AIE] Generate the column control overlay for intermediate columns

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -308,15 +308,36 @@ struct AIEGenerateColumnControlOverlayPass
       declaredCols.insert(tId.col);
     }
 
-    // Cover the full column range between the leftmost and rightmost occupied
-    // column, not just the occupied columns. A flow between two columns is
-    // routed through the stream switches of the columns in between, so those
-    // switchboxes are configured by control packets addressed to a column that
-    // holds no tile of its own. Skipping such a column leaves its control
-    // packets without a shim dma allocation to be issued through. This mirrors
-    // what the per-column loop below already does for intermediate rows.
+    // Both widenings below are scoped to the control-packet configuration path
+    // (`route-shim-to-tile-ctrl`). That is the path this fix is for: it is the
+    // one that routes a column's configuration through a shim dma, so it is the
+    // only one that cares which columns a flow crosses or whether a column's
+    // shim is in the tile set. On the default path the pass has to keep its
+    // previous shape -- it runs on every aiecc invocation, for every target,
+    // and widening it there changes routing for designs that never asked for a
+    // control overlay. Versal designs that declare compute tiles and no shim
+    // are the ones that showed this: they gained TCT routes they never had and
+    // stopped routing at all.
+    SmallVector<int> colsToCover;
+    if (clRouteShimDmaToTileCTRL) {
+      // Cover the full column range between the leftmost and rightmost occupied
+      // column, not just the occupied columns. A flow between two columns is
+      // routed through the stream switches of the columns in between, so those
+      // switchboxes are configured by control packets addressed to a column
+      // that holds no tile of its own. Skipping such a column leaves its
+      // control packets without a shim dma allocation to be issued through.
+      // This mirrors what the per-column loop below already does for
+      // intermediate rows.
+      for (int col = minOccupiedCol; col <= maxOccupiedCol; col++)
+        colsToCover.push_back(col);
+    } else {
+      for (auto &[tId, tOp] : tiles)
+        if (!llvm::is_contained(colsToCover, tId.col))
+          colsToCover.push_back(tId.col);
+    }
+
     auto tileIDMap = getTileToControllerIdMap(true, targetModel);
-    for (int col = minOccupiedCol; col <= maxOccupiedCol; col++) {
+    for (int col : colsToCover) {
       builder.setInsertionPointToStart(device.getBody());
       AIE::TileOp shimTile = TileOp::getOrCreate(builder, device, col, 0);
       // Register the shim in the column's tile set. The TCT branch below
@@ -326,7 +347,8 @@ struct AIEGenerateColumnControlOverlayPass
       // after it still wired that column's configuration path through the shim
       // materialized just above. Which of the two paths a column got therefore
       // depended on whether the design happened to declare its shim.
-      tiles[{col, 0}] = shimTile;
+      if (clRouteShimDmaToTileCTRL)
+        tiles[{col, 0}] = shimTile;
 
       if (clRouteShimCTRLToTCT == "all-tiles" ||
           clRouteShimCTRLToTCT == "shim-only") {

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -300,10 +300,12 @@ struct AIEGenerateColumnControlOverlayPass
     int minOccupiedCol = tiles.front().first.col;
     int maxOccupiedCol = minOccupiedCol;
     int maxOccupiedRow = 0;
+    llvm::SmallSet<int, 4> declaredCols;
     for (auto &[tId, tOp] : tiles) {
       minOccupiedCol = std::min(minOccupiedCol, tId.col);
       maxOccupiedCol = std::max(maxOccupiedCol, tId.col);
       maxOccupiedRow = std::max(maxOccupiedRow, tId.row);
+      declaredCols.insert(tId.col);
     }
 
     // Cover the full column range between the leftmost and rightmost occupied
@@ -317,6 +319,14 @@ struct AIEGenerateColumnControlOverlayPass
     for (int col = minOccupiedCol; col <= maxOccupiedCol; col++) {
       builder.setInsertionPointToStart(device.getBody());
       AIE::TileOp shimTile = TileOp::getOrCreate(builder, device, col, 0);
+      // Register the shim in the column's tile set. The TCT branch below
+      // selects out of `tiles` and, with the default `shim-only`, keeps only
+      // shim tiles -- so in a column holding compute tiles but no *declared*
+      // shim it selected nothing and emitted no TCT route, while the branch
+      // after it still wired that column's configuration path through the shim
+      // materialized just above. Which of the two paths a column got therefore
+      // depended on whether the design happened to declare its shim.
+      tiles[{col, 0}] = shimTile;
 
       if (clRouteShimCTRLToTCT == "all-tiles" ||
           clRouteShimCTRLToTCT == "shim-only") {
@@ -341,19 +351,18 @@ struct AIEGenerateColumnControlOverlayPass
         // tiles) are needed for control packet routing and will also need
         // their switchboxes configured via control packets.
         int maxRow = 0;
-        bool colIsOccupied = false;
         for (auto &[tId, tOp] : tiles) {
-          if (tId.col == col) {
+          if (tId.col == col)
             maxRow = std::max(maxRow, tId.row);
-            colIsOccupied = true;
-          }
         }
-        // A column holding no tile of its own is only in range because flows
-        // route through it, and such a flow can traverse it at any row up to
-        // the highest row in use. Rows map to shim channels in round robin
-        // (getRowToShimChanMap), so covering only row 0 here would allocate
-        // just one of the channels its control packets get addressed to.
-        if (!colIsOccupied)
+        // A column the design declared no tile in is only in range because
+        // flows route through it, and such a flow can traverse it at any row up
+        // to the highest row in use. Rows map to shim channels in round robin
+        // (getRowToShimChanMap), so covering only the shim row here would
+        // allocate just one of the channels its packets get addressed to. Test
+        // against the columns the design itself declared, not against `tiles`,
+        // which now also holds the shim materialized just above.
+        if (!declaredCols.contains(col))
           maxRow = maxOccupiedRow;
         SmallVector<AIE::TileOp> tilesOnCol;
         for (int row = 0; row <= maxRow; row++) {

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -357,11 +357,12 @@ struct AIEGenerateColumnControlOverlayPass
         }
         // A column the design declared no tile in is only in range because
         // flows route through it, and such a flow can traverse it at any row up
-        // to the highest row in use. Rows map to shim channels in round robin
-        // (getRowToShimChanMap), so covering only the shim row here would
-        // allocate just one of the channels its packets get addressed to. Test
-        // against the columns the design itself declared, not against `tiles`,
-        // which now also holds the shim materialized just above.
+        // to the highest row in use. getRowToShimChanMap splits the rows into
+        // one contiguous range per shim channel, so covering only the shim row
+        // here would allocate just one of the channels its packets get
+        // addressed to. Test against the columns the design itself declared,
+        // not against `tiles`, which now also holds the shim materialized just
+        // above.
         if (!declaredCols.contains(col))
           maxRow = maxOccupiedRow;
         SmallVector<AIE::TileOp> tilesOnCol;

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -309,25 +309,14 @@ struct AIEGenerateColumnControlOverlayPass
     }
 
     // Both widenings below are scoped to the control-packet configuration path
-    // (`route-shim-to-tile-ctrl`). That is the path this fix is for: it is the
-    // one that routes a column's configuration through a shim dma, so it is the
-    // only one that cares which columns a flow crosses or whether a column's
-    // shim is in the tile set. On the default path the pass has to keep its
-    // previous shape -- it runs on every aiecc invocation, for every target,
-    // and widening it there changes routing for designs that never asked for a
-    // control overlay. Versal designs that declare compute tiles and no shim
-    // are the ones that showed this: they gained TCT routes they never had and
-    // stopped routing at all.
+    // (`route-shim-to-tile-ctrl`); do not add tile declarations if the control
+    // overlay was not requested, as to not congest routing needlessly.
     SmallVector<int> colsToCover;
     if (clRouteShimDmaToTileCTRL) {
       // Cover the full column range between the leftmost and rightmost occupied
-      // column, not just the occupied columns. A flow between two columns is
-      // routed through the stream switches of the columns in between, so those
-      // switchboxes are configured by control packets addressed to a column
-      // that holds no tile of its own. Skipping such a column leaves its
-      // control packets without a shim dma allocation to be issued through.
-      // This mirrors what the per-column loop below already does for
-      // intermediate rows.
+      // column, not just the occupied columns. This is required so that a shim
+      // DMA allocation is later emitted for the intermediate columns that a
+      // flow will route through.
       for (int col = minOccupiedCol; col <= maxOccupiedCol; col++)
         colsToCover.push_back(col);
     } else {
@@ -340,13 +329,6 @@ struct AIEGenerateColumnControlOverlayPass
     for (int col : colsToCover) {
       builder.setInsertionPointToStart(device.getBody());
       AIE::TileOp shimTile = TileOp::getOrCreate(builder, device, col, 0);
-      // Register the shim in the column's tile set. The TCT branch below
-      // selects out of `tiles` and, with the default `shim-only`, keeps only
-      // shim tiles -- so in a column holding compute tiles but no *declared*
-      // shim it selected nothing and emitted no TCT route, while the branch
-      // after it still wired that column's configuration path through the shim
-      // materialized just above. Which of the two paths a column got therefore
-      // depended on whether the design happened to declare its shim.
       if (clRouteShimDmaToTileCTRL)
         tiles[{col, 0}] = shimTile;
 

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -292,16 +292,29 @@ struct AIEGenerateColumnControlOverlayPass
 
     // Collect existing TileOps
     llvm::MapVector<AIE::TileID, AIE::TileOp> tiles;
-    llvm::SmallSet<int, 1> occupiedCols;
-    for (auto tile : device.getOps<AIE::TileOp>()) {
-      int colIndex = tile.colIndex();
-      int rowIndex = tile.rowIndex();
-      tiles[{colIndex, rowIndex}] = tile;
-      occupiedCols.insert(colIndex);
+    for (auto tile : device.getOps<AIE::TileOp>())
+      tiles[{tile.colIndex(), tile.rowIndex()}] = tile;
+    if (tiles.empty())
+      return success();
+
+    int minOccupiedCol = tiles.front().first.col;
+    int maxOccupiedCol = minOccupiedCol;
+    int maxOccupiedRow = 0;
+    for (auto &[tId, tOp] : tiles) {
+      minOccupiedCol = std::min(minOccupiedCol, tId.col);
+      maxOccupiedCol = std::max(maxOccupiedCol, tId.col);
+      maxOccupiedRow = std::max(maxOccupiedRow, tId.row);
     }
 
+    // Cover the full column range between the leftmost and rightmost occupied
+    // column, not just the occupied columns. A flow between two columns is
+    // routed through the stream switches of the columns in between, so those
+    // switchboxes are configured by control packets addressed to a column that
+    // holds no tile of its own. Skipping such a column leaves its control
+    // packets without a shim dma allocation to be issued through. This mirrors
+    // what the per-column loop below already does for intermediate rows.
     auto tileIDMap = getTileToControllerIdMap(true, targetModel);
-    for (int col : occupiedCols) {
+    for (int col = minOccupiedCol; col <= maxOccupiedCol; col++) {
       builder.setInsertionPointToStart(device.getBody());
       AIE::TileOp shimTile = TileOp::getOrCreate(builder, device, col, 0);
 
@@ -328,10 +341,20 @@ struct AIEGenerateColumnControlOverlayPass
         // tiles) are needed for control packet routing and will also need
         // their switchboxes configured via control packets.
         int maxRow = 0;
+        bool colIsOccupied = false;
         for (auto &[tId, tOp] : tiles) {
-          if (tId.col == col)
+          if (tId.col == col) {
             maxRow = std::max(maxRow, tId.row);
+            colIsOccupied = true;
+          }
         }
+        // A column holding no tile of its own is only in range because flows
+        // route through it, and such a flow can traverse it at any row up to
+        // the highest row in use. Rows map to shim channels in round robin
+        // (getRowToShimChanMap), so covering only row 0 here would allocate
+        // just one of the channels its control packets get addressed to.
+        if (!colIsOccupied)
+          maxRow = maxOccupiedRow;
         SmallVector<AIE::TileOp> tilesOnCol;
         for (int row = 0; row <= maxRow; row++) {
           auto tOp = TileOp::getOrCreate(builder, device, col, row);

--- a/test/dialect/AIE/generate_column_control_overlay.mlir
+++ b/test/dialect/AIE/generate_column_control_overlay.mlir
@@ -239,16 +239,20 @@ aie.device(npu1_2col) {
 
 // two occupied columns with a gap: flows between column 0 and column 2 route
 // through column 1's stream switches, so column 1's switchboxes get configured
-// by control packets and need a shim dma allocation of their own.
+// by control packets and need a shim dma allocation of their own. Column 2
+// reaches row 5, which maps to the second shim channel, so column 1 has to
+// cover both channels and not just the one its own shim row maps to.
 
 // CHECK-LABEL: module {
 // CTRLPKT-LABEL: module {
 // CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0
 // CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col1_mm2s_chan0
+// CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col1_mm2s_chan1
 // CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col2_mm2s_chan0
+// CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col2_mm2s_chan1
 
 aie.device(npu2) {
   %tile_0_0 = aie.tile(0, 0)
   %tile_2_1 = aie.tile(2, 1)
-  %tile_2_2 = aie.tile(2, 2)
+  %tile_2_5 = aie.tile(2, 5)
 }

--- a/test/dialect/AIE/generate_column_control_overlay.mlir
+++ b/test/dialect/AIE/generate_column_control_overlay.mlir
@@ -234,3 +234,21 @@ aie.device(npu1_2col) {
   %tile_1_0 = aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
   %tile_1_1 = aie.tile(1, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 7>}
 }
+
+// -----
+
+// two occupied columns with a gap: flows between column 0 and column 2 route
+// through column 1's stream switches, so column 1's switchboxes get configured
+// by control packets and need a shim dma allocation of their own.
+
+// CHECK-LABEL: module {
+// CTRLPKT-LABEL: module {
+// CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0
+// CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col1_mm2s_chan0
+// CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col2_mm2s_chan0
+
+aie.device(npu2) {
+  %tile_0_0 = aie.tile(0, 0)
+  %tile_2_1 = aie.tile(2, 1)
+  %tile_2_2 = aie.tile(2, 2)
+}

--- a/test/dialect/AIE/generate_column_control_overlay.mlir
+++ b/test/dialect/AIE/generate_column_control_overlay.mlir
@@ -243,7 +243,13 @@ aie.device(npu1_2col) {
 // reaches row 5, which maps to the second shim channel, so column 1 has to
 // cover both channels and not just the one its own shim row maps to.
 
+// Only the control-packet path covers the gap. Without
+// route-shim-to-tile-ctrl the pass runs on every aiecc invocation for every
+// target, so it must not reach into a column the design never declared: doing
+// so gave such columns routes they previously had none of and left designs
+// that used to route with no legal routing at all.
 // CHECK-LABEL: module {
+// CHECK-NOT: aie.tile(1, {{[0-9]+}})
 // CTRLPKT-LABEL: module {
 // CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0
 // CTRLPKT-DAG: aie.shim_dma_allocation @ctrlpkt_col1_mm2s_chan0


### PR DESCRIPTION
## Description

A flow between two columns is routed through the stream switches of the columns in between, so those
switchboxes get configured by control packets addressed to a column that holds no tile of its own.
`AIEGenerateColumnControlOverlay` generated the overlay only for columns that hold a tile, so those
packets had no shim dma allocation to be issued through.

A design on columns 0 and 2 does not compile with `--load-pdi-to-ctrl-pkt`:

```
error: 'aiex.npu.dma_memcpy_nd' op couldn't find shim_dma_allocation op
```

on an op whose `metadata = @ctrlpkt_col1_mm2s_chan0`, column 1, which the design never mentions. The
producer names allocations after the columns that hold tiles; the consumer (`AIECtrlPacketToDma`)
names them after each control packet's target address. The two disagree exactly when routing crosses
a column that holds no tile.

### The fix

Cover the full column range between the leftmost and rightmost occupied column. For a column holding
no tile, cover rows up to the highest row in use rather than row 0 alone: `getRowToShimChanMap`
assigns rows to shim channels in round robin, so covering only row 0 would allocate one of the two
channels its packets get addressed to.

This is the column analogue of what the pass already does one loop down for rows, where intermediate
tiles are materialized with the same justification in its own comment ("Intermediate tiles (e.g. mem
tiles) are needed for control packet routing and will also need their switchboxes configured via
control packets").

`minCol..maxCol` covers every column a route can traverse without leaving the span of the design,
which is the case that fails today. It is not sufficient in general: `Pathfinder` builds its
switchbox graph over the whole device (`maxCol = targetModel.columns()`) and the pass runs before
routing, so a congested design can route around the span. See the thread on this. Designs on
contiguous columns are unaffected, since the range equals the occupied set, so only gapped designs
change behaviour.

### Evidence

Pass level, `aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true"` on tiles
`(0,0)`, `(2,1)`, `(2,5)`:

| | allocations emitted |
|---|---|
| before | `col0_chan0`, `col2_chan0`, `col2_chan1` |
| after | `col0_chan0`, **`col1_chan0`, `col1_chan1`**, `col2_chan0`, `col2_chan1` |

End to end on Strix (npu2/aie2p, RyzenAI-npu4) with `--get-full-elf --load-pdi-to-ctrl-pkt
--get-ctrlpkt`, on a reconfiguration design reduced from
`test/npu-xrt/reconfigure_loadpdi_persistent_memtile` with its compute moved to column 2: before this
change it fails to compile with the error above; after it, it compiles and runs to completion 3/3 with
the expected data (`11, 22, 33, 44` streamed out of the mem tile buffer through the core).

New `--split-input-file` unit in `test/dialect/AIE/generate_column_control_overlay.mlir` covering a
gapped column. Full `lit` suite over `build/test`: 815 passed, and the failure set is byte-identical to
the pre-change baseline on the same tree (86, all pre-existing environment failures in the python
bindings and `txn2mlir.py`).

### Second commit: a related asymmetry, no repro

`4e2182396fd` is a separate, smaller fix in the same function, kept as its own commit so it can be
dropped or split off.

With the default `route-shim-to-tct=shim-only`, the TCT branch selects shim tiles out of the tile map
collected *before* the per-column loop, which never contains the shim the loop materializes two lines
above it. So a column holding compute tiles but no *declared* shim got no TCT route, while the branch
immediately after it still wired that column's configuration path through that same materialized
shim. Which of the two paths a column received depended on whether the design happened to declare its
shim. Registering the shim in the tile set makes both branches see it, and makes a cross-column
design's routing for that column identical to the equivalent single-column design's; I verified that
by diffing the `input_physical.mlir` packet rules, where the `TileControl : 0` rule on the second
column's shim appears only after this change. No behaviour change for a design that declares its shim
in every column it uses, and no lit delta.

To be straight about the evidence: I found this while investigating the hang below, on the hypothesis
that a missing completion-token path was the cause. It is not. The hang reproduces with this applied,
so this commit fixes a real inconsistency with no failing test behind it. Happy to drop it if you
would rather it land with a repro, or as its own PR.

### Not fixed here

A design spanning two *adjacent* columns builds cleanly and then hangs on device
(`ERT_CMD_STATE_TIMEOUT`, `txn_op_idx = 0xFFFFFFFF`). Both columns hold tiles, so both allocations
already exist and neither commit changes that case.

What I can say from the bisect is that the trigger is the number of columns the overlay covers: one
overlay control-packet channel works, two hang, in either direction (shim in column 0 with compute in
column 1, and the reverse). Confirmed *not* the cause, each on device: the reconfiguration itself (it
hangs with the second `aiex.configure` deleted, so with zero reconfigurations), mem tile data seeding,
an explicit `aie.memtile_dma` versus objectFIFO-generated, unused tile declarations, a column whose
only tile is the shim, and the missing TCT route above. With two columns the host emits syncs against
both columns' shims and both channels' DMAs are issued, so nothing is obviously unissued or unawaited
in the lowered sequence.

I do not have the mechanism inside the two-channel delivery path and would be guessing if I proposed
one, so it is out of this PR. I can open it separately with the reduced repro if that is useful.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python)

