### PR TITLE
[AIEVec] Preserve operand signedness through vector.contract lowering

### DIFF
--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -658,9 +658,11 @@ def AIEVec_MatMulOp:
     operands to recover the narrow input types. That peel would otherwise
     discard whether each operand is signed, which the AIE2 MAC needs in order
     to set the `signX`/`signY` bits of its configuration word. The optional
-    `lhsSigned`/`rhsSigned` attributes carry that information forward. When
-    absent, the lowering falls back to inferring signedness from the operand
-    types (preserving behavior for hand-written `aievec.matmul` IR).
+    `lhsSigned`/`rhsSigned` attributes carry that information forward. When an
+    attribute is absent (e.g. hand-written `aievec.matmul` IR), the lowering
+    uses the historical asymmetric defaults: the lhs is treated as unsigned
+    unless it is fed by an `arith.extsi`, and the rhs is treated as signed
+    unless its element type is explicitly unsigned.
 
     Currently, this intrinsic supports the following type combinations:
 
@@ -700,6 +702,12 @@ def AIEVec_MatMulOp_AIE2P:
   let description = [{
     AMD AIEv2P-specific intrinsic that performs a matrix multiplication
     between `lhs` and `rhs`, and accumulates the result in `acc`.
+
+    As for `aievec.matmul`, the optional `lhsSigned`/`rhsSigned` attributes
+    carry each operand's signedness (lost when the pattern peels the
+    `arith.extsi`/`arith.extui`) so the integer MAC configuration word can set
+    its `signX`/`signY` bits. When absent, the integer lowering defaults to
+    signed x signed.
 
     Currently, this intrinsic supports the following type combinations:
 

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -644,25 +644,18 @@ def AIEVec_MatMulOp:
   ]>,
   Arguments<(ins AIE2MatMulLHS:$lhs,
                  AIE2MatMulRHS:$rhs,
-                 AIE2MatMulACC:$acc,
-                 OptionalAttr<BoolAttr>:$lhsSigned,
-                 OptionalAttr<BoolAttr>:$rhsSigned)>,
+                 AIE2MatMulACC:$acc)>,
   Results<(outs AIE2MatMulACC:$result)> {
   let summary = "AIE2 matrix-multiply and accummulate";
   let description = [{
     AMD AIEv2-specific intrinsic that performs a matrix multiplications
     between `lhs` and `rhs`, and accumulates the result in `acc`.
 
-    MLIR integers are signless, and the pattern that creates this op from a
-    `vector.contract` looks through any `arith.extsi`/`arith.extui` on the
-    operands to recover the narrow input types. That peel would otherwise
-    discard whether each operand is signed, which the AIE2 MAC needs in order
-    to set the `signX`/`signY` bits of its configuration word. The optional
-    `lhsSigned`/`rhsSigned` attributes carry that information forward. When an
-    attribute is absent (e.g. hand-written `aievec.matmul` IR), the lowering
-    uses the historical asymmetric defaults: the lhs is treated as unsigned
-    unless it is fed by an `arith.extsi`, and the rhs is treated as signed
-    unless its element type is explicitly unsigned.
+    Operand signedness is carried in the integer element types: a signed
+    element type (`si8`) sets the MAC `signX`/`signY` bit, an unsigned type
+    (`ui8`) clears it. A signless element type (`i8`) keeps the historical
+    asymmetric defaults for hand-written IR: the lhs is treated as unsigned and
+    the rhs as signed.
 
     Currently, this intrinsic supports the following type combinations:
 
@@ -694,20 +687,16 @@ def AIEVec_MatMulOp_AIE2P:
   ]>,
   Arguments<(ins AIE2PMatMulLHS:$lhs,
                  AIE2PMatMulRHS:$rhs,
-                 AIE2PMatMulACC:$acc,
-                 OptionalAttr<BoolAttr>:$lhsSigned,
-                 OptionalAttr<BoolAttr>:$rhsSigned)>,
+                 AIE2PMatMulACC:$acc)>,
   Results<(outs AIE2PMatMulACC:$result)> {
   let summary = "AIE2P matrix-multiply and accummulate";
   let description = [{
     AMD AIEv2P-specific intrinsic that performs a matrix multiplication
     between `lhs` and `rhs`, and accumulates the result in `acc`.
 
-    As for `aievec.matmul`, the optional `lhsSigned`/`rhsSigned` attributes
-    carry each operand's signedness (lost when the pattern peels the
-    `arith.extsi`/`arith.extui`) so the integer MAC configuration word can set
-    its `signX`/`signY` bits. When absent, the integer lowering defaults to
-    signed x signed.
+    As for `aievec.matmul`, operand signedness is carried in the integer
+    element types (`si8`/`ui8`) so the integer MAC configuration word can set
+    its `signX`/`signY` bits. A signless element type defaults to signed.
 
     Currently, this intrinsic supports the following type combinations:
 

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -653,9 +653,14 @@ def AIEVec_MatMulOp:
 
     Operand signedness is carried in the integer element types: a signed
     element type (`si8`) sets the MAC `signX`/`signY` bit, an unsigned type
-    (`ui8`) clears it. A signless element type (`i8`) keeps the historical
-    asymmetric defaults for hand-written IR: the lhs is treated as unsigned and
-    the rhs as signed.
+    (`ui8`) clears it. Prefer spelling the signedness out.
+
+    A signless element type (`i8`) falls back to the pre-existing asymmetric
+    behavior -- lhs treated as unsigned, rhs as signed. That fallback is kept
+    only for compatibility with IR written before signedness was expressible
+    here; it is not a recommended default, and it disagrees with
+    `aievec.matmul_aie2p`, which defaults signless operands to signed.
+    Reconciling the two is left to a follow-up.
 
     Currently, this intrinsic supports the following type combinations:
 

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -644,12 +644,23 @@ def AIEVec_MatMulOp:
   ]>,
   Arguments<(ins AIE2MatMulLHS:$lhs,
                  AIE2MatMulRHS:$rhs,
-                 AIE2MatMulACC:$acc)>,
+                 AIE2MatMulACC:$acc,
+                 OptionalAttr<BoolAttr>:$lhsSigned,
+                 OptionalAttr<BoolAttr>:$rhsSigned)>,
   Results<(outs AIE2MatMulACC:$result)> {
   let summary = "AIE2 matrix-multiply and accummulate";
   let description = [{
     AMD AIEv2-specific intrinsic that performs a matrix multiplications
     between `lhs` and `rhs`, and accumulates the result in `acc`.
+
+    MLIR integers are signless, and the pattern that creates this op from a
+    `vector.contract` looks through any `arith.extsi`/`arith.extui` on the
+    operands to recover the narrow input types. That peel would otherwise
+    discard whether each operand is signed, which the AIE2 MAC needs in order
+    to set the `signX`/`signY` bits of its configuration word. The optional
+    `lhsSigned`/`rhsSigned` attributes carry that information forward. When
+    absent, the lowering falls back to inferring signedness from the operand
+    types (preserving behavior for hand-written `aievec.matmul` IR).
 
     Currently, this intrinsic supports the following type combinations:
 
@@ -681,7 +692,9 @@ def AIEVec_MatMulOp_AIE2P:
   ]>,
   Arguments<(ins AIE2PMatMulLHS:$lhs,
                  AIE2PMatMulRHS:$rhs,
-                 AIE2PMatMulACC:$acc)>,
+                 AIE2PMatMulACC:$acc,
+                 OptionalAttr<BoolAttr>:$lhsSigned,
+                 OptionalAttr<BoolAttr>:$rhsSigned)>,
   Results<(outs AIE2PMatMulACC:$result)> {
   let summary = "AIE2P matrix-multiply and accummulate";
   let description = [{

--- a/include/aie/Dialect/AIEVec/IR/AIEVecTypeConstraints.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecTypeConstraints.td
@@ -47,39 +47,45 @@ class VectorOfBitWidthAndElementTypes<int bitwidth, list<Type> allowedTypes> :
             CPred<ShapedTypeBitWidth<"_self">.result # " == " # bitwidth>]>,
        bitwidth # "-bit wide vector, of " # AnyTypeOf<allowedTypes>.summary>;
 
+// Matmul integer operands carry signedness in the element type (e.g. si8/ui8);
+// a signless type keeps the historical default. AnyI<w> (isInteger(w)) matches
+// signless, signed, and unsigned integers of that width. Upstream defines
+// AnyI8/16/32/64; AnyI4 is not upstream, so define it here.
+def AnyI4 : AnyI<4>;
+
 def AIE2MatMulLHS :
-  AnyTypeOf<[VectorOfShapeAndType<[4, 16], I8>,
-             VectorOfShapeAndType<[4, 8], I8>,
-             VectorOfShapeAndType<[4, 4], I16>,
-             VectorOfShapeAndType<[4, 2], I16>,
-             VectorOfShapeAndType<[2, 8], I16>,
-             VectorOfShapeAndType<[4, 8], I16>,
-             VectorOfShapeAndType<[2, 4], I16>,
-             VectorOfShapeAndType<[4, 2], I32>,
+  AnyTypeOf<[VectorOfShapeAndType<[4, 16], AnyI8>,
+             VectorOfShapeAndType<[4, 8], AnyI8>,
+             VectorOfShapeAndType<[4, 4], AnyI16>,
+             VectorOfShapeAndType<[4, 2], AnyI16>,
+             VectorOfShapeAndType<[2, 8], AnyI16>,
+             VectorOfShapeAndType<[4, 8], AnyI16>,
+             VectorOfShapeAndType<[2, 4], AnyI16>,
+             VectorOfShapeAndType<[4, 2], AnyI32>,
              VectorOfShapeAndType<[4, 8], BF16>],
             "a vector compatible with a lhs operand of matrix-multiply and "
             # "accumulate",
             "::mlir::VectorType">;
 
 def AIE2MatMulRHS :
-  AnyTypeOf<[VectorOfShapeAndType<[16, 8], I4>,
-             VectorOfShapeAndType<[8, 8], I8>,
-             VectorOfShapeAndType<[4, 8], I8>,
-             VectorOfShapeAndType<[2, 8], I16>,
-             VectorOfShapeAndType<[8, 4], I8>,
-             VectorOfShapeAndType<[4, 8], I16>,
-             VectorOfShapeAndType<[4, 4], I16>,
-             VectorOfShapeAndType<[2, 4], I16>,
+  AnyTypeOf<[VectorOfShapeAndType<[16, 8], AnyI4>,
+             VectorOfShapeAndType<[8, 8], AnyI8>,
+             VectorOfShapeAndType<[4, 8], AnyI8>,
+             VectorOfShapeAndType<[2, 8], AnyI16>,
+             VectorOfShapeAndType<[8, 4], AnyI8>,
+             VectorOfShapeAndType<[4, 8], AnyI16>,
+             VectorOfShapeAndType<[4, 4], AnyI16>,
+             VectorOfShapeAndType<[2, 4], AnyI16>,
              VectorOfShapeAndType<[8, 4], BF16>],
             "a vector compatible with a rhs operand of matrix-multiply and "
             # "accumulate",
             "::mlir::VectorType">;
 
 def AIE2MatMulACC :
-  AnyTypeOf<[VectorOfShapeAndType<[4, 8], I32>,
-             VectorOfShapeAndType<[4, 4], I32>,
-             VectorOfShapeAndType<[2, 8], I64>,
-             VectorOfShapeAndType<[4, 4], I64>,
+  AnyTypeOf<[VectorOfShapeAndType<[4, 8], AnyI32>,
+             VectorOfShapeAndType<[4, 4], AnyI32>,
+             VectorOfShapeAndType<[2, 8], AnyI64>,
+             VectorOfShapeAndType<[4, 4], AnyI64>,
              VectorOfShapeAndType<[4, 4], F32>],
             "a vector compatible with an accumulator of matrix-multiply and "
             # "accumulate",
@@ -90,8 +96,8 @@ def AIE2PMatMulLHS :
             VectorOfShapeAndType<[8, 4], BF16>,
             VectorOfShapeAndType<[8, 1], BF16>,
             VectorOfShapeAndType<[4, 8], BF16>,
-            VectorOfShapeAndType<[8, 8], I8>,
-            VectorOfShapeAndType<[8, 2], I16>],
+            VectorOfShapeAndType<[8, 8], AnyI8>,
+            VectorOfShapeAndType<[8, 2], AnyI16>],
             "a vector compatible with a lhs operand of AIE2P matrix-multiply and "
             # "accumulate",
             "::mlir::VectorType">;
@@ -101,8 +107,8 @@ def AIE2PMatMulRHS :
             VectorOfShapeAndType<[4, 8], BF16>,
             VectorOfShapeAndType<[1, 8], BF16>,
             VectorOfShapeAndType<[8, 4], BF16>,
-            VectorOfShapeAndType<[8, 8], I8>,
-            VectorOfShapeAndType<[2, 8], I16>],
+            VectorOfShapeAndType<[8, 8], AnyI8>,
+            VectorOfShapeAndType<[2, 8], AnyI16>],
             "a vector compatible with a rhs operand of AIE2P matrix-multiply and "
             # "accumulate",
             "::mlir::VectorType">;
@@ -112,7 +118,7 @@ def AIE2PMatMulACC :
              VectorOfShapeAndType<[8, 4], F32>,
              VectorOfShapeAndType<[4, 8], F32>,
              VectorOfShapeAndType<[4, 4], F32>,
-             VectorOfShapeAndType<[8, 8], I32>],
+             VectorOfShapeAndType<[8, 8], AnyI32>],
             "a vector compatible with an accumulator of AIE2P matrix-multiply and "
             # "accumulate",
             "::mlir::VectorType">;
@@ -141,34 +147,34 @@ class VectorTypesMatch<string op1, Type t1,
 class IsValidAIE2MatMulShapeAndType<string lhs, string rhs, string acc> :
   PredOpTrait<lhs # " x " # rhs # " = " # acc # " is a valid AIE2 " #
               "matrix-multiply and accumulate op",
-              Or<[VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 16], I8>,
-                                   rhs, VectorOfShapeAndType<[16, 8], I4>,
-                                   acc, VectorOfShapeAndType<[4, 8], I32>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 8], I8>,
-                                   rhs, VectorOfShapeAndType<[8, 8], I8>,
-                                   acc, VectorOfShapeAndType<[4, 8], I32>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 4], I16>,
-                                   rhs, VectorOfShapeAndType<[4, 8], I8>,
-                                   acc, VectorOfShapeAndType<[4, 8], I32>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 2], I16>,
-                                   rhs, VectorOfShapeAndType<[2, 8], I16>,
-                                   acc, VectorOfShapeAndType<[4, 8], I32>>,
+              Or<[VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 16], AnyI8>,
+                                   rhs, VectorOfShapeAndType<[16, 8], AnyI4>,
+                                   acc, VectorOfShapeAndType<[4, 8], AnyI32>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 8], AnyI8>,
+                                   rhs, VectorOfShapeAndType<[8, 8], AnyI8>,
+                                   acc, VectorOfShapeAndType<[4, 8], AnyI32>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 4], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[4, 8], AnyI8>,
+                                   acc, VectorOfShapeAndType<[4, 8], AnyI32>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 2], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[2, 8], AnyI16>,
+                                   acc, VectorOfShapeAndType<[4, 8], AnyI32>>,
 
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[2, 8], I16>,
-                                   rhs, VectorOfShapeAndType<[8, 8], I8>,
-                                   acc, VectorOfShapeAndType<[2, 8], I64>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 8], I16>,
-                                   rhs, VectorOfShapeAndType<[8, 4], I8>,
-                                   acc, VectorOfShapeAndType<[4, 4], I64>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[2, 4], I16>,
-                                   rhs, VectorOfShapeAndType<[4, 8], I16>,
-                                   acc, VectorOfShapeAndType<[2, 8], I64>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 4], I16>,
-                                   rhs, VectorOfShapeAndType<[4, 4], I16>,
-                                   acc, VectorOfShapeAndType<[4, 4], I64>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 2], I32>,
-                                   rhs, VectorOfShapeAndType<[2, 4], I16>,
-                                   acc, VectorOfShapeAndType<[4, 4], I64>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[2, 8], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[8, 8], AnyI8>,
+                                   acc, VectorOfShapeAndType<[2, 8], AnyI64>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 8], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[8, 4], AnyI8>,
+                                   acc, VectorOfShapeAndType<[4, 4], AnyI64>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[2, 4], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[4, 8], AnyI16>,
+                                   acc, VectorOfShapeAndType<[2, 8], AnyI64>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 4], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[4, 4], AnyI16>,
+                                   acc, VectorOfShapeAndType<[4, 4], AnyI64>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 2], AnyI32>,
+                                   rhs, VectorOfShapeAndType<[2, 4], AnyI16>,
+                                   acc, VectorOfShapeAndType<[4, 4], AnyI64>>,
 
                   VectorTypesMatch<lhs, VectorOfShapeAndType<[4, 8], BF16>,
                                    rhs, VectorOfShapeAndType<[8, 4], BF16>,
