### PR TITLE
[AIEX] Guard verifyTaskBDDimensions against a mismatched dma_bd sizes list

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1117,6 +1117,11 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [AttrSizedOperandSegments]> {
     ::llvm::SmallVector<::mlir::OpFoldResult> getMixedSizes();
     ::llvm::SmallVector<::mlir::OpFoldResult> getMixedStrides();
 
+    // Consumers of the mixed lists index past the end of the operand range on
+    // a mismatch (llvm #179401). A BD in a DMA task reaches its parent op's
+    // verifier before its own, so that verifier must call this directly.
+    ::mlir::LogicalResult verifyMixedSizesAndStrides();
+
     // Reconstruct the historical BDDimLayoutAttr list (outermost-first) by
     // folding the mixed sizes/strides to constants. Returns:
     //   - empty vector if there are no dimensions (linear transfer);

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2192,6 +2192,24 @@ llvm::SmallVector<mlir::OpFoldResult> DMABDOp::getMixedStrides() {
       getContext());
 }
 
+LogicalResult DMABDOp::verifyMixedSizesAndStrides() {
+  llvm::ArrayRef<int64_t> staticSizes =
+      getStaticSizes().value_or(llvm::ArrayRef<int64_t>{});
+  llvm::ArrayRef<int64_t> staticStrides =
+      getStaticStrides().value_or(llvm::ArrayRef<int64_t>{});
+  if (failed(mlir::verifyListOfOperandsOrIntegers(
+          *this, "sizes", staticSizes.size(), staticSizes, getSizes())))
+    return failure();
+  if (failed(mlir::verifyListOfOperandsOrIntegers(
+          *this, "strides", staticStrides.size(), staticStrides, getStrides())))
+    return failure();
+  if (staticSizes.size() != staticStrides.size())
+    return emitOpError("expected the same number of sizes (")
+           << staticSizes.size() << ") and strides (" << staticStrides.size()
+           << ")";
+  return success();
+}
+
 std::optional<llvm::SmallVector<BDDimLayoutAttr>> DMABDOp::getFoldedDimensions(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
   llvm::SmallVector<mlir::OpFoldResult> sizes = getMixedSizes();
@@ -2325,23 +2343,8 @@ LogicalResult DMABDOp::verify() {
     }
   }
 
-  // The dynamic-operand count must match the kDynamic-sentinel count in each
-  // static array, and sizes/strides must agree in rank. Checked before any
-  // consumer calls getMixedValues, which crashes on a mismatch (llvm #179401).
-  llvm::ArrayRef<int64_t> staticSizes =
-      getStaticSizes().value_or(llvm::ArrayRef<int64_t>{});
-  llvm::ArrayRef<int64_t> staticStrides =
-      getStaticStrides().value_or(llvm::ArrayRef<int64_t>{});
-  if (failed(mlir::verifyListOfOperandsOrIntegers(
-          *this, "sizes", staticSizes.size(), staticSizes, getSizes())))
+  if (failed(verifyMixedSizesAndStrides()))
     return failure();
