### PR TITLE
ci: stop re-testing merged commits on the NPU runners

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -7,9 +7,12 @@ permissions:
   contents: read
 
 on:
+  # No `push` on main: see buildAndTestRyzenAIWindows.yml. The merge queue tests
+  # the exact commit that merging pushes to main, and main is admin-enforced
+  # with a required merge queue and no force pushes, so the postsubmit run only
+  # ever re-tests an already-tested SHA. The nightly schedule still covers main.
   push:
     branches:
-      - main
       - test-ryzen-ai
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/buildAndTestRyzenAIWindows.yml
+++ b/.github/workflows/buildAndTestRyzenAIWindows.yml
@@ -7,9 +7,16 @@ permissions:
   contents: read
 
 on:
+  # No `push` on main: the merge queue already tests the exact commit that
+  # merging pushes there, so a postsubmit run re-tests an identical SHA. main is
+  # admin-enforced with a required merge queue and no force pushes, so nothing
+  # can reach it without a merge_group run having tested it first. The nightly
+  # schedule below still covers main for environment drift.
+  #
+  # test-ryzen-ai is kept: it is a manual push target that does not go through
+  # the queue, so it has no merge_group run to inherit.
   push:
     branches:
-      - main
       - test-ryzen-ai
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Problem

The merge queue tests a candidate commit, and merging pushes **that exact commit** to `main` — which then fires a second, identical run of both on-device workflows.

Over the last 60 runs of each workflow:

| Trigger | Runs | |
|---|---|---|
| `pull_request` | 36 | 60% |
| `merge_group` | 12 | 20% |
| **`push`** | **12** | **20% — every one a duplicate** |

Seven duplicate pairs confirmed by SHA in a single afternoon:

| SHA | merge_group | push |
|---|---|---|
| `c81063d9` | 16:09 | 16:59 |
| `50f5d19f` | 16:52 | 17:18 |
| `e90b1b0a` | 16:59 | 17:43 |
| `c328b871` | 17:18 | 18:15 |
| `a4e05330` | 17:43 | 18:17 |
| `7b075665` | 18:47 | 19:12 |
| `3df743ab` | 18:48 | 19:17 |

This is expensive because these are **self-hosted NPU runners**, not ephemeral cloud ones. The Windows workflow shares a single npu2 box that executes ~3 runs/hour (measured: 20.1 min mean, n=8, back-to-back). Its queue has been 20+ deep with PR runs waiting 2–3 hours to start.

## Fix

Drop `main` from the `push:` trigger on both on-device workflows.

**This is safe because nothing can reach `main` without the queue having tested it.** Verified on the current branch protection:

```
enforce_admins          : True
required_linear_history : True
allow_force_pushes      : False
required_status_checks  : strict=True
merge queue             : enabled (SQUASH, ALLGREEN)
```

With `enforce_admins` now on, even admins cannot bypass it, so the postsubmit run adds no coverage that the merge_group run did not already provide.

## What is preserved

- **On-device tests still run on every PR and again in the merge queue** — presubmit coverage is unchanged.
- **Both required status checks** (`aie2-4col`, `aie2p-8col`) come from `pull_request` / `merge_group`, which are untouched. Branch protection is unaffected.
- **The nightly `schedule` run** still executes against `main`, so environment drift on the runners is still caught even though no commit-triggered postsubmit runs.
- **`test-ryzen-ai` keeps its push trigger** — it is a manual push target that does not go through the queue, so it has no `merge_group` run to inherit.

## Why not a concurrency-key change

An earlier attempt de-duplicated via the concurrency group instead. That does not work: sharing a group only *serializes* the two runs, and pending runs are cancelled and replaced independently of `cancel-in-progress`, so the push run could displace a still-pending merge-queue check. Removing the trigger avoids creating the second run at all. (See #3484 for that discussion.)

## Expected effect

Removes ~20% of the load on both NPU runner pools, with no loss of coverage. It does not fully fix the Windows saturation — arrivals are ~6.4/hour against ~3/hour service — but it is the part that is unambiguously redundant. Reducing `pull_request: [synchronize]` runs would be the next lever and is a genuine policy tradeoff, so it is left out of this PR.