@@ -192,12 +198,12 @@ class IsValidAIE2PMatMulShapeAndType<string lhs, string rhs, string acc> :
                   VectorTypesMatch<lhs, VectorOfShapeAndType<[8, 8], BF16>,
                                    rhs, VectorOfShapeAndType<[8, 4], BF16>,
                                    acc, VectorOfShapeAndType<[8, 4], F32>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[8, 8], I8>,
-                                   rhs, VectorOfShapeAndType<[8, 8], I8>,
-                                   acc, VectorOfShapeAndType<[8, 8], I32>>,
-                  VectorTypesMatch<lhs, VectorOfShapeAndType<[8, 2], I16>,
-                                   rhs, VectorOfShapeAndType<[2, 8], I16>,
-                                   acc, VectorOfShapeAndType<[8, 8], I32>>]>>;
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[8, 8], AnyI8>,
+                                   rhs, VectorOfShapeAndType<[8, 8], AnyI8>,
+                                   acc, VectorOfShapeAndType<[8, 8], AnyI32>>,
+                  VectorTypesMatch<lhs, VectorOfShapeAndType<[8, 2], AnyI16>,
+                                   rhs, VectorOfShapeAndType<[2, 8], AnyI16>,
+                                   acc, VectorOfShapeAndType<[8, 8], AnyI32>>]>>;
 
 
 

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -4289,11 +4289,16 @@ class MatMulOpConversion
       lhs = lookThroughShapeCasts(extUIOp.getIn());
       lhsVecTy = cast<VectorType>(lhs.getType());
       lhsScaTy = cast<IntegerType>(lhsVecTy.getElementType());