-  if (failed(mlir::verifyListOfOperandsOrIntegers(
-          *this, "strides", staticStrides.size(), staticStrides, getStrides())))
-    return failure();
-  if (staticSizes.size() != staticStrides.size())
-    return emitOpError("expected the same number of sizes (")
-           << staticSizes.size() << ") and strides (" << staticStrides.size()
-           << ")";
 
   // Fold the mixed sizes/strides to a constant BDDimLayoutAttr list for
   // verification; a runtime size/stride yields nullopt plus a diagnostic.

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -1125,6 +1126,20 @@ verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
     ++maxNDims; // leading dim is hoisted into the iteration/repeat register
   LogicalResult result = success();
   body.walk([&](AIE::DMABDOp bd) {
+    // AIE::DMABDOp::verify() only runs this same check when its parent is a
+    // MemOp/MemTileDMAOp/ShimDMAOp/DMAOp (see its own comment); a BD nested in
+    // a DMA task op reaches here unchecked. Validate the dynamic-operand count
+    // against the kDynamic-sentinel count in static_sizes before calling
+    // getMixedSizes(): mismatched lists make it call mlir::getMixedValues(),
+    // which indexes past the end of the operand range on a mismatch instead
+    // of diagnosing it (asserts in a debug build, OOB read otherwise).
+    llvm::ArrayRef<int64_t> staticSizes =
+        bd.getStaticSizes().value_or(llvm::ArrayRef<int64_t>{});
+    if (failed(mlir::verifyListOfOperandsOrIntegers(
+            bd, "sizes", staticSizes.size(), staticSizes, bd.getSizes()))) {
+      result = failure();
+      return;
+    }
     size_t numDims = bd.getMixedSizes().size();
     if (numDims > maxNDims) {
       bd.emitOpError() << "Cannot give more than " << std::to_string(maxNDims)

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -19,7 +19,6 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
-#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -1126,17 +1125,9 @@ verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
     ++maxNDims; // leading dim is hoisted into the iteration/repeat register
   LogicalResult result = success();
   body.walk([&](AIE::DMABDOp bd) {
-    // AIE::DMABDOp::verify() only runs this same check when its parent is a
-    // MemOp/MemTileDMAOp/ShimDMAOp/DMAOp (see its own comment); a BD nested in
-    // a DMA task op reaches here unchecked. Validate the dynamic-operand count
-    // against the kDynamic-sentinel count in static_sizes before calling
-    // getMixedSizes(): mismatched lists make it call mlir::getMixedValues(),
-    // which indexes past the end of the operand range on a mismatch instead
-    // of diagnosing it (asserts in a debug build, OOB read otherwise).
-    llvm::ArrayRef<int64_t> staticSizes =
-        bd.getStaticSizes().value_or(llvm::ArrayRef<int64_t>{});
-    if (failed(mlir::verifyListOfOperandsOrIntegers(
-            bd, "sizes", staticSizes.size(), staticSizes, bd.getSizes()))) {
+    // The BD's own verifier skips it here, so nothing has yet established that
+    // its mixed sizes/strides lists are safe to read.
+    if (failed(bd.verifyMixedSizesAndStrides())) {
       result = failure();
       return;
     }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-2.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-2.mlir
@@ -5,7 +5,7 @@
 
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
-// This test ensures that the proper error is emitted if the user attempts to sepcify more than
+// This test ensures that the proper error is emitted if the user attempts to specify more than
 // the architecturally possible number of data layout transformation dimensions in a `aie.dma_bd`
 // operation inside the runtime sequence. The DMAConfigureTaskOp verifier now rejects this at
 // verification time (a shim BD supports 3 access dimensions plus the hoisted iteration

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-20.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-20.mlir
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: aie-opt --verify-diagnostics %s
+
+// A dma_bd nested inside a DMAConfigureTaskOp is exempt from AIE::DMABDOp::
+// verify()'s own sizes/strides consistency check: that check only runs when
+// the BD's parent is a MemOp/MemTileDMAOp/ShimDMAOp/DMAOp (see the comment at
+// the top of DMABDOp::verify()), and a DMA-task BD's parent is none of those.
+// verifyTaskBDDimensions() (AIEXDialect.cpp) then calls bd.getMixedSizes() on
+// this never-validated BD to enforce the per-tile dimension cap. Before the
+// guard this test exercises, that crashed instead of diagnosing a malformed
+// static_sizes/sizes operand-count mismatch, because getMixedSizes() routes
+// through mlir::getMixedValues(), which indexes past the end of the dynamic
+// operand range on a mismatch (asserts in a debug build, OOB read otherwise).
+//
+// This state -- a static_sizes array whose dynamic-marker count disagrees
+// with the number of `sizes` SSA operands actually supplied -- is not
+// reachable through the pretty `sizes = [...]` syntax (its custom parser
+// always keeps the two lists consistent), so this is hand-written via the
+// generic op syntax to model malformed/fuzzed IR, not IR any real producer
+// emits.
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<32xi8>) {
+      %t1 = "aiex.dma_configure_task"(%tile_0_0) <{channel = 0 : i32, direction = 1 : i32, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+        // static_sizes declares one dynamic (kDynamic-sentinel) entry, but no
+        // `sizes` operand backs it (operandSegmentSizes' 4th entry, for
+        // $sizes, is 0).
+        // expected-error@+1 {{expected 1 dynamic sizes values}}
+        "aie.dma_bd"(%arg0) <{bd_id = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, static_len = 32 : i32, static_offset = 4 : i32, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 4, 1>}> : (memref<32xi8>) -> ()
+        aie.end
+      }) : (index) -> index
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-21.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-21.mlir
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: aie-opt --verify-diagnostics %s
+
+// As bad-20.mlir, but the mismatched list is `strides`. Unchecked, this state
+// reaches AIEDMATasksToNPU's bd.getMixedStrides() call, which indexes past the
+// end of the dynamic operand range.
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<32xi8>) {
+      %t1 = "aiex.dma_configure_task"(%tile_0_0) <{channel = 0 : i32, direction = 1 : i32, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+        // static_strides declares one dynamic (kDynamic-sentinel) entry, but no
+        // `strides` operand backs it (operandSegmentSizes' 5th entry, for
+        // $strides, is 0).
+        // expected-error@+1 {{expected 1 dynamic strides values}}
+        "aie.dma_bd"(%arg0) <{bd_id = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, static_len = 32 : i32, static_offset = 4 : i32, static_sizes = array<i64: 8, 2>, static_strides = array<i64: -9223372036854775808, 1>}> : (memref<32xi8>) -> ()
+        aie.end
+      }) : (index) -> index
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-22.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-22.mlir
@@ -1,0 +1,24 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: aie-opt --verify-diagnostics %s
+
+// As bad-20.mlir, but both lists are internally consistent and disagree only in
+// rank. Unchecked, AIEDMATasksToNPU's runtime-BD path pads the two mixed lists
+// to 4 dimensions in one loop bounded by the sizes rank, indexing the shorter
+// strides list and its 4-element destination out of bounds.
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<32xi8>) {
+      %t1 = "aiex.dma_configure_task"(%tile_0_0) <{channel = 0 : i32, direction = 1 : i32, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+        // expected-error@+1 {{expected the same number of sizes (2) and strides (1)}}
+        "aie.dma_bd"(%arg0) <{bd_id = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, static_len = 32 : i32, static_offset = 4 : i32, static_sizes = array<i64: 8, 2>, static_strides = array<i64: 1>}> : (memref<32xi8>) -> ()
+        aie.end
+      }) : (index) -> index
+    }
+  }
+}


