### PR TITLE
Windows XRTKernelResult.run fix npu_time precision

### DIFF
--- a/programming_examples/ml/magika/test_group0.py
+++ b/programming_examples/ml/magika/test_group0.py
@@ -105,9 +105,9 @@ def main(opts):
     # Main run loop
     # ------------------------------------------------------
     for i in range(num_iter):
-        start = time.time_ns()
+        start = time.perf_counter_ns()
         ret = DefaultNPURuntime.run(kernel_handle, buffers)
-        stop = time.time_ns()
+        stop = time.perf_counter_ns()
 
         if enable_trace:
             trace_buffer, _ = HostRuntime.extract_trace_from_args(buffers, trace_config)

--- a/programming_examples/ml/magika/test_group2.py
+++ b/programming_examples/ml/magika/test_group2.py
@@ -127,9 +127,9 @@ def main(opts):
     # Main run loop
     # ------------------------------------------------------
     for i in range(num_iter):
-        start = time.time_ns()
+        start = time.perf_counter_ns()
         ret = DefaultNPURuntime.run(kernel_handle, buffers)
-        stop = time.time_ns()
+        stop = time.perf_counter_ns()
 
         if enable_trace:
             trace_buffer, _ = HostRuntime.extract_trace_from_args(buffers, trace_config)

--- a/programming_examples/ml/mobilenet/test_mobilenet.py
+++ b/programming_examples/ml/mobilenet/test_mobilenet.py
@@ -515,9 +515,9 @@ def main(opts):
     # Main run loop
     # ------------------------------------------------------
     for i in range(num_iter):
-        start = time.time_ns()
+        start = time.perf_counter_ns()
         DefaultNPURuntime.run(kernel_handle, buffers)
-        stop = time.time_ns()
+        stop = time.perf_counter_ns()
         npu_time = stop - start
         npu_time_total = npu_time_total + npu_time
 

--- a/python/utils/hostruntime/hrxruntime/hostruntime.py
+++ b/python/utils/hostruntime/hrxruntime/hostruntime.py
@@ -284,7 +284,7 @@ class HRXHostRuntime(HostRuntime):
 
         args, bindings = self._prepare_bindings(args)
 
-        start = time.time_ns()
+        start = time.perf_counter_ns()
         try:
             self._ctx.dispatch(
                 kernel_handle.executable, kernel_handle.export_ordinal, bindings
@@ -293,9 +293,9 @@ class HRXHostRuntime(HostRuntime):
         except HRXError as e:
             if fail_on_error:
                 raise HostRuntimeError(f"HRX dispatch failed: {e}") from e
-            stop = time.time_ns()
+            stop = time.perf_counter_ns()
             return HRXKernelResult(stop - start, success=False)
-        stop = time.time_ns()
+        stop = time.perf_counter_ns()
 
         # Outputs were written on-device; the persistent host mapping is stale.
         # Leave the tensors marked device="npu" so the next host read
@@ -356,16 +356,16 @@ class HRXHostRuntime(HostRuntime):
             )
             touched.extend(kept)
 
-        start = time.time_ns()
+        start = time.perf_counter_ns()
         try:
             self._ctx.dispatch_chain(items)
             self._ctx.synchronize()
         except HRXError as e:
             if fail_on_error:
                 raise HostRuntimeError(f"HRX chain dispatch failed: {e}") from e
-            stop = time.time_ns()
+            stop = time.perf_counter_ns()
             return HRXKernelResult(stop - start, success=False)
-        stop = time.time_ns()
+        stop = time.perf_counter_ns()
 
         # Mark every touched tensor device-resident so the next host read
         # invalidates and observes the on-device results.

--- a/python/utils/hostruntime/xrtruntime/hostruntime.py
+++ b/python/utils/hostruntime/xrtruntime/hostruntime.py
@@ -356,10 +356,10 @@ class XRTHostRuntime(HostRuntime):
                         xrt_device=self._device,
                     ).buffer_object()
 
-            start = time.time_ns()
+            start = time.perf_counter_ns()
             h = kernel_handle.kernel(3, insts_bo, insts_bytes, *buffers)
             r = h.wait()
-            stop = time.time_ns()
+            stop = time.perf_counter_ns()
 
             if fail_on_error and r != pyxrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
                 raise HostRuntimeError(f"Kernel returned {str(r)}")
@@ -387,12 +387,12 @@ class XRTHostRuntime(HostRuntime):
         for i, buf in enumerate(buffers):
             run.set_arg(i, buf)
 
-        start = time.time_ns()
+        start = time.perf_counter_ns()
         run.start()
         # run.wait() returns the ert_cmd_state; run.wait2() returns None, so it
         # cannot be checked against ERT_CMD_STATE_COMPLETED.
         r = run.wait()
-        stop = time.time_ns()
+        stop = time.perf_counter_ns()
 
         if fail_on_error and r != pyxrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
             raise HostRuntimeError(f"Kernel returned {str(r)}")


### PR DESCRIPTION

<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Switch to `time.perf_counter_ns` since `time.time_ns` is not precise …enough on Windows causing start and stop to be the same value. Previously a majority of the IRON tests fail with a divide by zero error because the `npu_time` was 0.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