+    } else if (auto lhsSignedAttr = op.getLhsSigned()) {
+      // The VectorToAIEVec pass strips extsi/extui before creating
+      // aievec.matmul. When it does, it records the operand signedness on the
+      // op, because the remaining narrow integer type is signless and cannot
+      // carry it. Prefer that recorded value over any type-based guess.
+      signX = *lhsSignedAttr ? 1 : 0;
     } else {
       // Default to unsigned for lhs (activation input is typically uint8).
-      // The VectorToAIEVec pass strips extsi/extui before creating
-      // aievec.matmul, so sign info is not available here. Using unsigned
-      // for A matches the common use case of uint8 activations × int8 weights.
+      // Reached only for hand-written aievec.matmul IR that carries neither an
+      // extension op nor a recorded signedness.
       if (lhsScaTy.isUnsigned())
         signX = 0;
     }
@@ -4311,6 +4316,9 @@ class MatMulOpConversion
       rhs = lookThroughShapeCasts(extUIOp.getIn());
       rhsVecTy = cast<VectorType>(rhs.getType());
       rhsScaTy = cast<IntegerType>(rhsVecTy.getElementType());
+    } else if (auto rhsSignedAttr = op.getRhsSigned()) {
+      // See the lhs case above.
+      signY = *rhsSignedAttr ? 1 : 0;
     } else {
       // NOTE: We're choosing 'signed' by default
       if (!rhsScaTy.isUnsigned())

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -4257,6 +4257,30 @@ class MatMulOpConversion
     Value lhs = op.getLhs();
     Value rhs = op.getRhs();
     Value acc = op.getAcc();
+
+    // The VectorToAIEVec pass carries operand signedness in the element type
+    // (si8/ui8) via an unrealized_conversion_cast from a signless value.
+    // Capture the signedness from the cast result type, then continue with the
+    // signless input so the cast is left dead (DCE'd) rather than leaking to
+    // LLVM.
+    auto castSignedness = [](Value &v) -> std::optional<bool> {
+      auto c = v.getDefiningOp<UnrealizedConversionCastOp>();
+      if (!c)
+        return std::nullopt;
+      std::optional<bool> isSigned;
+      if (auto vt = dyn_cast<VectorType>(v.getType()))
+        if (auto it = dyn_cast<IntegerType>(vt.getElementType())) {
+          if (it.isSigned())
+            isSigned = true;
+          else if (it.isUnsigned())
+            isSigned = false;
+        }
+      v = c.getInputs()[0];
+      return isSigned;
+    };
+    std::optional<bool> lhsCastSigned = castSignedness(lhs);
+    std::optional<bool> rhsCastSigned = castSignedness(rhs);
+
     auto accVecTy = cast<VectorType>(acc.getType());
     if (isa<Float32Type>(accVecTy.getElementType()))
       // <4x8xbf16> x <8x4xbf16> + <4x4xf32>
@@ -4289,18 +4313,17 @@ class MatMulOpConversion
       lhs = lookThroughShapeCasts(extUIOp.getIn());
       lhsVecTy = cast<VectorType>(lhs.getType());
       lhsScaTy = cast<IntegerType>(lhsVecTy.getElementType());
-    } else if (auto lhsSignedAttr = op.getLhsSigned()) {
-      // The VectorToAIEVec pass strips extsi/extui before creating
-      // aievec.matmul. When it does, it records the operand signedness on the
-      // op, because the remaining narrow integer type is signless and cannot
-      // carry it. Prefer that recorded value over any type-based guess.
-      signX = *lhsSignedAttr ? 1 : 0;
+    } else if (lhsCastSigned.has_value()) {
+      // Signedness carried in the operand element type (si8/ui8).
+      signX = *lhsCastSigned ? 1 : 0;
+    } else if (lhsScaTy.isSigned()) {
+      signX = 1;
+    } else if (lhsScaTy.isUnsigned()) {
+      signX = 0;
     } else {
-      // Default to unsigned for lhs (activation input is typically uint8).
-      // Reached only for hand-written aievec.matmul IR that carries neither an
-      // extension op nor a recorded signedness.
-      if (lhsScaTy.isUnsigned())
-        signX = 0;
+      // Signless (e.g. hand-written aievec.matmul IR): default lhs to unsigned
+      // (activation input is typically uint8).
+      signX = 0;
     }
     auto lhsShape = lhsVecTy.getShape();
 
@@ -4316,13 +4339,14 @@ class MatMulOpConversion
       rhs = lookThroughShapeCasts(extUIOp.getIn());
       rhsVecTy = cast<VectorType>(rhs.getType());
       rhsScaTy = cast<IntegerType>(rhsVecTy.getElementType());
-    } else if (auto rhsSignedAttr = op.getRhsSigned()) {
-      // See the lhs case above.
-      signY = *rhsSignedAttr ? 1 : 0;
+    } else if (rhsCastSigned.has_value()) {
+      // Signedness carried in the operand element type (si8/ui8).
+      signY = *rhsCastSigned ? 1 : 0;
+    } else if (rhsScaTy.isUnsigned()) {
+      signY = 0;
     } else {
-      // NOTE: We're choosing 'signed' by default
-      if (!rhsScaTy.isUnsigned())
-        signY = 1;
+      // Signed element type or signless: default rhs to signed.
+      signY = 1;
     }
 
     unsigned lhsBitWidth = lhsScaTy.getWidth();
@@ -4716,8 +4740,18 @@ class MatMulOpAIE2pConversion
     Value rhs = op.getRhs();
     Value acc = op.getAcc();
 
-    auto lhsVecTy = cast<VectorType>(lhs.getType());
-    auto rhsVecTy = cast<VectorType>(rhs.getType());
+    // The VectorToAIEVec pass carries operand signedness in the element type
+    // (si8/ui8) via an unrealized_conversion_cast from a signless value. Read
+    // signedness from the cast result type below, but feed the intrinsic the
+    // signless input so the cast is left dead (and DCE'd) rather than leaking
+    // to LLVM translation.
+    if (auto c = lhs.getDefiningOp<UnrealizedConversionCastOp>())
+      lhs = c.getInputs()[0];
+    if (auto c = rhs.getDefiningOp<UnrealizedConversionCastOp>())
+      rhs = c.getInputs()[0];
+
+    auto lhsVecTy = cast<VectorType>(op.getLhs().getType());
+    auto rhsVecTy = cast<VectorType>(op.getRhs().getType());
     auto accVecTy = cast<VectorType>(acc.getType());
 
     // Check for AIE2p integer matmul
@@ -4739,12 +4773,11 @@ class MatMulOpAIE2pConversion
           accLanes == 64) {
         // Uses I512.I512.ACC2048 (64 lanes of i8 -> 64 lanes of i32).
         // Base conf for amode=0/bmode=1 is bmode<<3 = 8; signedness lives in
-        // signX (bit 9) / signY (bit 8). Prefer the recorded
-        // lhsSigned/rhsSigned attrs (see aiev2_vmac_compute_control /
-        // aie2p_compute_control), and default to signed x signed (776 = 0x308)
-        // to preserve prior behavior.
-        int signX = op.getLhsSigned().value_or(true) ? 1 : 0;
-        int signY = op.getRhsSigned().value_or(true) ? 1 : 0;
+        // signX (bit 9) / signY (bit 8). PROTOTYPE: read signedness from the
+        // operand element TYPE (si8 -> signed, ui8 -> unsigned, signless i8 ->
+        // signed default), instead of lhsSigned/rhsSigned attributes.
+        int signX = lhsIntTy.isUnsigned() ? 0 : 1;
+        int signY = rhsIntTy.isUnsigned() ? 0 : 1;
         int conf = 8 | (signX << 9) | (signY << 8);
         return {DecodedMatMulOp::Kind::I8_8x8x8_I512_ACC2048, lhs, rhs, acc,
                 conf};

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -4737,9 +4737,17 @@ class MatMulOpAIE2pConversion
       if (lhsIntTy.getWidth() == 8 && rhsIntTy.getWidth() == 8 &&
           accIntTy.getWidth() == 32 && lhsLanes == 64 && rhsLanes == 64 &&
           accLanes == 64) {
-        // Uses I512.I512.ACC2048 (64 lanes of i8 -> 64 lanes of i32)
+        // Uses I512.I512.ACC2048 (64 lanes of i8 -> 64 lanes of i32).
+        // Base conf for amode=0/bmode=1 is bmode<<3 = 8; signedness lives in
+        // signX (bit 9) / signY (bit 8). Prefer the recorded
+        // lhsSigned/rhsSigned attrs (see aiev2_vmac_compute_control /
+        // aie2p_compute_control), and default to signed x signed (776 = 0x308)
+        // to preserve prior behavior.
+        int signX = op.getLhsSigned().value_or(true) ? 1 : 0;
+        int signY = op.getRhsSigned().value_or(true) ? 1 : 0;
+        int conf = 8 | (signX << 9) | (signY << 8);
         return {DecodedMatMulOp::Kind::I8_8x8x8_I512_ACC2048, lhs, rhs, acc,
-                776};
+                conf};
       }
 
       // Check for <8x2xi16> x <2x8xi16> + <8x8xi32>

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -4692,35 +4692,54 @@ struct LowerVectorContractionOpToAIEVecMatMulPattern
     auto acc = reshapeLeadingUnitDims(rewriter, adaptor.getAcc());
     bool bReshapedAcc = (acc != adaptor.getAcc());
 
