### PR TITLE
[Urgent] Temporarily revert Peano pin

### DIFF
--- a/utils/peano-requirements.txt
+++ b/utils/peano-requirements.txt
@@ -3,4 +3,4 @@
 # workflow (utils/update_peano_version.py) so a bad nightly is caught in a PR
 # instead of breaking main. Mirrors the eudsl pin style in python/requirements.txt.
 -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-llvm-aie==21.0.0.2026072701+bc83427c
+llvm-aie==21.0.0.2026072001+ce8c0f8f


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

This temporarily reverts the Peano pin update from #3431 back to the last known-working version (July 20th, 2026: llvm-aie==21.0.0.2026072001+ce8c0f8f)

For reasons unknown, the Windows version of the July 27th llvm wheel commit was either never produced or disappeared from the nightly channel. This will get Windows CI working again while we investigate. It appears we may need to update the github-action to account for Windows and Linux individually in the future.
