### PR TITLE
build: enable ccache via COMPILER_LAUNCHER, not LLVM_CCACHE_BUILD

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -70,6 +70,15 @@ jobs:
       - name: Print hostname
         run: hostname
 
+      - name: ccache stats before the build
+        run: |
+          # These runners are long-lived and shared, so the ccache directory
+          # survives between runs while actions/checkout wipes the workspace.
+          # Deliberately read-only: no `ccache -z` and no `ccache -M`, because
+          # both write global state on a machine other jobs also build on.
+          # Print before and after instead; the delta is the per-job figure.
+          command -v ccache >/dev/null && ccache -s || echo "ccache not installed"
+
       - name: Setup virtual environment / prerequisites
         run: |
           source ./utils/env_install.sh aie-venv --dev --extras
@@ -247,6 +256,11 @@ jobs:
           fi
 
           popd
+      - name: ccache stats after the build
+        if: always()
+        run: |
+          command -v ccache >/dev/null && ccache -s || echo "ccache not installed"
+
       - name: Cleanup NPU_CACHE_HOME
         if: always()
         run: |
@@ -283,6 +297,15 @@ jobs:
       - name: Setup virtual environment / prerequisites
         run: |
           source ./utils/env_install.sh aie-venv --dev --extras
+
+      - name: ccache stats before the build
+        run: |
+          # These runners are long-lived and shared, so the ccache directory
+          # survives between runs while actions/checkout wipes the workspace.
+          # Deliberately read-only: no `ccache -z` and no `ccache -M`, because
+          # both write global state on a machine other jobs also build on.
+          # Print before and after instead; the delta is the per-job figure.
+          command -v ccache >/dev/null && ccache -s || echo "ccache not installed"
 
       - name: Fetch pinned HRX release
         run: |
@@ -378,6 +401,11 @@ jobs:
           NPU_RUNTIME=hrx make all
           NPU_RUNTIME=hrx make run
           popd
+
+      - name: ccache stats after the build
+        if: always()
+        run: |
+          command -v ccache >/dev/null && ccache -s || echo "ccache not installed"
 
       - name: Cleanup NPU_CACHE_HOME
         if: always()

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -34,8 +34,9 @@ env:
   XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
   VITIS: /opt/ryzen_ai-1.3.0.1/vitis_aie_essentials
   # ccache and lld are auto-detected and enabled by
-  # utils/build-mlir-aie-from-wheels.sh (LLVM_CCACHE_BUILD / LLVM_USE_LINKER),
-  # so only the options the script does not set itself are listed here.
+  # utils/build-mlir-aie-from-wheels.sh (CMAKE_<LANG>_COMPILER_LAUNCHER /
+  # LLVM_USE_LINKER), so only the options the script does not set itself are
+  # listed here.
   CMAKE_ARGS: |
             -DXRT_ROOT=/opt/xilinx/xrt \
             -DAIE_ENABLE_PYTHON_PASSES=OFF \

--- a/utils/build-mlir-aie-from-wheels.sh
+++ b/utils/build-mlir-aie-from-wheels.sh
@@ -133,8 +133,16 @@ if [ -x "$(command -v lld)" ]; then
   CMAKE_CONFIGS+=(-DLLVM_USE_LINKER=lld)
 fi
 
+# LLVM_CCACHE_BUILD is declared and acted on in llvm/CMakeLists.txt, LLVM's
+# top-level project file, not in HandleLLVMOptions.cmake, which is what a
+# standalone consumer includes.  Building mlir-aie against the MLIR wheels never
+# reaches that file, so the option was silently dropped and CMake said so on
+# every build ("Manually-specified variables were not used by the project:
+# LLVM_CCACHE_BUILD").  Set the launcher directly, which is the portable
+# spelling and the one this repo's own workflows already use.
 if [ -x "$(command -v ccache)" ]; then
-  CMAKE_CONFIGS+=(-DLLVM_CCACHE_BUILD=ON)
+  CMAKE_CONFIGS+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache)
+  CMAKE_CONFIGS+=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
 fi
 
 # Do not use LLVM_PARALLEL_{COMPILE,LINK}_JOBS: HandleLLVMOptions is included


### PR DESCRIPTION
`build-mlir-aie-from-wheels.sh` sets `-DLLVM_CCACHE_BUILD=ON` when ccache is on PATH. That variable is
declared and acted on in `llvm/CMakeLists.txt`, LLVM's top-level project file, and not in
`HandleLLVMOptions.cmake`, which is what a standalone consumer includes. A from-wheels build never
reaches it, so the option is dropped and CMake says so on every single build:

```
CMake Warning:
  Manually-specified variables were not used by the project:
    AIE_ENABLE_PYTHON_PASSES
    LLVM_CCACHE_BUILD
```

`LLVM_USE_LINKER`, set two lines above, is honoured, because `HandleLLVMOptions` owns that one. That is
probably why the dead half went unnoticed.

Three workflows already use the portable spelling, because they invoke cmake directly rather than
through this script (`buildAndTestMulti.yml:160`, `buildAndTestPythons.yml:123`,
`lintAndFormat.yml:362`). This makes the script agree with them.

## Measured

One machine, target `aie-opt`, build directory wiped before each build so the only thing carried over
is the ccache directory. That is how the Ryzen AI jobs run, since `actions/checkout` cleans the
workspace.

| configure | wall | ccache hits | ccache misses |
|---|---:|---:|---:|
| `LLVM_CCACHE_BUILD=ON`, build 1 | 163 s | +0 | +0 |
| `LLVM_CCACHE_BUILD=ON`, build 2 | 163 s | +0 | +0 |
| `COMPILER_LAUNCHER`, build 1 | 161 s | +0 | +146 |
| `COMPILER_LAUNCHER`, build 2 | **14 s** | +146 | +0 |

Zero hits and zero misses under the old flag is the tell: ccache was not being invoked at all, so there
was nothing to hit. Configure-level check on the same tree, the old flag yields 0 occurrences of
`ccache` in `build.ninja` and the launcher yields 351.

The Ryzen AI jobs are where I would expect this to matter most. They build from source on the
self-hosted runners with the workspace cleaned each run, and the flag being passed at all proves ccache
is installed there.

## Also in this PR

Corrects the comment in `buildAndTestRyzenAI.yml`, which currently tells readers ccache is already
enabled by this script.

`AIE_ENABLE_PYTHON_PASSES` rides in the same CMake warning. It is set to `OFF` at 8 sites across 7
workflows and declared nowhere in the project. I left it alone because I cannot tell from outside
whether it was renamed or dropped. Happy to delete the call sites in a follow-up if you can say which.

One note: fork PRs sit at `action_required` until a maintainer approves the runs, so I cannot get CI to
run on this myself.
