### PR TITLE
docs: keep the "latest" alias symlink in gh-pages cleanup

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -218,11 +218,15 @@ jobs:
           # owns versioned subdirs (dev/, 1.x.y/, versions.json, index.html);
           # everything else at the root is carry-over from the old Jekyll setup.
           cd ../gh-pages-wt
+          # Keep the versioned dirs (dev/, 1.x.y/) plus the bare "latest"
+          # alias mike writes as a symlink (a file literally named "latest",
+          # no trailing slash). The (/|$) is load-bearing: matching only
+          # "latest/" would let git rm delete the symlink, 404-ing the site.
           git ls-files -z \
             | grep -zv '^\.nojekyll$' \
             | grep -zv '^index\.html$' \
             | grep -zv '^versions\.json$' \
-            | grep -zvE '^(dev|latest)/' \
+            | grep -zvE '^(dev|latest)(/|$)' \
             | grep -zvE '^[0-9]+\.' \
             | xargs -0 -r git rm -rf --ignore-unmatch -q
           cd -


### PR DESCRIPTION
## Problem
  
After cutting v1.4.0, the published docs site 404'd at its root: https://xilinx.github.io/mlir-aie/latest/ (and `/`, which redirects there).
  
## Root cause
  
`mike` publishes the `latest` alias as a **symlink** — a bare file named `latest` pointing at `1.4.0` (git mode `120000`), not a `latest/` directory.
  
The gh-pages cleanup step in `generateDocs.yml` removes legacy Jekyll detritus while keeping the versioned dirs. Its keep-list matched `^(dev|latest)/` — but that trailing slash only protects files *inside* a directory. The bare `latest` symlink matched nothing in the keep-list, so `git rm` deleted it during the v1.4.0 deploy run itself (gh-pages commit `619d5f3`, `latest | 1 -`).
  
The result: `versions.json` and the root `index.html` still pointed at `latest/`, but the symlink was gone → 404. This was the first tagged release deployed through mike, so the alias-symlink path had never been exercised before.
  
## Fix
  
Anchor the keep pattern with `(/|$)` so the bare `latest` symlink survives alongside the `latest/`-prefixed case. Added a comment explaining why the anchor is load-bearing. The live site was already repaired by restoring the symlink directly on `gh-pages`; this change prevents recurrence on the next `v*` tag.
  
## Test plan
  
- [x] Verified the fixed regex keeps a bare `latest` entry while the current one drops it (dry-run against a sample `git ls-files`).
- [x] Confirmed the live site recovered after restoring the symlink: `/`, `/latest/`, `/latest/programming_guide/`, `/1.4.0/`, `/dev/` all return HTTP 200.