### PR TITLE
Pin a Peano nightly that ships a Windows wheel

### DIFF
--- a/utils/peano-requirements.txt
+++ b/utils/peano-requirements.txt
@@ -3,4 +3,4 @@
 # workflow (utils/update_peano_version.py) so a bad nightly is caught in a PR
 # instead of breaking main. Mirrors the eudsl pin style in python/requirements.txt.
 -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-llvm-aie==21.0.0.2026072701+bc83427c
+llvm-aie==21.0.0.2026073101+cfd8aae2


### PR DESCRIPTION
## Problem

`main` currently pins `llvm-aie==21.0.0.2026072701+bc83427c`, which published **only a manylinux wheel**. Every Windows job fails at `Setup IRON environment`:

```
ERROR: Could not find a version that satisfies the requirement
       llvm-aie==21.0.0.2026072701+bc83427c
ERROR: No matching distribution found for llvm-aie==21.0.0.2026072701+bc83427c
```

The error is easy to misread: pip's `from versions:` list is already filtered to Windows-compatible wheels, so it appears to stop at `2026072001` and suggests the pinned version was withdrawn. It wasn't — it exists, it just has no `win_amd64` wheel. Linux is unaffected, which is why only the Windows legs are red.

## Wheel coverage

| Nightly | manylinux | win_amd64 |
|---|---|---|
| `2026072001` | ✅ | ✅ |
| `2026072101` … `2026072901` | ✅ | ❌ |
| **`2026073101`** | ✅ | ✅ |

Windows publishing lapsed for about a week and resumed with `2026073101`.

## Fix

Pin `21.0.0.2026073101+cfd8aae2` — both wheels verified present in the nightly release assets. This rolls *forward* rather than reverting to `2026072001`, so the newer toolchain is kept.

## Follow-up (not in this PR)

`utils/update_peano_version.py` selects the latest nightly without checking that it has wheels for every platform CI builds on, which is what let this reach `main`. The header comment in `peano-requirements.txt` says the workflow exists "so a bad nightly is caught in a PR instead of breaking main" — that guarantee doesn't currently hold for Windows. Worth a separate issue.