### PR TITLE
[router] Fix packet flow channel sharing

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <iostream>
 #include <list>
+#include <optional>
 #include <set>
 
 namespace xilinx::AIE {
@@ -49,6 +50,9 @@ using SwitchboxConnect = struct SwitchboxConnect {
   std::vector<std::vector<int>> packetFlowCount;
   // only sharing the channel with the same packet group id
   std::vector<std::vector<int>> packetGroupId;
+  // packet ids currently routed through each channel (and its crossbar
+  // row/column); a channel may be shared only among distinct ids.
+  std::vector<std::vector<std::set<int>>> packetIds;
   // flags indicating priority routings
   std::vector<std::vector<bool>> isPriority;
 
@@ -63,6 +67,8 @@ using SwitchboxConnect = struct SwitchboxConnect {
     packetFlowCount.resize(srcPorts.size(),
                            std::vector<int>(dstPorts.size(), 0));
     packetGroupId.resize(srcPorts.size(), std::vector<int>(dstPorts.size(), 0));
+    packetIds.resize(srcPorts.size(),
+                     std::vector<std::set<int>>(dstPorts.size()));
     isPriority.resize(srcPorts.size(),
                       std::vector<bool>(dstPorts.size(), false));
   }
@@ -125,6 +131,10 @@ using Flow = struct Flow {
   bool isPriorityFlow;
   PathEndPoint src;
   std::vector<PathEndPoint> dsts;
+  // packet id carried by this flow (nullopt for circuit flows); a channel may
+  // be shared only among distinct ids so same-id flows never merge then fan
+  // out.
+  std::optional<int> packetId;
 };
 
 // A SwitchSetting defines the required settings for a Switchbox for a flow
@@ -186,7 +196,7 @@ public:
   virtual void initialize(int maxCol, int maxRow,
                           const AIETargetModel &targetModel) = 0;
   virtual void addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
-                       Port dstPort, bool isPacketFlow,
+                       Port dstPort, std::optional<int> packetId,
                        bool isPriorityFlow) = 0;
   virtual void sortFlows() = 0;
   virtual bool addFixedConnection(SwitchboxOp switchboxOp) = 0;
@@ -200,7 +210,7 @@ public:
   void initialize(int maxCol, int maxRow,
                   const AIETargetModel &targetModel) override;
   void addFlow(TileID srcCoords, Port srcPort, TileID dstCoords, Port dstPort,
-               bool isPacketFlow, bool isPriorityFlow) override;
+               std::optional<int> packetId, bool isPriorityFlow) override;
   void sortFlows() override;
   bool addFixedConnection(SwitchboxOp switchboxOp) override;
   std::optional<std::map<PathEndPoint, SwitchSettings>>

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -65,7 +65,7 @@ LogicalResult DynamicTileAnalysis::runAnalysis(DeviceOp &device) {
                      << stringifyWireBundle(dstPort.bundle) << dstPort.channel
                      << "\n");
           pathfinder->addFlow(srcCoords, srcPort, dstCoords, dstPort,
-                              /*isPktFlow*/ true, priorityFlow);
+                              pktFlowOp.IDInt(), priorityFlow);
         }
       }
     }
@@ -86,7 +86,7 @@ LogicalResult DynamicTileAnalysis::runAnalysis(DeviceOp &device) {
                << stringifyWireBundle(dstPort.bundle) << dstPort.channel
                << "\n");
     pathfinder->addFlow(srcCoords, srcPort, dstCoords, dstPort,
-                        /*isPktFlow*/ false, /*isPriorityFlow*/ false);
+                        /*packetId=*/std::nullopt, /*isPriorityFlow=*/false);
   }
 
   // Canonicalize all flows after both packet and circuit flows are collected.
