### PR TITLE
update_peano_version: require wheels for every CI platform

### DIFF
--- a/utils/update_peano_version.py
+++ b/utils/update_peano_version.py
@@ -27,8 +27,22 @@ NIGHTLY_INDEX_URL = (
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REQUIREMENTS_FILE = REPO_ROOT / "utils" / "peano-requirements.txt"
 
-# Wheel filenames look like: llvm_aie-21.0.0.2026062501+c83e305a-py3-none-...whl
-WHEEL_VERSION_RE = re.compile(r"llvm_aie-([0-9][0-9.]*\+[0-9a-f]+)-")
+# Wheel filenames look like:
+#   llvm_aie-21.0.0.2026062501+c83e305a-py3-none-manylinux_2_27_x86_64...whl
+#   llvm_aie-21.0.0.2026062501+c83e305a-py3-none-win_amd64.whl
+# Capture the version and the platform tag separately: a nightly is only usable
+# once it has published a wheel for every platform CI builds on.
+WHEEL_RE = re.compile(r"llvm_aie-([0-9][0-9.]*\+[0-9a-f]+)-[^\"]*?-([^\"-]+)\.whl")
+
+# Platform tags CI needs. The Linux runners install the manylinux wheel and the
+# Windows runners the win_amd64 one, so a nightly missing either breaks half of
+# CI at IRON setup -- with a confusing error, because pip's "from versions:"
+# list is filtered to the current platform and so appears to omit the pin
+# entirely rather than reporting a platform mismatch.
+REQUIRED_PLATFORMS = {
+    "linux": lambda tag: "linux" in tag,
+    "windows": lambda tag: tag.startswith("win"),
+}
 
 # The pin line in peano-requirements.txt, e.g. llvm-aie==21.0.0.2026062501+c83e305a
 PIN_RE = re.compile(r"^(llvm-aie==)(\S+)[^\S\n]*$", re.MULTILINE)
@@ -42,16 +56,56 @@ def get_request(url):
     return urllib.request.urlopen(req, timeout=60)
 
 
-def fetch_latest_nightly():
+def fetch_nightly_platforms():
+    """Map each nightly version to the set of REQUIRED_PLATFORMS it ships."""
     with get_request(NIGHTLY_INDEX_URL) as response:
         html = response.read().decode("utf-8")
-    versions = set(WHEEL_VERSION_RE.findall(html))
-    if not versions:
+    found = {}
+    for version, platform_tag in WHEEL_RE.findall(html):
+        names = {
+            name
+            for name, matches in REQUIRED_PLATFORMS.items()
+            if matches(platform_tag)
+        }
+        if names:
+            found.setdefault(version, set()).update(names)
+    if not found:
         sys.exit(
             f"error: no llvm-aie wheels found at {NIGHTLY_INDEX_URL}; "
             "the index format may have changed."
         )
-    return max(versions, key=Version)
+    return found
+
+
+def fetch_latest_nightly():
+    """Newest nightly that has a wheel for every platform CI builds on.
+
+    Publishing is not atomic across platforms -- a nightly can ship its Linux
+    wheel while the Windows one is delayed or never appears (2026072101 through
+    2026072901 had no win_amd64 wheel at all). Taking the newest version
+    outright pins something half the CI fleet cannot install, so skip any
+    nightly that is not complete.
+    """
+    found = fetch_nightly_platforms()
+    complete = [v for v, plats in found.items() if plats == set(REQUIRED_PLATFORMS)]
+    if not complete:
+        newest = max(found, key=Version)
+        sys.exit(
+            f"error: no llvm-aie nightly at {NIGHTLY_INDEX_URL} has wheels for "
+            f"all required platforms ({', '.join(sorted(REQUIRED_PLATFORMS))}). "
+            f"Newest available is {newest} with: "
+            f"{', '.join(sorted(found[newest])) or 'none'}."
+        )
+
+    latest = max(complete, key=Version)
+    newest_any = max(found, key=Version)
+    if Version(newest_any) > Version(latest):
+        missing = sorted(set(REQUIRED_PLATFORMS) - found[newest_any])
+        print(
+            f"note: skipping {newest_any} and newer; no wheel for "
+            f"{', '.join(missing)}. Falling back to {latest}."
+        )
+    return latest
 
 
 def read_current():
@@ -101,7 +155,20 @@ def main():
     args = parser.parse_args()
 
     current = read_current()
-    target = args.peano_version.strip() or fetch_latest_nightly()
+    explicit = args.peano_version.strip()
+    if explicit:
+        # Check the hand-picked version too: pinning one that is missing a
+        # platform is exactly the failure this script exists to prevent.
+        available = fetch_nightly_platforms().get(explicit, set())
+        missing = sorted(set(REQUIRED_PLATFORMS) - available)
+        if missing:
+            sys.exit(
+                f"error: llvm-aie {explicit} has no wheel for "
+                f"{', '.join(missing)} at {NIGHTLY_INDEX_URL}."
+            )
+        target = explicit
+    else:
+        target = fetch_latest_nightly()
 
     print(f"current: {current}")
     print(f"target:  {target}")

--- a/utils/update_peano_version.py
+++ b/utils/update_peano_version.py
@@ -39,9 +39,14 @@ WHEEL_RE = re.compile(r"llvm_aie-([0-9][0-9.]*\+[0-9a-f]+)-[^\"]*?-([^\"-]+)\.wh
 # CI at IRON setup -- with a confusing error, because pip's "from versions:"
 # list is filtered to the current platform and so appears to omit the pin
 # entirely rather than reporting a platform mismatch.
+#
+# Match the architecture too, not just the OS: every runner is x86_64, so a
+# nightly that shipped only win_arm64 or only linux_aarch64 would satisfy a
+# looser OS-only check while still being uninstallable on the machines that
+# actually run CI. Add an entry here if CI grows a non-x86_64 runner.
 REQUIRED_PLATFORMS = {
-    "linux": lambda tag: "linux" in tag,
-    "windows": lambda tag: tag.startswith("win"),
+    "linux-x86_64": lambda tag: "linux" in tag and tag.endswith("x86_64"),
+    "windows-x86_64": lambda tag: tag == "win_amd64",
 }
 
 # The pin line in peano-requirements.txt, e.g. llvm-aie==21.0.0.2026062501+c83e305a


### PR DESCRIPTION
## Problem

`update_peano_version.py` picks the newest version string on the nightly index without checking which wheels that version actually shipped:

```python
WHEEL_VERSION_RE = re.compile(r"llvm_aie-([0-9][0-9.]*\+[0-9a-f]+)-")
...
return max(versions, key=Version)
```

Publishing is not atomic across platforms. A nightly can ship its Linux wheel while the Windows one is delayed — or never arrives. **`2026072101` through `2026073001` published no `win_amd64` wheel at all.**

That is how `2026072701` reached `main` and broke every Windows job at `Setup IRON environment` (fixed by #3477). The failure is easy to misdiagnose, because pip filters its `from versions:` list to the current platform, so the pinned version looks *withdrawn* rather than platform-incomplete.

This defeats the guarantee in `peano-requirements.txt`'s own header — that the workflow exists "so a bad nightly is caught in a PR instead of breaking main."

## Fix

Parse each wheel's platform tag alongside its version, and only treat a nightly as a bump candidate once it has wheels for **both** Linux and Windows. `REQUIRED_PLATFORMS` is the single place to extend if CI grows another platform.

When newer-but-incomplete nightlies exist, the script reports what it skipped instead of silently pinning something older:

```
note: skipping 21.0.0.2026073001+2d0a7d4e and newer; no wheel for windows.
      Falling back to 21.0.0.2026072001+ce8c0f8f.
```

An explicit `--peano-version` is validated the same way — hand-picking an incomplete nightly is the same failure mode:

```
error: llvm-aie 21.0.0.2026072701+bc83427c has no wheel for windows at
       https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly.
```

## Verification

Against the live index, platform detection is correct across the broken window:

| Nightly | Detected |
|---|---|
| `2026072001` | linux, windows |
| `2026072601` … `2026072901` | linux |
| `2026073101` | linux, windows |

Replaying the index as it stood on 30 Jul (with `2026073101` withheld), the script selects **`2026072001`** — the last complete nightly — instead of the `2026072701` that broke CI. A bad explicit pin exits 1; the default run resolves to `2026073101` and leaves the file untouched under `--identify-only`.

Depends on nothing; independent of #3477, which fixes the currently-pinned version.