### PR TITLE
[CI] Serialize gh-pages deploys to stop mike push racess

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -7,6 +7,15 @@ name: Generate GitHub Pages
 permissions:
   contents: read
 
+# Serialize deploys instead of racing them: mike and the Doxygen-copy step
+# both push to gh-pages, so two runs overlapping (e.g. back-to-back pushes
+# to main) can have the second's push rejected as non-fast-forward.
+# cancel-in-progress is false so a queued run still deploys rather than
+# being dropped.
+concurrency:
+  group: generate-docs-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches:


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Overlapping generateDocs.yml runs (e.g. two quick pushes to main) both try to push to gh-pages via mike; the second's push gets rejected as non-fast-forward, failing the "Deploy with mike" step. Add a concurrency group so runs queue instead of racing.


## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