@@ -304,9 +304,10 @@ void Pathfinder::initialize(int maxCol, int maxRow,
 // Add a flow from src to dst can have an arbitrary number of dst locations
 // due to fanout.
 void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
-                         Port dstPort, bool isPacketFlow, bool isPriorityFlow) {
+                         Port dstPort, std::optional<int> packetId,
+                         bool isPriorityFlow) {
   // check if a flow with this source already exists
-  for (auto &[_, prioritized, src, dsts] : flows) {
+  for (auto &[_, prioritized, src, dsts, pid] : flows) {
     if (src.coords == srcCoords && src.port == srcPort) {
       if (isPriorityFlow) {
         prioritized = true;
@@ -322,9 +323,9 @@ void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
   // channel sharing will happen within the same group ID
   // for circuit flows, group ID is always -1, and no channel sharing
   int packetGroupId = -1;
-  if (isPacketFlow) {
+  if (packetId.has_value()) {
     bool found = false;
-    for (auto &[existingId, _, src, dsts] : flows) {
+    for (auto &[existingId, _, src, dsts, pid] : flows) {
       if (src.coords == srcCoords && src.port == srcPort) {
         packetGroupId = existingId;
         found = true;
@@ -344,9 +345,9 @@ void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
     }
   }
   // If no existing flow was found with this source, create a new flow.
-  flows.push_back(
-      Flow{packetGroupId, isPriorityFlow, PathEndPoint{srcCoords, srcPort},
-           std::vector<PathEndPoint>{PathEndPoint{dstCoords, dstPort}}});
+  flows.push_back(Flow{
+      packetGroupId, isPriorityFlow, PathEndPoint{srcCoords, srcPort},
+      std::vector<PathEndPoint>{PathEndPoint{dstCoords, dstPort}}, packetId});
 }
 
 // Sort flows to (1) get deterministic routing, and (2) perform routings on
@@ -632,6 +633,7 @@ Pathfinder::findPaths(const int maxIterations) {
           sb.usedCapacity[i][j] = 0;
           sb.packetFlowCount[i][j] = 0;
           sb.packetGroupId[i][j] = -1;
+          sb.packetIds[i][j].clear();
         }
       }
     }
@@ -640,7 +642,8 @@ Pathfinder::findPaths(const int maxIterations) {
     // update used_capacity for the path between them
 
     for (const auto &[_, flows] : groupedFlows) {
-      for (const auto &[packetGroupId, isPriority, src, dsts] : flows) {
+      for (const auto &[packetGroupId, isPriority, src, dsts, packetId] :
+           flows) {
         // Use dijkstra to find path given current demand from the start
         // switchbox; find the shortest paths to each other switchbox. Output is
         // in the predecessor arrays, which must then be processed to get
@@ -675,14 +678,19 @@ Pathfinder::findPaths(const int maxIterations) {
             int i = e.i;
             int j = e.j;
             sb.isPriority[i][j] = isPriority;
+            // Packet flows in the same group may share a channel, but only if
+            // their ids differ, so two same-id flows never merge onto a channel
+            // and then fan back out to separate destinations.
             if (packetGroupId >= 0 &&
                 (sb.packetGroupId[i][j] == -1 ||
-                 sb.packetGroupId[i][j] == packetGroupId)) {
+                 sb.packetGroupId[i][j] == packetGroupId) &&
+                sb.packetIds[i][j].count(*packetId) == 0) {
               for (size_t k = 0; k < sb.srcPorts.size(); k++) {
                 for (size_t l = 0; l < sb.dstPorts.size(); l++) {
                   if (k == static_cast<size_t>(i) ||
                       l == static_cast<size_t>(j)) {
                     sb.packetGroupId[k][l] = packetGroupId;
+                    sb.packetIds[k][l].insert(*packetId);
                   }
                 }
               }

--- a/test/create-flows/same_id_shared_link.mlir
+++ b/test/create-flows/same_id_shared_link.mlir
@@ -1,0 +1,90 @@
+//===- same_id_shared_link.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// Regression test for the pathfinder "merge-then-fanout" packet-routing bug.
+//
+// Two DISTINCT packet flows share the same packet id (0) and the same
+// destination (mem_tile_1_1 DMA:3). The old router merged them onto a single
+// amsel and then fanned that merged stream out to two switchbox output ports,
+// so the two id-0 streams were delivered duplicated/indistinguishably and
+// deadlocked on hardware. The bug is order-dependent: it only surfaces when the
+// unrelated congestion flow (packet_flow(2), mem_tile_1_1 DMA:5 -> tile_3_5) is
+// routed before the two colliding id-0 flows.
+//
+// With id-gated channel sharing, the two id-0 flows must take disjoint physical
+// paths wherever they would otherwise share a link. The checks below pin that
+// at the merge tile (tile_1_2) each id-0 stream gets its own amsel driving a
+// single output port -- no amsel fans out to more than one masterset port.
+
+// CHECK-LABEL: aie.device(npu2)
+
+// Destination tile: both id-0 streams arrive on separate input ports (North : 0
+// and North : 3) and fan in to the single DMA : 3 endpoint.
+// CHECK:      %[[mem_tile_1_1:.*]] = aie.tile(1, 1)
+// CHECK:      aie.switchbox(%[[mem_tile_1_1]]) {
+// CHECK-NEXT:   %[[b0:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:   %[[b1:.*]] = aie.amsel<1> (0)
+// CHECK-NEXT:   aie.masterset(DMA : 3, %[[b1]])
+// CHECK-NEXT:   aie.masterset(North : 1, %[[b0]])
+// CHECK-NEXT:   aie.packet_rules(North : 0) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[b1]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(North : 3) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[b1]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(DMA : 5) {
+// CHECK-NEXT:     aie.rule(31, 2, %[[b0]])
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// Merge tile: the two id-0 streams stay on distinct amsels, each driving exactly
+// one output port (North : 1 -> South : 3 via %[[a1]]; North : 3 -> South : 0 via
+// %[[a2]]). No single amsel fans out to two ports.
+// CHECK:      %[[tile_1_2:.*]] = aie.tile(1, 2)
+// CHECK:      aie.switchbox(%[[tile_1_2]]) {
+// CHECK-NEXT:   %[[a0:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:   %[[a1:.*]] = aie.amsel<1> (0)
+// CHECK-NEXT:   %[[a2:.*]] = aie.amsel<2> (0)
+// CHECK-NEXT:   aie.masterset(South : 0, %[[a2]])
+// CHECK-NEXT:   aie.masterset(South : 3, %[[a1]])
+// CHECK-NEXT:   aie.masterset(East : 3, %[[a0]])
+// CHECK-NEXT:   aie.packet_rules(North : 3) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a2]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(North : 1) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a1]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(South : 1) {
+// CHECK-NEXT:     aie.rule(31, 2, %[[a0]])
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+module {
+  aie.device(npu2) {
+    %mem_tile_1_1 = aie.tile(1, 1)
+    %tile_2_3 = aie.tile(2, 3)
+    %tile_2_5 = aie.tile(2, 5)
+    %tile_3_5 = aie.tile(3, 5)
+    // Congestion flow -- must be routed FIRST to trigger the bug:
+    aie.packet_flow(2) {
+      aie.packet_source<%mem_tile_1_1, DMA : 5>
+      aie.packet_dest<%tile_3_5, DMA : 0>
+    }
+    // Two distinct flows sharing id 0 and dest mem_tile_1_1 DMA:3 -- the router merges
+    // these and fans the merged stream out to two ports:
+    aie.packet_flow(0) {
+      aie.packet_source<%tile_2_3, DMA : 0>
+      aie.packet_dest<%mem_tile_1_1, DMA : 3>
+    }
+    aie.packet_flow(0) {
+      aie.packet_source<%tile_2_5, DMA : 0>
+      aie.packet_dest<%mem_tile_1_1, DMA : 3>
+    }
+  }
+}


### PR DESCRIPTION
One of the FastFlowLM designs uncovered a fundamental routing bug for packet flows.

We want to enable channel sharing -- being able to multiplex a single channel is kind of the whole point of packet flows. But, when sharing channels, we need to be careful about packet IDs, so we can distinguish packets to different destinations. We don't need globally-unique packet IDs. But, as soon as two flows traverse the same channel _and_ need to later be split up again to different destinations, those two flows can't have the same ID.

The previous router had two bugs/shortcomings:
1. Routing was not packet ID-aware. 
2. The router only enabled sharing channels for flows that originated from the same source port or that ended at the same destination port. This is somewhat arbitrary (though it might make sense if you look at it from a bandwidth-bottleneck perspective).

**(Edit)** A previous iteration of this PR attempted to address both of those points, but that turned out to be a bigger challenge than anticipated. So, for now, I've decided to only fix (1) here; After this PR, the router never allows sharing a channel between two packet flows if they have the same ID.

The following is the concrete bug that the FastFlowLM design uncovered:
<img width="1103" height="1497" alt="image" src="https://github.com/user-attachments/assets/0a4708d3-642d-4c03-949e-73c58eb90202" />