### PR TITLE
Find the Python interpreter regardless of AIE_ENABLE_BINDINGS_PYTHON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,12 @@ include(HandleLLVMOptions)
 include(ExternalProject)
 include(CMakeDependentOption)
 
+# The AIE event codegen (include/aie/Dialect/AIE/IR) runs on every build, but
+# mlir_configure_python_dev_packages() only sets Python3_EXECUTABLE when
+# AIE_ENABLE_BINDINGS_PYTHON is on. Same minimum version, so the two agree.
+include(MLIRDetectPythonEnv)
+find_package(Python3 ${MLIR_MINIMUM_PYTHON_VERSION} REQUIRED COMPONENTS Interpreter)
+
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
## Problem

The AIE event codegen (`include/aie/Dialect/AIE/IR`) runs on every build and
drives it with `${Python3_EXECUTABLE}`, but that is only set by
`mlir_configure_python_dev_packages()`, guarded by `AIE_ENABLE_BINDINGS_PYTHON`.
With the bindings off it expands to nothing, so the custom command runs
`generate_events_json.py` directly and the build dies at exit 126.

## Fix

`find_package(Python3 ... COMPONENTS Interpreter)` before the guard, pinned to
`MLIR_MINIMUM_PYTHON_VERSION` so this and the bindings' own call cannot select
different interpreters.

## Test

`-DAIE_ENABLE_BINDINGS_PYTHON=OFF`, from scratch: `ninja GenerateAIEEventsTD`
fails `[code=126]` before, succeeds after. Bindings-on configure unchanged.
