### PR TITLE
[AIE] Move the core stack-size default onto AIETargetModel

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -371,7 +371,8 @@ def AIE_CoreOp: AIE_Op<"core", [
   ]>, Results<(outs Index)> {
   let arguments = (
     ins Index:$tile,
-    DefaultValuedAttr<AIEI32Attr, "0x400">:$stack_size,
+    // Absent means "use this target's default"; read getEffectiveStackSize().
+    OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<1>]>>:$stack_size,
     // Deprecated: attach link_with to func.func declarations instead and run
     // aie-assign-core-link-files to populate link_files.
     OptionalAttr<StrAttr>:$link_with,
@@ -407,10 +408,15 @@ def AIE_CoreOp: AIE_Op<"core", [
     will run in the core. The path specified should is relative to the MLIR
     file.
 
-    This op has an optional `stackSize` attribute, to control the amount of memory (in bytes)
-    reserved for the stack.  The default value is 1024.  The stack (and other data allocations)
-    are always stored in the local core memory, to avoid conflicts with static data allocations
-    in other cores.
+    This op has an optional `stack_size` attribute, to control the amount of memory (in bytes)
+    reserved for the stack.  When absent the target's default is used
+    (`AIETargetModel::getDefaultCoreStackSize()`).  The stack (and other data allocations)
+    are always stored in the local core memory, to avoid conflicts with static data
+    allocations in other cores.
+
+    The reservation is not checked against the core's actual frames, and the stack sits
+    directly below the objectFIFO buffers with no clearance, so a design with large frames
+    must set this attribute or it will overwrite them silently.
 
     This op has an optional `dynamic_objfifo_lowering` attribute, to finely control whether the
     objectfifos in this core should be lowered using the dynamic runtime lowering.
@@ -464,7 +470,7 @@ def AIE_CoreOp: AIE_Op<"core", [
     %tile = aie.tile(3, 3)
     aie.core(%tile) {
       aie.end
-    } { stackSize = 2048 : i32, elf_file = "core_33.elf" }
+    } { stack_size = 2048 : i32, elf_file = "core_33.elf" }
     ```
   }];
 
@@ -476,6 +482,9 @@ def AIE_CoreOp: AIE_Op<"core", [
     TileOp getTileOp();
     bool isMemWest() { return ((rowIndex() % 2) == 0); };
     bool isEmpty();
+    /// The stack reservation in bytes: the `stack_size` attribute when set,
+    /// otherwise this target's default.
+    uint32_t getEffectiveStackSize();
     void getAsmResultNames(::mlir::OpAsmSetValueNameFn setNameFn) {
       TileElement::Trait<CoreOp>::getAsmResultNames(setNameFn);
     }

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -254,6 +254,12 @@ public:
   /// Return the size (in bytes) of the local data memory of a core.
   virtual uint32_t getLocalMemorySize() const = 0;
 
+  /// Return the default stack reservation (in bytes) for a core, used when a
+  /// design does not state one. The linker script places the stack directly
+  /// below the objectFIFO buffers with no clearance, so a design whose frames
+  /// exceed this corrupts them instead of faulting.
+  virtual uint32_t getDefaultCoreStackSize() const { return 0x400; }
+
   /// Return the data bus width (in bits) for load/store operations of a compute
   /// core.
   virtual uint32_t getComputeTileLoadStoreBusWidth() const = 0;

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1833,6 +1833,14 @@ LogicalResult CoreOp::verify() {
                  << "' appears in both 'link_files' and 'link_merge_files'; an "
                     "artifact must be either merged or linked, not both";
     }
+  // Checked last so it does not pre-empt the diagnostics above on an op with
+  // more than one defect.
+  if (uint32_t stackSize = getEffectiveStackSize(),
+      localMem = getTargetModel(*this).getLocalMemorySize();
+      stackSize >= localMem)
+    return emitOpError("stack_size ")
+           << stackSize << " leaves no local memory for this tile's buffers ("
+           << localMem << " bytes total)";
   return success();
 }
 
@@ -1845,6 +1853,11 @@ bool CoreOp::isEmpty() {
 
 TileOp CoreOp::getTileOp() {
   return cast<TileElement>(this->getOperation()).getTileOp();
+}
+
+uint32_t CoreOp::getEffectiveStackSize() {
+  return getStackSize().value_or(
+      getTargetModel(*this).getDefaultCoreStackSize());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -182,7 +182,7 @@ static bool basicAllocation(TileOp tile) {
   int64_t stacksize = 0;
   int64_t address = 0;
   if (auto core = tile.getCoreOp()) {
-    stacksize = core.getStackSize();
+    stacksize = core.getEffectiveStackSize();
     address += stacksize;
   }
 
@@ -544,7 +544,7 @@ static bool simpleBankAwareAllocation(TileOp tile) {
   for (int i = 0; i < numBanks; i++)
     nextAddrInBanks.push_back(bankSize * i);
   if (auto core = tile.getCoreOp()) {
-    stacksize = core.getStackSize();
+    stacksize = core.getEffectiveStackSize();
     nextAddrInBanks[0] += stacksize;
   }
   fillBankLimits(numBanks, bankSize, bankLimits);

--- a/lib/Dialect/AIE/Transforms/AIESAPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIESAPlacer.cpp
@@ -1199,7 +1199,7 @@ LogicalResult SAPlacer::collectAndBuildModel(DeviceOp device) {
     auto *tileOp = coreOp.getTile().getDefiningOp();
     if (!tileOp || !isa<LogicalTileOp>(tileOp))
       return;
-    stackSizes[tileOp] = coreOp.getStackSize();
+    stackSizes[tileOp] = coreOp.getEffectiveStackSize();
   });
 
   // Build net model, fifo buffer info, and cascade groups

--- a/lib/Targets/AIETargetBCF.cpp
+++ b/lib/Targets/AIETargetBCF.cpp
@@ -68,7 +68,7 @@ LogicalResult AIETranslateToBCF(ModuleOp module, raw_ostream &output,
 
       int stacksize = 0;
       if (auto core = tile.getCoreOp())
-        stacksize = core.getStackSize();
+        stacksize = core.getEffectiveStackSize();
       output << "_stack DM_stack "
              << utohexstr(targetModel.getMemInternalBaseAddress(srcCoord))
              << " " << utohexstr(stacksize) << " // stack for core\n";

--- a/lib/Targets/AIETargetLdScript.cpp
+++ b/lib/Targets/AIETargetLdScript.cpp
@@ -92,7 +92,7 @@ LogicalResult xilinx::AIE::AIETranslateToLdScript(ModuleOp module,
       // Collect occupied [start, end) intervals in tile-local coordinates: the
       // stack sits at the bottom of memory, followed by the placed buffers.
       SmallVector<std::pair<int, int>, 8> occupied;
-      occupied.push_back({0, core.getStackSize()});
+      occupied.push_back({0, core.getEffectiveStackSize()});
       for (auto buf : buffers[tiles[srcCoord]]) {
         int bufferBaseAddr = getBufferBaseAddress(buf);
         int numBytes = buf.getAllocationSize();
@@ -190,7 +190,7 @@ SECTIONS
       output << "_sp_start_value_DM_stack = .;\n";
 
       if (auto core = tile.getCoreOp())
-        output << ". += 0x" << llvm::utohexstr(core.getStackSize())
+        output << ". += 0x" << llvm::utohexstr(core.getEffectiveStackSize())
                << "; /* stack */\n";
       else
         output << "/* no stack allocated */\n";

--- a/python/iron/worker.py
+++ b/python/iron/worker.py
@@ -58,7 +58,7 @@ class Worker(ObjectFifoEndpoint):
             fn_args (list | None, optional): Pointers to arguments, which should include all context the core_fn needs to run. Defaults to None (empty list).
             tile (Tile, optional): The compute tile for the Worker. Also accepts None (treated as AnyComputeTile). Defaults to AnyComputeTile.
             while_true (bool, optional): If true, will wrap the core_fn in a while(true) loop to ensure it runs until reconfiguration. Defaults to True.
-            stack_size (int, optional): The stack_size in bytes to be allocated for the worker. Defaults to 1024 bytes.
+            stack_size (int, optional): The stack_size in bytes for the worker. Defaults to AIETargetModel::getDefaultCoreStackSize() (currently 1024 bytes).
             allocation_scheme (str, optional): The memory allocation scheme to use for the
                 Worker, either 'basic-sequential' or 'bank-aware'. If None, defaults to bank-aware.
                 Will override any allocation scheme set on the tile.

--- a/test/dialect/AIE/bad_stack_size.mlir
+++ b/test/dialect/AIE/bad_stack_size.mlir
@@ -1,0 +1,36 @@
+//===- bad_stack_size.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aie-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// CHECK: error{{.*}}'aie.core' op stack_size 65536 leaves no local memory for this tile's buffers (65536 bytes total)
+module @exceeds_local_memory {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %core = aie.core(%t) { aie.end } {stack_size = 65536 : i32}
+  }
+}
+
+// -----
+
+// CHECK: error{{.*}}'aie.core' op attribute 'stack_size' failed to satisfy constraint
+module @zero {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %core = aie.core(%t) { aie.end } {stack_size = 0 : i32}
+  }
+}
+
+// -----
+
+// CHECK: error{{.*}}'aie.core' op attribute 'stack_size' failed to satisfy constraint
+module @negative {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %core = aie.core(%t) { aie.end } {stack_size = -1 : i32}
+  }
+}


### PR DESCRIPTION
## Problem

`aie.core`'s `stack_size` default of `0x400` was stated in the TableGen default
and again in the op docs, and could not vary per target although
`getLocalMemorySize()` does. The attribute was also unconstrained, so
`stack_size = -1` was read as a huge unsigned and accepted without a diagnostic.

## Fix

`AIETargetModel::getDefaultCoreStackSize()` holds the default; consumers read
`CoreOp::getEffectiveStackSize()`. The attribute is constrained positive, and
`verify()` rejects a reservation that leaves no local memory for the tile's
buffers.

## Scope

This does not check the reservation against a core's actual frames. That needs
the linked ELF's `.stack_sizes`, which the generated script already keeps and
nothing reads; `iree-amd-aie` does that check downstream. Separate change.

## Test

New `test/dialect/AIE/bad_stack_size.mlir`. Diffed `aie-opt` error text against
a binary built from this branch's own base over 1062 files in `test/`: the new
test is the only difference. BCF and ldscript output byte-identical with and
without the attribute.
