### PR TITLE
docs: advertise the ROCm Discord (ROCm-NPU channel)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ below before contributing.
 We use GitHub to host code, collaborate, and manage version control. All changes
 go through pull requests; [GitHub issues](https://github.com/Xilinx/mlir-aie/issues)
 track known bugs, and [GitHub Discussions](https://github.com/Xilinx/mlir-aie/discussions)
-are the place for usage questions and feature ideas.
+are the place for usage questions and feature ideas. For more informal, real-time
+chat with the team and other users, join the [ROCm Discord](https://discord.gg/UbXzGdXsR5)
+and look for the **ROCm-NPU** channel.
 
 ## Issue tracking
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Latest tag](https://img.shields.io/github/v/tag/Xilinx/mlir-aie?sort=semver&label=release&cacheSeconds=86400)](https://github.com/Xilinx/mlir-aie/tags)
 [![License](https://img.shields.io/badge/license-Apache%202.0%20with%20LLVM%20exception-blue)](LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/Xilinx/mlir-aie?cacheSeconds=86400)](https://github.com/Xilinx/mlir-aie/graphs/contributors)
+[![Discord](https://img.shields.io/badge/Discord-ROCm--NPU-5865F2?logo=discord&logoColor=white)](https://discord.gg/UbXzGdXsR5)
 
 📖 **[Documentation](https://xilinx.github.io/mlir-aie/)** &nbsp;·&nbsp; 🚀 **[Programming Guide](programming_guide/)** &nbsp;·&nbsp; 🐍 **[Python API](https://xilinx.github.io/mlir-aie/api/)** &nbsp;·&nbsp; 💡 **[Examples](programming_examples/)**
 
@@ -329,6 +330,8 @@ Examples with a separate native host, explicit artifact builds, or multi-stage w
 1. AIE API header library documentation for single-core AIE programming in C++ is available [here](https://xilinx.github.io/aie_api/topics.html)
 
 1. If you are a university researcher or student and interested in trying these tools on our Ryzen™ AI AUP Cloud systems, please contact the [AMD University Program](mailto:aup@amd.com)
+
+1. Have a question or want to talk with the team and other users? Join the [ROCm Discord](https://discord.gg/UbXzGdXsR5) and look for the **ROCm-NPU** channel
 
 ## Optional: Install AIETools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,12 @@ with full control over tile placement, data movement, and vectorized compute.
 <span class="iron-card-desc">Agent Skills that teach a coding agent to port and optimize IRON designs.</span>
 </a>
 
+<a class="iron-card" href="https://discord.gg/UbXzGdXsR5" markdown>
+<span class="iron-card-icon">💬</span>
+<span class="iron-card-title">Join us on Discord</span>
+<span class="iron-card-desc">Chat with the team and other users in the ROCm Discord's ROCm-NPU channel.</span>
+</a>
+
 </div>
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,9 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/Xilinx/mlir-aie
       name: mlir-aie on GitHub
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/UbXzGdXsR5
+      name: Join us on the ROCm Discord (#ROCm-NPU)
     - icon: fontawesome/solid/paper-plane
       link: mailto:aup@amd.com
       name: AMD University Program


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

- Point contributors and users to the ROCm Discord's **ROCm-NPU** channel as an informal, real-time complement to GitHub Issues/Discussions.
- Add Discord links/badges to `README.md`, `CONTRIBUTING.md`, `docs/index.md` (landing page card), and `mkdocs.yml` (site footer social link).

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