-    // Record operand signedness up front so it is preserved regardless of which
-    // creation path is taken below. The narrow integer type left after peeling
-    // a widening op is signless, and later canonicalizations may strip the
-    // original extsi/extui, so the LLVM lowering cannot be relied upon to
-    // re-derive it. Consult both the (possibly already-rewritten) adaptor
-    // operands and the original pre-conversion contraction operands.
+    // Recover operand signedness from the widening op before it is peeled.
+    // Consult both the (possibly already-rewritten) adaptor operands and the
+    // original pre-conversion contraction operands.
     auto lhsSigned = getSignednessOfWideningOp(adaptor.getLhs());
     if (!lhsSigned)
       lhsSigned = getSignednessOfWideningOp(contractOp.getLhs());
     auto rhsSigned = getSignednessOfWideningOp(adaptor.getRhs());
     if (!rhsSigned)
       rhsSigned = getSignednessOfWideningOp(contractOp.getRhs());
-    auto lhsSignedAttr = lhsSigned ? rewriter.getBoolAttr(*lhsSigned) : nullptr;
-    auto rhsSignedAttr = rhsSigned ? rewriter.getBoolAttr(*rhsSigned) : nullptr;
 
-    auto matmulOp =
-        MatMulOpTy::create(rewriter, contractOp.getLoc(), acc.getType(), lhs,
-                           rhs, acc, lhsSignedAttr, rhsSignedAttr);
+    // Carry the signedness in the matmul operand element type (si8/ui8). MLIR
+    // has no signless->signed/unsigned cast, so materialize an
+    // unrealized_conversion_cast; it folds to a no-op once both sides lower to
+    // signless LLVM integers. bf16/unknown-signedness operands are unchanged.
+    auto retype = [&](Value v, std::optional<bool> isSigned) -> Value {
+      if (!isSigned)
+        return v;
+      auto vecTy = dyn_cast<VectorType>(v.getType());
+      if (!vecTy)
+        return v;
+      auto intTy = dyn_cast<IntegerType>(vecTy.getElementType());
+      if (!intTy || !intTy.isSignless())
+        return v;
+      auto signednessTy = IntegerType::get(intTy.getContext(), intTy.getWidth(),
+                                           *isSigned ? IntegerType::Signed
+                                                     : IntegerType::Unsigned);
+      return UnrealizedConversionCastOp::create(rewriter, v.getLoc(),
+                                                vecTy.clone(signednessTy), v)
+          .getResult(0);
+    };
+
     Value result;
     {
       // Replace diagnostics handler to silence errors when verifying the
       // validity of the matmul ops being generated.
       ScopedDiagnosticHandler diagHandler(
           contractOp.getContext(), [](Diagnostic &) { return success(); });
-      if (failed(matmulOp.verifyInvariants())) {
-        rewriter.eraseOp(matmulOp);
-        // There is a possibility that, when the linalg op is converted to
-        // contractions, lower precisions operands are cast to the target
-        // precision outside the contraction. For those cases, we check.
+      // Decide whether the wide operands already form a valid matmul, or
+      // whether the widening ops must be peeled to reach a supported narrow
+      // shape. Use a throwaway signless op so a failed attempt leaves no retype
+      // casts behind.
+      auto testOp = MatMulOpTy::create(rewriter, contractOp.getLoc(),
+                                       acc.getType(), lhs, rhs, acc);
+      bool needsPeel = failed(testOp.verifyInvariants());
+      rewriter.eraseOp(testOp);
+      if (needsPeel) {
+        // When the linalg op is converted to contractions, lower-precision
+        // operands may be cast to the target precision outside the contraction.
         lhs = adaptor.getLhs();
         auto wideLhsValue = getSourceOfWideningOp(lhs).value_or(nullptr);
         if (wideLhsValue)
@@ -4730,15 +4749,15 @@ struct LowerVectorContractionOpToAIEVecMatMulPattern
         auto wideRhsValue = getSourceOfWideningOp(rhs).value_or(nullptr);
         if (wideRhsValue)
           rhs = reshapeLeadingUnitDims(rewriter, wideRhsValue);
-
-        matmulOp =
-            MatMulOpTy::create(rewriter, contractOp.getLoc(), acc.getType(),
-                               lhs, rhs, acc, lhsSignedAttr, rhsSignedAttr);
-        if (failed(matmulOp.verifyInvariants()))
-          return failure();
       }
+
+      auto matmulOp = MatMulOpTy::create(rewriter, contractOp.getLoc(),
+                                         acc.getType(), retype(lhs, lhsSigned),
+                                         retype(rhs, rhsSigned), acc);
+      if (failed(matmulOp.verifyInvariants()))
+        return failure();
+      result = matmulOp.getResult();
     }
-    result = matmulOp.getResult();
 
     if (bReshapedAcc)
       result = vector::ShapeCastOp::create(rewriter, contractOp.getLoc(),

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -179,12 +179,13 @@ static std::optional<Value> getSourceOfWideningOp(Value src) {
 }
 
 // Given a Value, if it is defined by an integer widening op, return whether
-// that widening is signed. Returns std::nullopt when the defining op is not a
-// recognized integer widening op, or when it carries no signedness (e.g. a
-// floating-point extension, or an accumulator round-trip through
-// aievec.ups/srs). Callers use this to record the operand signedness on the
-// created matmul op, since peeling the widening op would otherwise discard it
-// (MLIR integers are signless).
+// that widening is signed: arith.extsi -> signed, arith.extui -> unsigned, and
+// an aievec.srs (from an already-rewritten extsi/extui) -> its own `sign`
+// attribute. Returns std::nullopt when the defining op is not a recognized
+// integer widening op, or carries no signedness: a floating-point arith.extf,
+// or an aievec.ups/aievec.cast (which do not encode signedness). Callers record
+// this on the created matmul op, since peeling the widening op would otherwise
+// discard it (MLIR integers are signless).
 static std::optional<bool> getSignednessOfWideningOp(Value src) {
   // Look through shape casts, which may sit between the extension op and the
   // consumer.
@@ -4691,13 +4692,24 @@ struct LowerVectorContractionOpToAIEVecMatMulPattern
     auto acc = reshapeLeadingUnitDims(rewriter, adaptor.getAcc());
     bool bReshapedAcc = (acc != adaptor.getAcc());
 
-    // No signedness recorded on this first attempt: the operands still carry
-    // their extension ops, so the LLVM lowering can read the signedness from
-    // them directly.
+    // Record operand signedness up front so it is preserved regardless of which
+    // creation path is taken below. The narrow integer type left after peeling
+    // a widening op is signless, and later canonicalizations may strip the
+    // original extsi/extui, so the LLVM lowering cannot be relied upon to
+    // re-derive it. Consult both the (possibly already-rewritten) adaptor
+    // operands and the original pre-conversion contraction operands.
+    auto lhsSigned = getSignednessOfWideningOp(adaptor.getLhs());
+    if (!lhsSigned)
+      lhsSigned = getSignednessOfWideningOp(contractOp.getLhs());
+    auto rhsSigned = getSignednessOfWideningOp(adaptor.getRhs());
+    if (!rhsSigned)
+      rhsSigned = getSignednessOfWideningOp(contractOp.getRhs());
+    auto lhsSignedAttr = lhsSigned ? rewriter.getBoolAttr(*lhsSigned) : nullptr;
+    auto rhsSignedAttr = rhsSigned ? rewriter.getBoolAttr(*rhsSigned) : nullptr;
+
     auto matmulOp =
         MatMulOpTy::create(rewriter, contractOp.getLoc(), acc.getType(), lhs,
-                           rhs, acc, /*lhsSigned=*/nullptr,
-                           /*rhsSigned=*/nullptr);
+                           rhs, acc, lhsSignedAttr, rhsSignedAttr);
     Value result;
     {
       // Replace diagnostics handler to silence errors when verifying the
@@ -4711,29 +4723,17 @@ struct LowerVectorContractionOpToAIEVecMatMulPattern
         // precision outside the contraction. For those cases, we check.
         lhs = adaptor.getLhs();
         auto wideLhsValue = getSourceOfWideningOp(lhs).value_or(nullptr);
-        // Record the signedness before the widening op is peeled off; the
-        // narrow integer type left behind is signless and cannot carry it.
-        // Consult the original (pre-conversion) operand as well: by the time
-        // this pattern runs, another pattern in the same conversion may have
-        // already rewritten the arith.extsi into aievec ops.
-        auto lhsSigned = getSignednessOfWideningOp(lhs);
-        if (!lhsSigned)
-          lhsSigned = getSignednessOfWideningOp(contractOp.getLhs());
         if (wideLhsValue)
           lhs = reshapeLeadingUnitDims(rewriter, wideLhsValue);
 
         rhs = adaptor.getRhs();
         auto wideRhsValue = getSourceOfWideningOp(rhs).value_or(nullptr);
-        auto rhsSigned = getSignednessOfWideningOp(rhs);
-        if (!rhsSigned)
-          rhsSigned = getSignednessOfWideningOp(contractOp.getRhs());
         if (wideRhsValue)
           rhs = reshapeLeadingUnitDims(rewriter, wideRhsValue);
 
-        matmulOp = MatMulOpTy::create(
-            rewriter, contractOp.getLoc(), acc.getType(), lhs, rhs, acc,
-            lhsSigned ? rewriter.getBoolAttr(*lhsSigned) : nullptr,
-            rhsSigned ? rewriter.getBoolAttr(*rhsSigned) : nullptr);
+        matmulOp =
+            MatMulOpTy::create(rewriter, contractOp.getLoc(), acc.getType(),
+                               lhs, rhs, acc, lhsSignedAttr, rhsSignedAttr);
         if (failed(matmulOp.verifyInvariants()))
           return failure();
       }

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -178,6 +178,30 @@ static std::optional<Value> getSourceOfWideningOp(Value src) {
   return std::optional<Value>();
 }
 
+// Given a Value, if it is defined by an integer widening op, return whether
+// that widening is signed. Returns std::nullopt when the defining op is not a
+// recognized integer widening op, or when it carries no signedness (e.g. a
+// floating-point extension, or an accumulator round-trip through
+// aievec.ups/srs). Callers use this to record the operand signedness on the
+// created matmul op, since peeling the widening op would otherwise discard it
+// (MLIR integers are signless).
+static std::optional<bool> getSignednessOfWideningOp(Value src) {
+  // Look through shape casts, which may sit between the extension op and the
+  // consumer.
+  while (auto castOp = src.getDefiningOp<vector::ShapeCastOp>())
+    src = castOp.getSource();
+  if (src.getDefiningOp<arith::ExtSIOp>())
+    return true;
+  if (src.getDefiningOp<arith::ExtUIOp>())
+    return false;
+  // An arith.extsi/extui may already have been rewritten into an
+  // aievec.ups + aievec.srs pair by another pattern in this same conversion.
+  // Only aievec.srs records a signedness; aievec.ups and aievec.cast do not.
+  if (auto srsOp = src.getDefiningOp<aievec::SRSOp>())
+    return srsOp.getSign() != 0;
+  return std::nullopt;
+}
+
 // Given a Value, if it is defined by a narrowing op (arith::TruncFOp,
 // arith::TruncIOp), return the source of the narrowing op.
 static std::optional<Value> getSourceOfNarrowingOp(Value src) {
@@ -4667,8 +4691,13 @@ struct LowerVectorContractionOpToAIEVecMatMulPattern
     auto acc = reshapeLeadingUnitDims(rewriter, adaptor.getAcc());
     bool bReshapedAcc = (acc != adaptor.getAcc());
 
-    auto matmulOp = MatMulOpTy::create(rewriter, contractOp.getLoc(),
-                                       acc.getType(), lhs, rhs, acc);
+    // No signedness recorded on this first attempt: the operands still carry
+    // their extension ops, so the LLVM lowering can read the signedness from
+    // them directly.
+    auto matmulOp =
+        MatMulOpTy::create(rewriter, contractOp.getLoc(), acc.getType(), lhs,
+                           rhs, acc, /*lhsSigned=*/nullptr,
+                           /*rhsSigned=*/nullptr);
     Value result;
     {
       // Replace diagnostics handler to silence errors when verifying the
@@ -4682,16 +4711,29 @@ struct LowerVectorContractionOpToAIEVecMatMulPattern
         // precision outside the contraction. For those cases, we check.
         lhs = adaptor.getLhs();
         auto wideLhsValue = getSourceOfWideningOp(lhs).value_or(nullptr);
+        // Record the signedness before the widening op is peeled off; the
+        // narrow integer type left behind is signless and cannot carry it.
+        // Consult the original (pre-conversion) operand as well: by the time
+        // this pattern runs, another pattern in the same conversion may have
+        // already rewritten the arith.extsi into aievec ops.
+        auto lhsSigned = getSignednessOfWideningOp(lhs);
+        if (!lhsSigned)
+          lhsSigned = getSignednessOfWideningOp(contractOp.getLhs());
         if (wideLhsValue)
           lhs = reshapeLeadingUnitDims(rewriter, wideLhsValue);
 
         rhs = adaptor.getRhs();
         auto wideRhsValue = getSourceOfWideningOp(rhs).value_or(nullptr);
+        auto rhsSigned = getSignednessOfWideningOp(rhs);
+        if (!rhsSigned)
+          rhsSigned = getSignednessOfWideningOp(contractOp.getRhs());
         if (wideRhsValue)
           rhs = reshapeLeadingUnitDims(rewriter, wideRhsValue);
 
-        matmulOp = MatMulOpTy::create(rewriter, contractOp.getLoc(),
-                                      acc.getType(), lhs, rhs, acc);
+        matmulOp = MatMulOpTy::create(
+            rewriter, contractOp.getLoc(), acc.getType(), lhs, rhs, acc,
+            lhsSigned ? rewriter.getBoolAttr(*lhsSigned) : nullptr,
+            rhsSigned ? rewriter.getBoolAttr(*rhsSigned) : nullptr);
         if (failed(matmulOp.verifyInvariants()))
           return failure();
       }

--- a/test/Conversion/AIEVecToLLVM/matmul-aie2p.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul-aie2p.mlir
@@ -164,3 +164,68 @@ func.func @matmul_aie2p_i512_acc2048(%A : vector<4x8xbf16>, %B : vector<8x4xbf16
 // Extract first 16 elements from 32-element result
 // CHECK:      vector.shuffle {{.*}} : vector<32xf32>, vector<32xf32>
 // CHECK:      vector.shape_cast {{.*}} : vector<16xf32> to vector<4x4xf32>
+
+
+// i8 x i8 matmul MAC configuration word for each signedness combination. The
+// AIE2P config word places signX at bit 9 and signY at bit 8 over the base
+// (bmode=1 -> 0x8), so: uns/uns=8, uns/sgn=264, sgn/uns=520, sgn/sgn=776.
+
+func.func @matmul_aie2p_i8_signed_signed(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+                                         %C : vector<8x8xi32>) -> vector<8x8xi32> {
+  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = true, rhsSigned = true} :
+       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  return %0 : vector<8x8xi32>
+}
+
+// CHECK-LABEL: @matmul_aie2p_i8_signed_signed
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(776 : i32) : i32
+// CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
+
+
+func.func @matmul_aie2p_i8_unsigned_signed(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+                                           %C : vector<8x8xi32>) -> vector<8x8xi32> {
+  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = false, rhsSigned = true} :
+       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  return %0 : vector<8x8xi32>
+}
+
+// CHECK-LABEL: @matmul_aie2p_i8_unsigned_signed
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(264 : i32) : i32
+// CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
+
+
+func.func @matmul_aie2p_i8_signed_unsigned(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+                                           %C : vector<8x8xi32>) -> vector<8x8xi32> {
+  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = true, rhsSigned = false} :
+       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  return %0 : vector<8x8xi32>
+}
+
+// CHECK-LABEL: @matmul_aie2p_i8_signed_unsigned
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(520 : i32) : i32
+// CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
+
+
+func.func @matmul_aie2p_i8_unsigned_unsigned(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+                                             %C : vector<8x8xi32>) -> vector<8x8xi32> {
+  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = false, rhsSigned = false} :
+       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  return %0 : vector<8x8xi32>
+}
+
+// CHECK-LABEL: @matmul_aie2p_i8_unsigned_unsigned
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(8 : i32) : i32
+// CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
+
+
+// No attributes: integer lowering defaults to signed x signed (776).
+func.func @matmul_aie2p_i8_default(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+                                   %C : vector<8x8xi32>) -> vector<8x8xi32> {
+  %0 = aievec.matmul_aie2p %A, %B, %C :
+       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  return %0 : vector<8x8xi32>
+}
+
+// CHECK-LABEL: @matmul_aie2p_i8_default
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(776 : i32) : i32
+// CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])

