### PR TITLE
Allow limiting build parallelism in `build-mlir-aie-from-wheels.sh`

### DIFF
--- a/utils/build-mlir-aie-from-wheels.sh
+++ b/utils/build-mlir-aie-from-wheels.sh
@@ -17,6 +17,20 @@
 # <build dir>    - optional, mlir-aie/build dir name, default is 'build'
 # <install dir>  - optional, mlir-aie/install dir name, default is 'install'
 #
+# Optional 4th positional arg / environment:
+#
+# <peano dir>              - optional 4th arg, Peano (llvm-aie) install dir;
+#                           default: located via 'pip show llvm-aie'
+#
+# Environment variables picked up by this script:
+#
+#   BUILD_TYPE                    CMake build type. Default: Release
+#   LLVM_ENABLE_RTTI              ON/OFF. Default: OFF
+#   COMPILE_JOBS=N                Cap parallel compiles (job pool, generation).
+#   LINK_JOBS=N                   Cap parallel links (job pool, generation).
+#   CMAKE_BUILD_PARALLEL_LEVEL=N  Overall -j at build time (cmake --build).
+#   EXTRA_CMAKE_ARGS="..."        Extra -D options appended last for overrides.
+#
 ##===----------------------------------------------------------------------===##
 
 # Windows (Git-for-Windows/MSYS) bash: gate off Linux-only assumptions.
@@ -90,7 +104,7 @@ BUILD_TYPE="${BUILD_TYPE:-Release}"
 mkdir -p $BUILD_DIR
 mkdir -p $INSTALL_DIR
 cd $BUILD_DIR
-#set -o pipefail
+set -o pipefail
 #set -e
 
 # Build the -D list as an array so paths with spaces survive as single args.
@@ -123,6 +137,21 @@ if [ -x "$(command -v ccache)" ]; then
   CMAKE_CONFIGS+=(-DLLVM_CCACHE_BUILD=ON)
 fi
 
+# Do not use LLVM_PARALLEL_{COMPILE,LINK}_JOBS: HandleLLVMOptions is included
+# several times in this tree, so those append duplicate pools.
+POOLS=""
+if [ -n "${COMPILE_JOBS}" ]; then
+  POOLS="compile=${COMPILE_JOBS}"
+  CMAKE_CONFIGS+=(-DCMAKE_JOB_POOL_COMPILE=compile)
+fi
+if [ -n "${LINK_JOBS}" ]; then
+  POOLS="${POOLS:+${POOLS};}link=${LINK_JOBS}"
+  CMAKE_CONFIGS+=(-DCMAKE_JOB_POOL_LINK=link)
+fi
+if [ -n "${POOLS}" ]; then
+  CMAKE_CONFIGS+=("-DCMAKE_JOB_POOLS=${POOLS}")
+fi
+
 # Allow callers (e.g. CI) to inject additional -D options without editing this
 # script. Appended last so they can override the defaults above. Values with
 # spaces can't survive this flat env var; callers must pass space-free paths.
@@ -132,9 +161,15 @@ if [ -n "${EXTRA_CMAKE_ARGS}" ]; then
 fi
 
 cmake "${CMAKE_CONFIGS[@]}" .. 2>&1 | tee cmake.log
-ninja 2>&1 | tee mlir-aie-ninja.log
-ninja install 2>&1 | tee mlir-aie-ninja-install.log
 success=$?
+if [ ${success} -eq 0 ]; then
+    cmake --build . 2>&1 | tee cmake-build.log
+    success=$?
+fi
+if [ ${success} -eq 0 ]; then
+    cmake --build . --target install 2>&1 | tee cmake-install.log
+    success=$?
+fi
 
 if [ ${success} -ne 0 ]
 then


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

On machines with limited RAM, the build can OOM with high job parallelism. This PR adds two env vars, COMPILE_JOBS and LINK_JOBS, that limits parallelism using job pools, which are enforced by the generated build files.

It also swaps the raw `ninja` calls for `cmake --build`, which respects the standard `CMAKE_BUILD_PARALLEL_LEVEL` for portable `-j` behavior.

Minor: fixed error handling w.r.t. `pipefail`.

```
# Default: no caps — Ninja uses all cores for everything (unchanged behavior).
./utils/build-mlir-aie-from-wheels.sh

# Limit linking to 2 at a time, compiles unbounded.
LINK_JOBS=2 ./utils/build-mlir-aie-from-wheels.sh

# Cap both: at most 8 concurrent compiles, 2 concurrent links.
COMPILE_JOBS=8 LINK_JOBS=2 ./utils/build-mlir-aie-from-wheels.sh

# Set the overall -j (no per-phase pools), via cmake --build.
CMAKE_BUILD_PARALLEL_LEVEL=4 ./utils/build-mlir-aie-from-wheels.sh
```
