### PR TITLE
fix(aiecc): merge inline kernels in-process, then downgrade for Peano

### DIFF
--- a/test/aiecc/Inputs/peano_merge_intrinsics_kernel.ll
+++ b/test/aiecc/Inputs/peano_merge_intrinsics_kernel.ll
@@ -1,0 +1,61 @@
+; Copyright (C) 2026 Advanced Micro Devices, Inc.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; A merge-mode ("inline") kernel artifact in the shape ExternalFunction(
+; inline=True) hands aiecc: an `alwaysinline`, `linkonce_odr` definition in
+; textual LLVM IR. Owned by peano_compat_merge_link.mlir.
+;
+; Hand-written rather than compiled so the constructs that broke the merge stay
+; pinned whatever a given clang emits:
+;
+;   * generic intrinsics (llvm.fabs / fmuladd / smax / smin) -- their
+;     declarations are what the merge linker decorates with attributes Peano
+;     cannot parse. Real kernels reach them by canonicalization: a NaN check
+;     becomes llvm.fabs, a multiply-add llvm.fmuladd, a clamp smax/smin.
+;   * llvm.lifetime.start/end carrying the size operand Peano requires and a
+;     newer LLVM drops.
+;
+; The (ptr, ptr) signature is aiecc's bare-pointer memref calling convention.
+
+target triple = "aie2"
+
+define linkonce_odr void @merge_kernel(ptr %in, ptr %out) #0 {
+entry:
+  %scratch = alloca [4 x float], align 4
+  call void @llvm.lifetime.start.p0(i64 16, ptr %scratch)
+  br label %body
+
+body:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %body ]
+  %in.ptr = getelementptr inbounds i32, ptr %in, i32 %i
+  %x = load i32, ptr %in.ptr, align 4
+  ; A clamp to [0, 255]: llvm.smax / llvm.smin.
+  %lo = call i32 @llvm.smax.i32(i32 %x, i32 0)
+  %clamped = call i32 @llvm.smin.i32(i32 %lo, i32 255)
+  ; |v| * v + v staged through the local buffer: llvm.fabs / llvm.fmuladd.
+  %v = sitofp i32 %clamped to float
+  %mag = call float @llvm.fabs.f32(float %v)
+  %slot = getelementptr inbounds [4 x float], ptr %scratch, i32 0, i32 0
+  store float %mag, ptr %slot, align 4
+  %mag.reloaded = load float, ptr %slot, align 4
+  %acc = call float @llvm.fmuladd.f32(float %mag.reloaded, float %v, float %v)
+  %res = fptosi float %acc to i32
+  %out.ptr = getelementptr inbounds i32, ptr %out, i32 %i
+  store i32 %res, ptr %out.ptr, align 4
+  %i.next = add nuw nsw i32 %i, 1
+  %done = icmp eq i32 %i.next, 16
+  br i1 %done, label %exit, label %body
+
+exit:
+  call void @llvm.lifetime.end.p0(i64 16, ptr %scratch)
+  ret void
+}
+
+declare float @llvm.fabs.f32(float)
+declare float @llvm.fmuladd.f32(float, float, float)
+declare i32 @llvm.smax.i32(i32, i32)
+declare i32 @llvm.smin.i32(i32, i32)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
+
+attributes #0 = { alwaysinline }

