### PR TITLE
ci: stop running the NPU workflows twice per merged PR

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -26,7 +26,12 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-ryzenai-${{ github.event.number || github.sha }}-${{ github.event_name }}
+  #
+  # github.event_name is deliberately NOT part of the key. The merge queue tests
+  # a candidate SHA, then that same SHA lands on main and fires a `push` run --
+  # keying on the event made those two distinct groups, so every merged PR
+  # occupied the self-hosted NPU runners twice for the identical commit.
+  group: ci-build-test-ryzenai-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/buildAndTestRyzenAIWindows.yml
+++ b/.github/workflows/buildAndTestRyzenAIWindows.yml
@@ -22,7 +22,12 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-ryzenai-windows-${{ github.event.number || github.sha }}-${{ github.event_name }}
+  #
+  # github.event_name is deliberately NOT part of the key. The merge queue tests
+  # a candidate SHA, then that same SHA lands on main and fires a `push` run --
+  # keying on the event made those two distinct groups, so every merged PR
+  # occupied the single self-hosted NPU runner twice for the identical commit.
+  group: ci-build-test-ryzenai-windows-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Problem

The merge queue tests a candidate SHA, then that same SHA lands on `main` and fires a `push` run. `github.event_name` was part of the concurrency key, so those became **distinct groups** — meaning every merged PR occupied the self-hosted NPU runners **twice for a byte-identical commit**.

Observed on three consecutive merges today, each tested twice on the single Windows npu2 box at ~20 min per run:

| PR | merge_group | push | SHA |
|---|---|---|---|
| #3456 | 17:18 | 17:43 | `e90b1b0a` |
| #3478 | 17:43 | 18:15 | `c328b871` |
| #3474 | 18:47 | 18:17 | `a4e05330` |

## Fix

Drop `-${{ github.event_name }}` from the key so the `push` run collapses into the `merge_group` run for the same SHA:

| event | before | after |
|---|---|---|
| `pull_request` | `...-3468-pull_request` | `...-3468` |
| `merge_group` | `...-c328b87-merge_group` | `...-c328b87` |
| `push` | `...-c328b87-push` | `...-c328b87` ← same group |
| `schedule` | `...-deadbee-schedule` | `...-deadbee` |

`pull_request` keys on the PR number and `schedule` on its own SHA, so both stay in their own groups — presubmit cancellation behaviour is unchanged. Only the merge_group/push pair, which is genuinely redundant, is collapsed.

Applied to both hardware workflows. Several other workflows (`buildAndTestAieTools`, `buildAndTestRyzenAISw`, `buildRyzenWheels`) already omit `event_name`, so this also makes the pattern consistent.

## Why it matters

The Windows workflow shares a **single** self-hosted npu2 runner. Measured today:

- execution time is a steady **20.1 min** (n=8, range 18.4–20.9), runs back-to-back → capacity ≈ **3 runs/hour**
- arrivals were ≈ **6.4/hour**, so the queue grew to **16 deep with 2.5–3 hour waits**

Roughly **5 of those 16 queued runs were duplicate `push` runs** this change removes. That is not a full fix for the saturation, but it is free — it strictly removes work already done, with no loss of coverage.