### PR TITLE
ci: retry the CREATE_HWCTX transient on the on-device runners

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -102,6 +102,10 @@ jobs:
           # pure noise. Retry once when the failure matches a known transient
           # signature:
           #   1. aie2-4col NPU hardware fault (DRM_IOCTL_AMDXDNA_EXEC_CMD I/O error).
+          #   1b. Hardware-context creation failure (DRM_IOCTL_AMDXDNA_CREATE_HWCTX
+          #      err=-2). The driver intermittently cannot hand out a context; the
+          #      same test passes on a re-run. Seen on both NPU generations, so
+          #      unlike the EIO case it is not restricted to aie2-4col.
           #   2. A host/device read race in an on-device test: an "X != X" result
           #      mismatch where the observed and reference values are equal. The
           #      host read an output buffer before the NPU DMA had fully landed;
@@ -133,6 +137,10 @@ jobs:
             if [ "${{ matrix.runner_type }}" = "aie2-4col" ] && \
                grep -qF "DRM_IOCTL_AMDXDNA_EXEC_CMD IOCTL failed (err=-5): Input/output error" "$log"; then
               transient=eio
+            elif grep -qF "DRM_IOCTL_AMDXDNA_CREATE_HWCTX IOCTL failed (err=-2): No such file or directory" "$log"; then
+              # Same shape as the EIO case -- the abort can leave tests un-run --
+              # so it takes the full-suite retry path rather than narrowing.
+              transient=hwctx
             elif grep -Pq 'idx [0-9]+: ([0-9]+) != \1\b' "$log"; then
               transient=readrace
             fi


### PR DESCRIPTION
## Problem

```
DRM_IOCTL_AMDXDNA_CREATE_HWCTX IOCTL failed (err=-2): No such file or directory
```

The driver intermittently cannot hand out a hardware context; the same test passes on a re-run. It hit `basic/memcpy/run.lit` and `matrix_multiplication/single_core` within a few hours, each costing a manual re-run, because the retry matcher only covered `EXEC_CMD err=-5`.

## Fix

Add the signature to the transient classifier.

- **Not gated on `aie2-4col`**, unlike the EIO rule — it has been seen on both NPU generations, so restricting it would leave the flake unhandled on the other runner.
- **Full-suite retry path.** Like EIO, this can abort lit mid-suite leaving tests un-run, so narrowing to the failed tests would silently drop coverage. Only the read-race case narrows.
- A deterministic failure still fails both passes, so this only masks nondeterminism.

Verified the classifier against captured log text: a `CREATE_HWCTX` log classifies as `hwctx`, an `EXEC_CMD` log still as `eio`, and a genuine mismatch (`idx 3: 7 != 9`) matches nothing and is not retried.

## Removed from this PR: the concurrency de-duplication

An earlier revision also dropped `github.event_name` from the concurrency key, to stop a `merge_group` run and the follow-up `push` run testing the same SHA twice (7 duplicate pairs observed in one afternoon on the single Windows runner).

**That change was wrong and has been dropped.** Copilot correctly pointed out that with `cancel-in-progress` disabled for postsubmit, sharing a group only *serializes* the two runs — both still execute, so nothing is de-duplicated.

Checking the docs while confirming that turned up a worse consequence. Pending runs are handled separately from in-progress ones:

> "By default, any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place."

That applies **regardless of `cancel-in-progress`**. Since the Windows queue routinely runs hours deep, the `merge_group` run is often still *pending* when the push arrives — 4 of 10 recent pairs. The push would then have cancelled the merge-queue check that gates `main`, replacing a required check with a postsubmit run. Strictly worse than the duplication it was meant to fix.

Genuinely fixing the duplication means the push run must never be *created*, not merely cancelled — e.g. dropping `push: branches: [main]` and relying on `merge_group` plus the nightly `schedule`. That is a real policy change (it assumes every commit reaches `main` through the queue; `enforce_admins` is currently `false`, so a direct admin push would bypass it), so it belongs in its own PR with its own discussion rather than riding along here.