--- a/test/aiecc/peano_compat_merge_link.mlir
+++ b/test/aiecc/peano_compat_merge_link.mlir
@@ -1,0 +1,64 @@
+//===- peano_compat_merge_link.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Merging a kernel into the core (`link_with_mode = "merge"`) is the only step
+// that hands *textual* LLVM IR between LLVM versions, so it is the only one
+// exposed to the skew between aiecc's LLVM and Peano's older one.  The linker
+// reprints the merged module in aiecc's dialect, and Peano then rejects its own
+// kernel back unless that text is downgraded: `unterminated attribute group` on
+// `nocreateundeforpoison`, `immarg operand has non-immediate parameter` on a
+// size-less `llvm.lifetime.*`.
+//
+// The whole peano path runs here, so Peano's own opt/llc decide.  Drop the
+// post-link downgrade and this fails at `opted_{0}.ll` with those errors.
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: aiecc --tmpdir %t %s
+// RUN: FileCheck %s --check-prefix=LINKED --input-file %t/peano-linked_main_core_0_2.ll --implicit-check-not=nocreateundeforpoison --implicit-check-not=", align "
+// RUN: FileCheck %s --check-prefix=OPTED --input-file %t/opted_main_core_0_2.ll --implicit-check-not=@merge_kernel
+
+// The kernel arrived, and the merged text is back in a dialect Peano parses: no
+// unknown attribute (--implicit-check-not above) and lifetime markers carrying
+// the size operand its verifier requires.  `-1` is "whole object" -- the
+// original size is gone, dropped when the newer LLVM read the kernel in.
+// LINKED: define linkonce_odr void @merge_kernel
+// LINKED-DAG: call void @llvm.lifetime.start.p0(i64 -1,
+// LINKED-DAG: call void @llvm.lifetime.end.p0(i64 -1,
+// LINKED-DAG: declare void @llvm.lifetime.start.p0(i64 immarg,
+// LINKED-DAG: declare void @llvm.lifetime.end.p0(i64 immarg,
+
+// Peano's opt then folds the alwaysinline kernel in and dead-strips the
+// linkonce_odr definition: no `@merge_kernel` survives (--implicit-check-not
+// above; the inliner's `merge_kernel.exit` label carries no `@`).
+// OPTED: define void @core_0_2
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+    // Relative link_with resolves against the input file's directory, so the
+    // artifact is referenced in place -- no copy into the work dir needed.
+    func.func private @merge_kernel(memref<16xi32>, memref<16xi32>) attributes {link_with = "Inputs/peano_merge_intrinsics_kernel.ll", link_with_mode = "merge"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %subview_in = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_in = aie.objectfifo.subview.access %subview_in[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+      %subview_out = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_out = aie.objectfifo.subview.access %subview_out[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+      func.call @merge_kernel(%elem_in, %elem_out) : (memref<16xi32>, memref<16xi32>) -> ()
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+  }
+}

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -292,6 +292,41 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
   replaceAll("getelementptr inbounds nuw", "getelementptr inbounds");
   erasePattern("nocreateundeforpoison",
                [](char c) { return c == ' ' || c == '\t'; });
+  // LLVM 23 dropped the size operand of `llvm.lifetime.start`/`.end`; Peano
+  // still declares it `immarg`, so the size-less form fails its verifier
+  // ("immarg operand has non-immediate parameter"). Put it back -- `-1` is
+  // "whole object", what LLVM's own auto-upgrade uses. Matching the marker name
+  // covers every address space; already-sized calls are skipped, so this is
+  // idempotent.
+  for (llvm::StringRef marker :
+       {"@llvm.lifetime.start.", "@llvm.lifetime.end."}) {
+    for (size_t p = 0;
+         (p = result.find(marker.str(), p)) != std::string::npos;) {
+      size_t paren = result.find('(', p);
+      size_t eol = result.find('\n', p);
+      if (paren == std::string::npos ||
+          (eol != std::string::npos && paren > eol)) {
+        p += marker.size();
+        continue;
+      }
+      // The size-less form is the one whose first operand is the pointer.
+      size_t arg = paren + 1;
+      if (arg + 3 > result.size() || result.compare(arg, 3, "ptr") != 0 ||
+          (arg + 3 < result.size() && isIdentChar(result[arg + 3]))) {
+        p = arg;
+        continue;
+      }
+      size_t bol = result.rfind('\n', p);
+      bol = (bol == std::string::npos) ? 0 : bol + 1;
+      bool isDeclaration = llvm::StringRef(result)
+                               .substr(bol, p - bol)
+                               .ltrim()
+                               .starts_with("declare");
+      std::string sizeArg = isDeclaration ? "i64 immarg, " : "i64 -1, ";
+      result.insert(arg, sizeArg);
+      p = arg + sizeArg.size();
+    }
+  }
   replaceTypedLiteral("half -inf", "half 0xHFC00");
   replaceTypedLiteral("half inf", "half 0xH7C00");
   replaceTypedLiteral("half nan", "half 0xH7E00");
@@ -337,6 +372,10 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
   // to skip vectorizing the matmul K-loop, scalarizing it into ~10x more
   // program memory and overflowing AIE core memory. Do not remove without
   // confirming the i8 matmul still fits program memory.
+  //
+  // Applies after the merge too: llvm-link reprints the module and reintroduces
+  // `align` (with ABI defaults) on the very instructions this stripped before
+  // linking, so a merged core would otherwise reach opt fully annotated.
   {
     const std::string alignPat = ", align ";
     size_t pos = 0;

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -182,62 +182,92 @@ buildObjectSubgraph(EdgeWithTypedOutput<ModRef> &lowered,
       .output("-o");
   auto &peanoCompat =
       llvmIR.map<std::string>("peano-compat_{0}.ll", downgradeIRForPeano);
-  // Merge the core's merge-mode link artifacts into the downgraded core IR via
-  // llvm-link before opt. With the kernel marked alwaysinline this inlines the
-  // kernel body into the core -- no surviving func.call and no separately
-  // object-linked kernel object. The kernel IR is already peano-flavored (it is
-  // emitted by the peano toolchain), so only the core IR needs downgrading;
-  // llvm-link then merges the two. These artifacts come from the core's
-  // `link_merge_files`, which the ld-script/BCF emitters never emit (they emit
-  // `link_files` only, see AIETranslateToLdScript / AIETranslateToBCF), so each
-  // symbol is merged exactly once. Keys with no merge-mode link files pass the
-  // downgraded IR straight through (no llvm-link is run). Peano only: the chess
-  // front-end cannot llvm-link.
-  ShellCommand llvmLinkCmd{"llvm-link"};
-  llvmLinkCmd.input().inputs().arg("-S").output("-o");
+  // Merge the core's merge-mode link artifacts (`link_merge_files`) into the
+  // downgraded core IR before opt; with the kernel marked alwaysinline that
+  // inlines its body into the core, leaving no func.call and no separate kernel
+  // object. The ld-script/BCF emitters emit `link_files` only, so each symbol
+  // is merged exactly once. Keys with no merge-mode files pass straight
+  // through. Peano only: the chess front-end cannot llvm-link.
+  //
+  // Merged in-process (AIELLVMLink) rather than via `llvm-link`, which the
+  // Peano wheel does not ship -- a bare-name lookup silently lands on whatever
+  // other LLVM is on PATH. A linker reprints the merged module in its own IR
+  // dialect, so downgradeIRForPeano runs again on the result: the pre-link pass
+  // above cannot see the newer spellings the reprint introduces, and the
+  // reprint also restores the `align` attributes it had stripped.
   auto &peanoLinked =
       bundle(peanoCompat.out, irLinkFiles.out)
-          .map<File>("peano-linked_{0}.ll",
-                     [llvmLinkCmd](const Item<std::string> &ir,
-                                   const Item<std::vector<std::string>> &links,
-                                   Item<File> &out) -> mlir::LogicalResult {
-                       if (links.get().empty()) {
-                         // Nothing to merge: the downgraded core IR is the
-                         // object input. Copy it to this edge's own output path
-                         // -- aliasing the peano-compat item's path collides
-                         // with it (the engine requires each item's output path
-                         // to be unique).
-                         if (std::error_code ec = llvm::sys::fs::copy_file(
-                                 ir.asFile(), out.filePath)) {
-                           llvm::errs()
-                               << "aiecc: peano-linked: cannot copy '"
-                               << ir.asFile() << "' to '" << out.filePath
-                               << "': " << ec.message() << "\n";
-                           return mlir::failure();
-                         }
-                         out.value = File{};
-                         return mlir::success();
-                       }
-                       return llvmLinkCmd(ir, links, out);
-                     })
+          .map<File>(
+              "peano-linked_{0}.ll",
+              [](const Item<std::string> &ir,
+                 const Item<std::vector<std::string>> &links,
+                 Item<File> &out) -> mlir::LogicalResult {
+                if (links.get().empty()) {
+                  // Nothing to merge: the downgraded core IR is the
+                  // object input. Copy it to this edge's own output path
+                  // -- aliasing the peano-compat item's path collides
+                  // with it (the engine requires each item's output path
+                  // to be unique).
+                  if (std::error_code ec =
+                          llvm::sys::fs::copy_file(ir.asFile(), out.filePath)) {
+                    llvm::errs() << "aiecc: peano-linked: cannot copy '"
+                                 << ir.asFile() << "' to '" << out.filePath
+                                 << "': " << ec.message() << "\n";
+                    return mlir::failure();
+                  }
+                  out.value = File{};
+                  return mlir::success();
+                }
+                if (dryRun) {
+                  // Placeholder so path bookkeeping resolves without requiring
+                  // the merge artifacts to exist, as the ShellCommand edges do.
+                  std::error_code ec;
+                  llvm::raw_fd_ostream placeholder(out.filePath, ec);
+                  if (ec) {
+                    llvm::errs()
+                        << "aiecc: peano-linked: cannot write '" << out.filePath
+                        << "': " << ec.message() << "\n";
+                    return mlir::failure();
+                  }
+                  out.value = File{};
+                  return mlir::success();
+                }
+                // AIELLVMLink takes module *contents*, not paths (its `Files`
+                // parameter is a misnomer). parseIR sniffs each buffer, so a
+                // `.bc` artifact works the same as a `.ll`.
+                std::vector<std::string> modules{ir.asString()};
+                for (const std::string &link : links.get()) {
+                  auto buf = llvm::MemoryBuffer::getFile(link);
+                  if (!buf) {
+                    llvm::errs()
+                        << "aiecc: peano-linked: cannot read merge-mode link "
+                           "artifact '"
+                        << link << "': " << buf.getError().message() << "\n";
+                    return mlir::failure();
+                  }
+                  modules.push_back((*buf)->getBuffer().str());
+                }
+                std::string merged;
+                llvm::raw_string_ostream mergedOs(merged);
+                if (mlir::failed(xilinx::AIE::AIELLVMLink(mergedOs, modules))) {
+                  llvm::errs() << "aiecc: peano-linked: cannot merge "
+                                  "link_with_mode = \"merge\" artifacts into "
+                                  "the core module\n";
+                  return mlir::failure();
+                }
+                std::error_code ec;
+                llvm::raw_fd_ostream os(out.filePath, ec);
+                if (ec) {
+                  llvm::errs() << "aiecc: peano-linked: cannot write '"
+                               << out.filePath << "': " << ec.message() << "\n";
+                  return mlir::failure();
+                }
+                os << downgradeIRForPeano(merged);
+                out.value = File{};
+                return mlir::success();
+              })
           .threadSafe();
-  // Peano ships opt/llc but not llvm-link, so `llvm-link` resolves to a newer
-  // host LLVM that re-serializes the whole module and reintroduces the LLVM-24
-  // constructs downgradeIRForPeano stripped from peano-compat (notably the
-  // `nocreateundeforpoison` fn attr). Peano's opt then can't parse them, so
-  // downgrade the linked module once more before opt.
-  auto &peanoCompatLinked = peanoLinked.map<std::string>(
-      "peano-compat-linked_{0}.ll",
-      [](const Item<File> &in, Item<std::string> &out) -> mlir::LogicalResult {
-        auto ir =
-            Deserializer<std::string>::read(in.asFile(), DeserializeContext{});
-        if (mlir::failed(ir))
-          return mlir::failure();
-        out.value = downgradeIRForPeano(*ir);
-        return mlir::success();
-      });
-  auto &opted =
-      peanoCompatLinked.map<File>("opted_{0}.ll", optCmd).threadSafe();
+  auto &opted = peanoLinked.map<File>("opted_{0}.ll", optCmd).threadSafe();
   ShellCommand llcCmd{"llc"};
   llcCmd.input()
       .arg("-O" + std::to_string(optLevel.getValue()))


### PR DESCRIPTION
The merge path `link_with_mode = "merge"`, i.e. ExternalFunction(inline=True) shelled out to `llvm-link` by bare name. That is the one step in the toolchain that hands *textual* LLVM IR between LLVM versions, and it broke in a way that depended on how Peano was installed:

  * The released llvm-aie wheel ships a toolchain-only bin -- 21 binaries, no `llvm-link` (its LLVM_TOOLCHAIN_TOOLS list omits it). A source build ships one. So the bare-name lookup found Peano's linker on a source build and silently fell through to mlir-aie's own newer LLVM on a wheel install.
  * A linker does not concatenate; it reprints the merged module in its own LLVM's textual IR. Reprinted by the newer LLVM, Peano then rejects its own kernel back: `unterminated attribute group` on the `nocreateundeforpoison` stamped onto generic intrinsic declarations (llvm.fabs, llvm.fmuladd, llvm.smax/smin), and `immarg operand has non-immediate parameter` on an `llvm.lifetime.*` whose size operand the newer LLVM dropped.

downgradeIRForPeano could not cover either: it runs before the linker reprints. Object-linked kernels were never affected -- ld.lld links objects, not IR text.

Merge in-process via AIELLVMLink instead. That drops the external `llvm-link` dependency (so wheel and source installs run the same code), fixes the linker version, and lets the reprint be normalized afterwards. Split the per-core downgrade so only its syntax half runs on the merged text: the `, align <N>` stripping is a codegen tuning hack, not a compatibility fix, and dropping alignment on merged-in kernel IR would let LLVM assume the type's stricter ABI alignment. Also restore the `llvm.lifetime.*` size operand (`-1`, "whole object") when downgrading, which the reprint drops.

Adds a Peano-only, hardware-free regression test: the previous end-to-end coverage of the inline path was gated on ryzen_ai_npu1/npu2, so nothing in CI compiled a merge-mode design. The test fails at `opted_{0}.ll` with the errors above if the post-link downgrade is removed (verified), and passes against a wheel-shaped Peano install with no `llvm-link` (verified).

<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

<!-- What does this PR change, and why? Link any related issue with "Fixes #123". -->

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
