### PR TITLE
[programming_examples] Fix why block_datatypes ATB needs chess

### DIFF
--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/README.md
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/README.md
@@ -57,14 +57,12 @@ combined tradeoff) see Sections 3 – 5 of the paper.
 
 These designs use IRON and currently require the **chess** compiler (each
 `config*/n32_core.py` declares its bfp16 mac kernel with `use_chess=True`
-on the `ExternalFunction`).  Peano's AIE2P backend still crashes on the
-bfp16 matmul kernels — verified June 2026 with `llvm-aie 21.0.0.2026052701+9e603b76`:
-
-```
-fatal error: error in backend: unable to legalize instruction:
-  %242:_(<8 x s8>) = G_BUILD_VECTOR %243:_(s8), %243:_(s8), ...
-  (in function: matmul_vectorized_bfp16)
-```
+on the `ExternalFunction`).  The reason is register placement rather than
+codegen support: the kernels pin their ping and pong tiles and accumulators
+to named registers with `chess_storage(ex0..ex7)` and `chess_storage(dm0..dm3)`,
+which is the asymmetric buffering these examples exist to demonstrate.  Peano
+defines `chess_storage(...)` as an empty macro, so those placements are dropped
+and its allocator chooses instead.
 
 Build any of them with:
 


### PR DESCRIPTION
## Problem

The ATB README explains the chess requirement with a Peano legalizer crash in
`matmul_vectorized_bfp16`. These designs do not compile that function. Each
`config*/n32_core.py` declares `matmul_vectorized_different_datatypes` from
`config*/mm_bfp_mixed.cc`, and that kernel builds under Peano today. The quoted
crash belongs to `aie_kernels/aie2p/mm_bfp.cc`, which the neighbouring
`matrix_multiplication` examples use.

## Fix

State the actual reason: the kernels pin their ping and pong tiles and
accumulators to named registers with `chess_storage(ex0..ex7)` and
`chess_storage(dm0..dm3)`, which is the asymmetric buffering these examples
exist to demonstrate. Peano defines `chess_storage(...)` as an empty macro, so
the placement is dropped rather than rejected.

## Evidence

Compiled `config1/mm_bfp_mixed.cc` for `aie2p-none-unknown-elf` with two Peano
builds, one predating and one containing llvm-aie#1184. Both succeed. The same
command on `aie_kernels/aie2p/mm_bfp.cc` fails on the older build with the exact
error the README quotes, and succeeds on the newer one.

## Scope

Documentation only. No design, kernel or lit change; the examples still build
with chess. I have not measured a Peano build against the published throughput
numbers, so this does not claim the placement is or is not load-bearing for
them, only that it is what the flag is for.