### PR DESCRIPTION
### What

Add a guard in `verifyTaskBDDimensions` (`AIEXDialect.cpp`) so a `dma_bd` with a malformed `static_sizes`/`sizes` operand count, nested inside a `DMAConfigureTaskOp`, gets a diagnostic instead of crashing the verifier. Adds `bad-20.mlir`, a hand written generic-syntax test for this exact state, and fixes a one character typo (`sepcify` to `specify`) in `bad-2.mlir`'s comment while I was in the file.

### Why

`AIE::DMABDOp::verify()` already checks that a `dma_bd`'s `static_sizes` dynamic marker count matches its `sizes` SSA operand count, via `mlir::verifyListOfOperandsOrIntegers`, but only when the op's parent is a `MemOp`/`MemTileDMAOp`/`ShimDMAOp`/`DMAOp` (see that function's own comment). A `dma_bd` nested inside a `DMAConfigureTaskOp` has none of those as parent, so it reaches `verifyTaskBDDimensions` (called from `DMAConfigureTaskOp::verify()` to enforce the per tile ND dimension cap) completely unchecked. That function calls `bd.getMixedSizes()` on the never validated op, which routes through `mlir::getMixedValues()`. On a mismatch, `getMixedValues()` indexes past the end of the dynamic operand range instead of diagnosing it: an assertion failure when the linked MLIR core is built with assertions, an out of bounds read otherwise. A verifier's job is turning invalid IR into a diagnostic, not crashing on it.

This state is not reachable through the pretty `sizes = [...]` syntax (its custom parser always keeps the two lists consistent), so it models malformed or fuzzed IR rather than anything a real producer emits. Still, a verifier that can be made to assert or read out of bounds on adversarial input is worth closing, and this was flagged as an unresolved Copilot finding on #3351.

### How

Add the same `verifyListOfOperandsOrIntegers` check `DMABDOp::verify()` already uses, ahead of the `getMixedSizes()` call inside `verifyTaskBDDimensions`'s per BD walk. On failure it marks the containing result as failure and returns before reaching `getMixedSizes()`, so the existing dimension cap check downstream never runs on unchecked data.

### Test

`bad-20.mlir` constructs the mismatched state directly (`static_sizes` declares one dynamic, `kDynamic` sentinel entry, but `operandSegmentSizes` gives the `sizes` operand group zero entries) via the generic op syntax, since the pretty parser cannot produce it. With the fix, `aie-opt --verify-diagnostics bad-20.mlir` exits 0 (the expected `expected 1 dynamic sizes values` diagnostic matches). Without the fix (only this file's guard reverted, tests unchanged), the same invocation aborts:

```
aie-opt: mlir/lib/Dialect/Utils/StaticValueUtils.cpp:214: llvm::SmallVector<mlir::OpFoldResult> mlir::getMixedValues(...): Assertion `dynamicValues.size() == ...' failed.
```

exit 134, SIGABRT, with a stack trace through `DMABDOp::getMixedSizes()`, the `verifyTaskBDDimensions` walk lambda, and `DMAConfigureTaskOp::verify()`, confirming the exact call path the commit message describes. I checked this both ways rather than trusting that a passing test with the fix applied was sufficient. I also ran the rest of the `dma-tasks-to-npu` directory (46 files total, each via its own `RUN:` line) both ways: 46/46 pass with the fix, and without it exactly one file fails, `bad-20.mlir` itself (the other 45 are unaffected, including `bad-2.mlir`, whose own check is downstream of this guard and unrelated to it).

### Refs

Follow up to #3351 (mine, merged), closing a Copilot review finding left unresolved there: that `verifyTaskBDDimensions` calls `getMixedSizes()` purely to count dimensions, and `getMixedValues()` can assert when the `static_sizes` and `sizes` lists disagree. This is that check.