--- a/test/Conversion/AIEVecToLLVM/matmul-aie2p.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul-aie2p.mlir
@@ -166,14 +166,15 @@ func.func @matmul_aie2p_i512_acc2048(%A : vector<4x8xbf16>, %B : vector<8x4xbf16
 // CHECK:      vector.shape_cast {{.*}} : vector<16xf32> to vector<4x4xf32>
 
 
-// i8 x i8 matmul MAC configuration word for each signedness combination. The
-// AIE2P config word places signX at bit 9 and signY at bit 8 over the base
-// (bmode=1 -> 0x8), so: uns/uns=8, uns/sgn=264, sgn/uns=520, sgn/sgn=776.
+// i8 x i8 matmul MAC configuration word for each signedness combination.
+// Operand signedness is carried in the element type (si8/ui8). The AIE2P config
+// word places signX at bit 9 and signY at bit 8 over the base (bmode=1 -> 0x8),
+// so: uns/uns=8, uns/sgn=264, sgn/uns=520, sgn/sgn=776.
 
-func.func @matmul_aie2p_i8_signed_signed(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_aie2p_i8_signed_signed(%A : vector<8x8xsi8>, %B : vector<8x8xsi8>,
                                          %C : vector<8x8xi32>) -> vector<8x8xi32> {
-  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = true, rhsSigned = true} :
-       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  %0 = aievec.matmul_aie2p %A, %B, %C :
+       vector<8x8xsi8>, vector<8x8xsi8> into vector<8x8xi32>
   return %0 : vector<8x8xi32>
 }
 
@@ -182,10 +183,10 @@ func.func @matmul_aie2p_i8_signed_signed(%A : vector<8x8xi8>, %B : vector<8x8xi8
 // CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
 
 
-func.func @matmul_aie2p_i8_unsigned_signed(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_aie2p_i8_unsigned_signed(%A : vector<8x8xui8>, %B : vector<8x8xsi8>,
                                            %C : vector<8x8xi32>) -> vector<8x8xi32> {
-  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = false, rhsSigned = true} :
-       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  %0 = aievec.matmul_aie2p %A, %B, %C :
+       vector<8x8xui8>, vector<8x8xsi8> into vector<8x8xi32>
   return %0 : vector<8x8xi32>
 }
 
@@ -194,10 +195,10 @@ func.func @matmul_aie2p_i8_unsigned_signed(%A : vector<8x8xi8>, %B : vector<8x8x
 // CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
 
 
-func.func @matmul_aie2p_i8_signed_unsigned(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_aie2p_i8_signed_unsigned(%A : vector<8x8xsi8>, %B : vector<8x8xui8>,
                                            %C : vector<8x8xi32>) -> vector<8x8xi32> {
-  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = true, rhsSigned = false} :
-       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  %0 = aievec.matmul_aie2p %A, %B, %C :
+       vector<8x8xsi8>, vector<8x8xui8> into vector<8x8xi32>
   return %0 : vector<8x8xi32>
 }
 
@@ -206,10 +207,10 @@ func.func @matmul_aie2p_i8_signed_unsigned(%A : vector<8x8xi8>, %B : vector<8x8x
 // CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
 
 
-func.func @matmul_aie2p_i8_unsigned_unsigned(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_aie2p_i8_unsigned_unsigned(%A : vector<8x8xui8>, %B : vector<8x8xui8>,
                                              %C : vector<8x8xi32>) -> vector<8x8xi32> {
-  %0 = aievec.matmul_aie2p %A, %B, %C {lhsSigned = false, rhsSigned = false} :
-       vector<8x8xi8>, vector<8x8xi8> into vector<8x8xi32>
+  %0 = aievec.matmul_aie2p %A, %B, %C :
+       vector<8x8xui8>, vector<8x8xui8> into vector<8x8xi32>
   return %0 : vector<8x8xi32>
 }
 
@@ -218,7 +219,7 @@ func.func @matmul_aie2p_i8_unsigned_unsigned(%A : vector<8x8xi8>, %B : vector<8x
 // CHECK:      "xllvm.intr.aie2p.I512.I512.ACC2048.mac.conf"({{.*}}, {{.*}}, {{.*}}, %[[CONF]])
 
 
-// No attributes: integer lowering defaults to signed x signed (776).
+// Signless element type: integer lowering defaults to signed x signed (776).
 func.func @matmul_aie2p_i8_default(%A : vector<8x8xi8>, %B : vector<8x8xi8>,
                                    %C : vector<8x8xi32>) -> vector<8x8xi32> {
   %0 = aievec.matmul_aie2p %A, %B, %C :

--- a/test/Conversion/AIEVecToLLVM/matmul.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul.mlir
@@ -115,16 +115,14 @@ func.func @matmul(%A : vector<4x2xi32>, %B : vector<2x4xi16>,
 // -----
 
 // The AIE2 MAC takes its operand signedness from bits 9 (signX, lhs) and
-// 8 (signY, rhs) of the configuration word, not from the operand types --
-// MLIR integers are signless and the intrinsic always takes v64uint8. For the
-// i8 4x8x8 shape the remaining config bits are amode=0, bmode=1 (BMODE_8x8),
-// giving a base of 0x008. The four combinations below therefore pin
-// 0x008/0x108/0x208/0x308.
+// 8 (signY, rhs) of the configuration word. Operand signedness is carried in
+// the element type (si8/ui8). For the i8 4x8x8 shape the remaining config bits
+// are amode=0, bmode=1 (BMODE_8x8), giving a base of 0x008. The four
+// combinations below therefore pin 0x008/0x108/0x208/0x308.
 
-func.func @matmul_i8i8_signed_signed(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_i8i8_signed_signed(%A : vector<4x8xsi8>, %B : vector<8x8xsi8>,
                                      %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = aievec.matmul %A, %B, %C {lhsSigned = true, rhsSigned = true} :
-                                  vector<4x8xi8>, vector<8x8xi8>
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xsi8>, vector<8x8xsi8>
                                   into vector<4x8xi32>
   return %0 : vector<4x8xi32>
 }
@@ -137,10 +135,9 @@ func.func @matmul_i8i8_signed_signed(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
 
 // -----
 
-func.func @matmul_i8i8_unsigned_unsigned(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_i8i8_unsigned_unsigned(%A : vector<4x8xui8>, %B : vector<8x8xui8>,
                                          %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = aievec.matmul %A, %B, %C {lhsSigned = false, rhsSigned = false} :
-                                  vector<4x8xi8>, vector<8x8xi8>
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xui8>, vector<8x8xui8>
                                   into vector<4x8xi32>
   return %0 : vector<4x8xi32>
 }
@@ -153,10 +150,9 @@ func.func @matmul_i8i8_unsigned_unsigned(%A : vector<4x8xi8>, %B : vector<8x8xi8
 
 // -----
 
-func.func @matmul_i8i8_unsigned_signed(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_i8i8_unsigned_signed(%A : vector<4x8xui8>, %B : vector<8x8xsi8>,
                                        %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = aievec.matmul %A, %B, %C {lhsSigned = false, rhsSigned = true} :
-                                  vector<4x8xi8>, vector<8x8xi8>
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xui8>, vector<8x8xsi8>
                                   into vector<4x8xi32>
   return %0 : vector<4x8xi32>
 }
@@ -169,10 +165,9 @@ func.func @matmul_i8i8_unsigned_signed(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
 
 // -----
 
-func.func @matmul_i8i8_signed_unsigned(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_i8i8_signed_unsigned(%A : vector<4x8xsi8>, %B : vector<8x8xui8>,
                                        %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = aievec.matmul %A, %B, %C {lhsSigned = true, rhsSigned = false} :
-                                  vector<4x8xi8>, vector<8x8xi8>
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xsi8>, vector<8x8xui8>
                                   into vector<4x8xi32>
   return %0 : vector<4x8xi32>
 }

--- a/test/Conversion/AIEVecToLLVM/matmul.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul.mlir
@@ -111,3 +111,75 @@ func.func @matmul(%A : vector<4x2xi32>, %B : vector<2x4xi16>,
 // CHECK:      %[[R:.*]] = vector.shape_cast %[[BCR]] :
 // CHECK-SAME:                      vector<16xi64> to vector<4x4xi64>
 // CHECK:      return %[[R]] : vector<4x4xi64>
+
+// -----
+
+// The AIE2 MAC takes its operand signedness from bits 9 (signX, lhs) and
+// 8 (signY, rhs) of the configuration word, not from the operand types --
+// MLIR integers are signless and the intrinsic always takes v64uint8. For the
+// i8 4x8x8 shape the remaining config bits are amode=0, bmode=1 (BMODE_8x8),
+// giving a base of 0x008. The four combinations below therefore pin
+// 0x008/0x108/0x208/0x308.
+
+func.func @matmul_i8i8_signed_signed(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                     %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C {lhsSigned = true, rhsSigned = true} :
+                                  vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i8i8_signed_signed
+// signX = 1, signY = 1 -> 0x308
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(776 : i32) : i32
+// CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
+// CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
+
+// -----
+
+func.func @matmul_i8i8_unsigned_unsigned(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                         %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C {lhsSigned = false, rhsSigned = false} :
+                                  vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i8i8_unsigned_unsigned
+// signX = 0, signY = 0 -> 0x008
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(8 : i32) : i32
+// CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
+// CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
+
+// -----
+
+func.func @matmul_i8i8_unsigned_signed(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                       %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C {lhsSigned = false, rhsSigned = true} :
+                                  vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i8i8_unsigned_signed
+// signX = 0, signY = 1 -> 0x108 (uint8 activations x int8 weights)
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(264 : i32) : i32
+// CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
+// CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
+
+// -----
+
+func.func @matmul_i8i8_signed_unsigned(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                       %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C {lhsSigned = true, rhsSigned = false} :
+                                  vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i8i8_signed_unsigned
+// signX = 1, signY = 0 -> 0x208
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(520 : i32) : i32
+// CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
+// CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
+

--- a/test/Conversion/VectorToAIEVec/test-contract.mlir
+++ b/test/Conversion/VectorToAIEVec/test-contract.mlir
@@ -28,8 +28,8 @@ func.func @contractbf16bf16f32(%A : vector<4x8xbf16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {rhsSigned = true} :
-// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xsi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contracti16i8i32(%A : vector<4x4xi16>,
                             %B : vector<4x8xi8>,
@@ -46,8 +46,8 @@ func.func @contracti16i8i32(%A : vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {rhsSigned = true} :
-// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xsi16> into vector<4x4xi64>
 // CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
 func.func @contracti32i16i64(%A : vector<4x2xi32>,
                              %B : vector<2x4xi16>,
@@ -83,8 +83,8 @@ func.func @contractf32f32f32(%A : vector<4x8xbf16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = true, rhsSigned = true} :
-// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x4xsi16>, vector<4x8xsi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contracti32i32i32(%A : vector<4x4xi16>,
                              %B : vector<4x8xi8>,
@@ -102,8 +102,8 @@ func.func @contracti32i32i32(%A : vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = false, rhsSigned = false} :
-// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x2xui32>, vector<2x4xui16> into vector<4x4xi64>
 // CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
 func.func @contracti64i64i64(%A : vector<4x2xi32>,
                              %B : vector<2x4xi16>,
@@ -125,8 +125,8 @@ func.func @contracti64i64i64(%A : vector<4x2xi32>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = false, rhsSigned = true} :
-// CHECK-LLVM-SAME:   vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x8xui8>, vector<8x8xsi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contract_extui_extsi_i8(%A : vector<4x8xi8>,
                                     %B : vector<8x8xi8>,
@@ -148,8 +148,8 @@ func.func @contract_extui_extsi_i8(%A : vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = true, rhsSigned = true} :
-// CHECK-LLVM-SAME:   vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x8xsi8>, vector<8x8xsi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contract_extsi_extsi_i8(%A : vector<4x8xi8>,
                                    %B : vector<8x8xi8>,
@@ -169,8 +169,8 @@ func.func @contract_extsi_extsi_i8(%A : vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = true, rhsSigned = false} :
-// CHECK-LLVM-SAME:   vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x8xsi8>, vector<8x8xui8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contract_extsi_extui_i8(%A : vector<4x8xi8>,
                                    %B : vector<8x8xi8>,

--- a/test/Conversion/VectorToAIEVec/test-contract.mlir
+++ b/test/Conversion/VectorToAIEVec/test-contract.mlir
@@ -28,7 +28,7 @@ func.func @contractbf16bf16f32(%A : vector<4x8xbf16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {rhsSigned = true} :
 // CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contracti16i8i32(%A : vector<4x4xi16>,
@@ -46,7 +46,7 @@ func.func @contracti16i8i32(%A : vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {rhsSigned = true} :
 // CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
 // CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
 func.func @contracti32i16i64(%A : vector<4x2xi32>,
@@ -83,7 +83,7 @@ func.func @contractf32f32f32(%A : vector<4x8xbf16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = true, rhsSigned = true} :
 // CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contracti32i32i32(%A : vector<4x4xi16>,
@@ -102,7 +102,7 @@ func.func @contracti32i32i32(%A : vector<4x4xi16>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = false, rhsSigned = false} :
 // CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
 // CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
 func.func @contracti64i64i64(%A : vector<4x2xi32>,
@@ -125,7 +125,7 @@ func.func @contracti64i64i64(%A : vector<4x2xi32>,
 // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xi8>,
 // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x8xi8>,
 // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = false, rhsSigned = true} :
 // CHECK-LLVM-SAME:   vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
 // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contract_extui_extsi_i8(%A : vector<4x8xi8>,
@@ -140,3 +140,46 @@ func.func @contract_extui_extsi_i8(%A : vector<4x8xi8>,
   return %2 : vector<4x8xi32>
 }
 
+// Signed A (extsi) x signed B (extsi) for i8 matmul: the plain signed case,
+// e.g. tl.dot(i8, i8) -> i32. Both signX and signY must be set; defaulting the
+// lhs to unsigned here silently computes zext(A) * sext(B).
+
+// CHECK-LLVM-LABEL: func.func @contract_extsi_extsi_i8(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x8xi8>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = true, rhsSigned = true} :
+// CHECK-LLVM-SAME:   vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
+func.func @contract_extsi_extsi_i8(%A : vector<4x8xi8>,
+                                   %B : vector<8x8xi8>,
+                                   %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = arith.extsi %A : vector<4x8xi8> to vector<4x8xi32>
+  %1 = arith.extsi %B : vector<8x8xi8> to vector<8x8xi32>
+  %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                        iterator_types = ["parallel", "parallel", "reduction"],
+                        kind = #vector.kind<add>} %0, %1, %C :
+                        vector<4x8xi32>, vector<8x8xi32> into vector<4x8xi32>
+  return %2 : vector<4x8xi32>
+}
+
+// Signed A (extsi) x unsigned B (extui): the remaining mixed combination.
+
+// CHECK-LLVM-LABEL: func.func @contract_extsi_extui_i8(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x8xi8>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] {lhsSigned = true, rhsSigned = false} :
+// CHECK-LLVM-SAME:   vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
+func.func @contract_extsi_extui_i8(%A : vector<4x8xi8>,
+                                   %B : vector<8x8xi8>,
+                                   %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = arith.extsi %A : vector<4x8xi8> to vector<4x8xi32>
+  %1 = arith.extui %B : vector<8x8xi8> to vector<8x8xi32>
+  %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                        iterator_types = ["parallel", "parallel", "reduction"],
+                        kind = #vector.kind<add>} %0, %1, %C :
+                        vector<4x8xi32>, vector<8x8xi32> into vector<4x8xi32>
+  return %2 : vector<4x8xi32>
+}

--- a/test/dialect/AIEVec/roundtrip.mlir
+++ b/test/dialect/AIEVec/roundtrip.mlir
@@ -367,34 +367,31 @@ func.func @shuffle_i512(%v : vector<1xi512>) -> vector<1xi512> {
 
 // -----
 
+// Operand signedness is carried in the element type (si8/ui8) and round-trips.
+
 // CHECK-LABEL: func.func @matmul_i8i8_signedness(
-// CHECK-SAME: %[[A:.*]]: vector<4x8xi8>
-// CHECK-SAME: %[[B:.*]]: vector<8x8xi8>
+// CHECK-SAME: %[[A:.*]]: vector<4x8xsi8>
+// CHECK-SAME: %[[B:.*]]: vector<8x8xui8>
 // CHECK-SAME: %[[C:.*]]: vector<4x8xi32>
-// CHECK:      %[[RES:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]]
-// CHECK-SAME: {lhsSigned = true, rhsSigned = false}
-// CHECK-SAME: vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK:      %[[RES:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-SAME: vector<4x8xsi8>, vector<8x8xui8> into vector<4x8xi32>
 // CHECK: return %[[RES]] : vector<4x8xi32>
-func.func @matmul_i8i8_signedness(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+func.func @matmul_i8i8_signedness(%A : vector<4x8xsi8>, %B : vector<8x8xui8>,
                                   %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = aievec.matmul %A, %B, %C {lhsSigned = true, rhsSigned = false} :
-                                  vector<4x8xi8>, vector<8x8xi8>
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xsi8>, vector<8x8xui8>
                                   into vector<4x8xi32>
   return %0 : vector<4x8xi32>
 }
 
 // -----
 
-// The signedness attributes are optional: an op without them round-trips
-// unchanged.
+// Signless operands round-trip unchanged (historical default signedness).
 
-// CHECK-LABEL: func.func @matmul_i8i8_no_signedness(
+// CHECK-LABEL: func.func @matmul_i8i8_signless(
 // CHECK:      %[[RES:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %{{.*}} :
 // CHECK-SAME: vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
-// CHECK-NOT:  lhsSigned
-// CHECK-NOT:  rhsSigned
-func.func @matmul_i8i8_no_signedness(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
-                                     %C : vector<4x8xi32>) -> vector<4x8xi32> {
+func.func @matmul_i8i8_signless(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                %C : vector<4x8xi32>) -> vector<4x8xi32> {
   %0 = aievec.matmul %A, %B, %C : vector<4x8xi8>, vector<8x8xi8>
                                   into vector<4x8xi32>
   return %0 : vector<4x8xi32>

--- a/test/dialect/AIEVec/roundtrip.mlir
+++ b/test/dialect/AIEVec/roundtrip.mlir
@@ -364,3 +364,38 @@ func.func @shuffle_i512(%v : vector<1xi512>) -> vector<1xi512> {
   %1 = aievec.shuffle %0, %v [t512_1x2_hi] : vector<1xi512>
   return %1 : vector<1xi512>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @matmul_i8i8_signedness(
+// CHECK-SAME: %[[A:.*]]: vector<4x8xi8>
+// CHECK-SAME: %[[B:.*]]: vector<8x8xi8>
+// CHECK-SAME: %[[C:.*]]: vector<4x8xi32>
+// CHECK:      %[[RES:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]]
+// CHECK-SAME: {lhsSigned = true, rhsSigned = false}
+// CHECK-SAME: vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK: return %[[RES]] : vector<4x8xi32>
+func.func @matmul_i8i8_signedness(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                  %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C {lhsSigned = true, rhsSigned = false} :
+                                  vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// -----
+
+// The signedness attributes are optional: an op without them round-trips
+// unchanged.
+
+// CHECK-LABEL: func.func @matmul_i8i8_no_signedness(
+// CHECK:      %[[RES:.*]] = aievec.matmul %{{.*}}, %{{.*}}, %{{.*}} :
+// CHECK-SAME: vector<4x8xi8>, vector<8x8xi8> into vector<4x8xi32>
+// CHECK-NOT:  lhsSigned
+// CHECK-NOT:  rhsSigned
+func.func @matmul_i8i8_no_signedness(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                                     %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}


### PR DESCRIPTION
## Problem

An i8 matmul lowered from `vector.contract` computes `zext(A) * sext(B)` on AIE2 — the LHS is zero-extended while the RHS is sign-extended. Any negative value in A gives a wrong result:

| A | B | expected | actual |
|---|---|---|---|
| -1 | 1 | -1 | 255 |
| -7 | 5 | -35 | 1245 |
| -3 | -3 | 9 | -759 |
| 1 | -3 | -3 | -3 ✅ |

Non-negative A is always correct, so the bug is invisible to any test using only non-negative inputs — which is why it has gone unnoticed.

## Cause

The AIE2 MAC reads operand signedness from bits 9 (`signX`) and 8 (`signY`) of its configuration word (`AIE2InstrPatterns.td`, `aiev2_compute_control` in `aiev2_vmult.h`). The intrinsic always takes `v64uint8`, so the operand *type* carries no signedness.

`MatMulOpConversion` tries to recover it by looking for an `arith.extsi`/`extui` on each operand. But by the time it runs, `LowerVectorContractionOpToAIEVecMatMulPattern` has already peeled those ops off via `getSourceOfWideningOp` in order to match the narrow AIE2 shapes. The lookup always misses and falls through to an asymmetric default — unsigned LHS, signed RHS — emitting conf `0x108` where a signed × signed matmul needs `0x308`. The existing comment in `AIEVecToLLVM.cpp` notes the information is unavailable; this PR makes it available.

## Fix

Record the signedness on the op while it is still known:

- add optional `lhsSigned`/`rhsSigned` attributes to `aievec.matmul` and `aievec.matmul_aie2p`;
- set them in the contraction pattern at the point it peels the widening op;
- prefer them in `MatMulOpConversion`.

The attributes are **optional** and the previous type-based defaults are retained, so hand-written `aievec.matmul` IR behaves exactly as before.

Detection also consults the original, pre-conversion contraction operands: another pattern in the same conversion may already have rewritten `arith.extsi` into an `aievec.ups`/`aievec.srs` pair, so `getSignednessOfWideningOp` additionally reads `aievec.srs`'s own `sign` attribute.

The uint8-activation × int8-weight case used by quantized CNNs is unchanged — it now derives conf `0x108` from the actual `extui`/`extsi` ops instead of assuming it.

## Verification status

Verified end-to-end on **NPU1 (Phoenix, AIE2)** hardware, plus NPU2 as noted in the thread. The NPU1 runs below use mlir-aie **v1.4.0 + these three commits** (they cherry-pick cleanly onto the tag), driving the real `aircc`/`aiecc` flow with mlir-air `d3c5f87`. Note `aiecc` runs its passes in-process, so the patched `aiecc` binary — not just `aie-opt` — is what is exercised here.

**Config word in the generated core ELF**, same `vmac ..., rN` instruction:

```
before:  mova r22, #0x108     (signX=0, signY=1)  -> zext(A) * sext(B)
after:   mova r18, #0x308     (signX=1, signY=1)  -> sext(A) * sext(B)
```

**mlir-air `programming_examples/matrix_multiplication/i8`, `run4x4` (512x512x512, 4x4 herd, `--direct-codegen`):**

| inputs | unpatched | patched |
|---|---|---|
| `np.arange(...) % 7 - 3` (signed) | `failed.` | **`PASS!`** |
| `np.arange(...) % 7` (as shipped, non-negative) | `PASS!` | **`PASS!`** |

The as-shipped example uses values 0..6. That is exactly the non-negative pattern that hides this bug, which is why it passes either way — the signed variant is the one that exposes it.

**Triton i8 GEMM** (`tl.dot(i8,i8) -> i32`, 256x256x256, exact compare `atol=0 rtol=0`):

| probe | unpatched | patched |
|---|---|---|
| signed single products (`A=-1,B=1`; `-7,5`; `-3,-3`; ...) | wrong, `= zext8(A)*sext8(B)` | **all exact** |
| vary along M | 28416 / 65536 wrong | **0 wrong** |
| vary along N / K | 0 wrong | **0 wrong** |
| random `[-8, 8)` | 65293 / 65536 wrong | **0 wrong** |
| full example, all shapes | fails | **exit 0** |

**No regression:** a bf16 GEMM sweep (27 kernels) passes on NPU1 with the patched toolchain in 352 s, matching the unpatched baseline exactly.

## Tests

- `test/Conversion/AIEVecToLLVM/matmul.mlir` — all four signedness combinations pinned to their exact configuration words (`0x008` / `0x108` / `0x208` / `0x308`). The pre-existing attribute-free case still checks `264`, covering the unchanged fallback.
- `test/Conversion/VectorToAIEVec/test-contract.mlir` — all four `extsi`/`extui` pairings, plus the bf16 path which correctly gets no attributes (`arith.extf` carries no signedness).
- `test/dialect/AIEVec/roundtrip.mlir` — printing/parsing with and without the attributes.

`check-aie`: 90/90 AIEVec tests pass. The 20 `python/` failures in the full suite are pre-existing in my environment — I confirmed they reproduce identically on a clean `main` build.


---

## Update: AIE2P (NPU2) now honors the attributes

The first revision added `lhsSigned`/`rhsSigned` to `aievec.matmul_aie2p` but `MatMulOpAIE2pConversion` still hardcoded the i8 MAC configuration word (`776` = `0x308`, signed×signed) and ignored them — so mixed signedness silently computed signed×signed on AIE2P. The AIE2P integer lowering now derives the conf word as `0x8 | (signX<<9) | (signY<<8)` from the attributes (defaulting to signed×signed when absent), matching the AIE2 encoding (`sgn_x` at bit 9, `sgn_y` at bit 8 per `aie2p_compute_control`).

Verified end-to-end on NPU2 (Strix / AIE2P) through the mlir-air `matrix_multiplication/i8` example with `--direct-codegen`:

| test | result |
|---|---|
| uint8 LHS × int8 RHS (`cast_unsigned` on A), 64×64×64, LHS bytes straddling 127 | **PASS** vs uint8 reference |
| same run, reference recomputed as *signed* A (negative control) | **fails** (expected −1026, hardware 8190 = the unsigned result) → confirms `signX=0` reached the MAC |
| signed × signed (regression) | **PASS** |

## Review comments addressed

- **AIE2P lowering** now consumes `lhsSigned`/`rhsSigned` instead of hardcoding `776`.
- Signedness is recorded on the **first** `aievec.matmul` create, not only on the widening-peel fallback, so it survives a later canonicalization stripping the `extsi`/`extui`.
- `getSignednessOfWideningOp` doc corrected: `aievec.srs` carries its own `sign` attribute; `aievec.ups`/`aievec.cast` do not.
- `.td` fallback description clarified to match the actual asymmetric defaults (lhs unsigned unless `extsi`, rhs signed unless explicitly unsigned).

## Added tests

- `test/Conversion/AIEVecToLLVM/matmul-aie2p.mlir` — i8 conf words `8`/`264`/`520`/`776` pinned for all four signedness combinations plus the attribute-free default.

