### PR TITLE
[aiecc] Fail on a backend directory that does not exist

### DIFF
--- a/test/aiecc/cpp_backend_dir_missing.mlir
+++ b/test/aiecc/cpp_backend_dir_missing.mlir
@@ -1,0 +1,65 @@
+//===- cpp_backend_dir_missing.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A --peano path that does not exist used to be dropped and the search fell
+// through to PATH, which answers `opt` and `llc` with the host LLVM. The build
+// then ran most of the way against the wrong toolchain before failing inside
+// one of those tools. Stop at the flag instead.
+
+// RUN: not aiecc --peano=%t.does.not.exist --get-full-elf -n %s 2>&1 | FileCheck %s
+// CHECK: --peano directory does not exist
+
+// Same rule on the Chess side: discoverAietoolsDir would fall through to
+// $AIETOOLS_ROOT and then xchesscc on PATH.
+// RUN: not aiecc --xchesscc --xbridge --aietools=%t.no.aietools --get-full-elf -n %s 2>&1 | FileCheck %s --check-prefix=AIETOOLS
+// AIETOOLS: --aietools directory does not exist
+
+// An empty value is not a stated path, so it must still reach discovery.
+// RUN: aiecc --peano= --get-full-elf -n %s 2>&1 | FileCheck %s --check-prefix=DISCOVER
+// DISCOVER-NOT: does not exist
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+      %c1_i32 = arith.constant 1 : i32
+
+      %subview_in = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_in = aie.objectfifo.subview.access %subview_in[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+
+      %subview_out = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_out = aie.objectfifo.subview.access %subview_out[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+
+      scf.for %i = %c0 to %c16 step %c1 {
+        %val = memref.load %elem_in[%i] : memref<16xi32>
+        %result = arith.addi %val, %c1_i32 : i32
+        memref.store %result, %elem_out[%i] : memref<16xi32>
+      }
+
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+
+    aie.runtime_sequence(%in : memref<16xi32>, %out : memref<16xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c16 = arith.constant 16 : i64
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_wait {symbol = @of_out}
+    }
+  }
+}

--- a/tools/aiecc/Actions.h
+++ b/tools/aiecc/Actions.h
@@ -232,8 +232,10 @@ struct ShellCommand {
 
   // Register `<dir>/bin` as a search path. Tries (in order): overrideDir,
   // $<NAME>_INSTALL_DIR, <exe-prefix>/<name>, <exe-grandparent>/<name>.
-  static void addInstallPrefix(llvm::StringRef name,
-                               llvm::StringRef overrideDir = "") {
+  // Returns false only when overrideDir was given and is not a directory; the
+  // discovered candidates are guesses, so their absence is not an error.
+  [[nodiscard]] static bool addInstallPrefix(llvm::StringRef name,
+                                             llvm::StringRef overrideDir = "") {
     auto tryAdd = [](llvm::StringRef dir) -> bool {
       if (dir.empty() || !llvm::sys::fs::is_directory(dir))
         return false;
@@ -242,12 +244,20 @@ struct ShellCommand {
       addSearchPath(std::string(binDir));
       return true;
     };
-    if (tryAdd(overrideDir))
-      return;
+    if (!overrideDir.empty()) {
+      // Not falling through to discovery: the last candidate is PATH, which
+      // answers `opt` and `llc` with the host LLVM.
+      if (!tryAdd(overrideDir)) {
+        llvm::errs() << "aiecc: --" << name
+                     << " directory does not exist: " << overrideDir << "\n";
+        return false;
+      }
+      return true;
+    }
     std::string envName = name.upper() + "_INSTALL_DIR";
     if (const char *env = std::getenv(envName.c_str()))
       if (tryAdd(env))
-        return;
+        return true;
     std::string mainExe = llvm::sys::fs::getMainExecutable(
         nullptr, reinterpret_cast<void *>(&addInstallPrefix));
     llvm::StringRef prefix =
@@ -256,8 +266,9 @@ struct ShellCommand {
       llvm::SmallString<256> p(base);
       llvm::sys::path::append(p, name);
       if (tryAdd(p))
-        return;
+        return true;
     }
+    return true;
   }
 
   // Force `name` to resolve to `path` (caller must pass an executable path),

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -1761,7 +1761,15 @@ int main(int argc, char **argv) {
     inputBufferId =
         sourceMgr.AddNewSourceBuffer(std::move(inputBuf), llvm::SMLoc());
   mlir::SourceMgrDiagnosticHandler diagHandler(sourceMgr, &context);
-  ShellCommand::addInstallPrefix("peano", peanoInstallDir);
+  if (!ShellCommand::addInstallPrefix("peano", peanoInstallDir))
+    return 1;
+  // discoverAietoolsDir has the same shape: it falls through to $AIETOOLS_ROOT
+  // and then to xchesscc on PATH.
+  if (!aietoolsDir.empty() && !llvm::sys::fs::is_directory(aietoolsDir)) {
+    llvm::errs() << "aiecc: --aietools directory does not exist: "
+                 << aietoolsDir << "\n";
+    return 1;
+  }
   ShellCommand::verbose = verbose;
   ShellCommand::dryRun = dryRun;
 


### PR DESCRIPTION
## Problem

`--peano` and `--aietools` were both dropped when the stated directory did not
exist, and the search fell through to PATH -- which answers `opt` and `llc` with
the host LLVM. A bogus `--peano` ran 30 of 42 pipeline edges and died inside
`/usr/bin/opt`, never naming the flag. The Peano arm can also succeed against the
host toolchain and emit an artifact built by the wrong compiler.

## Fix

Both flags fail at the flag when the stated directory is missing. Discovery
candidates are guesses, so their absence stays non-fatal, and an unset or empty
value still reaches discovery unchanged. This is what `--xclbinutil-path`
already does with an unusable override.

## Test

`test/aiecc/cpp_backend_dir_missing.mlir`. Measured against the built binary:
`--peano=<missing>` and `--aietools=<missing>` now exit 1 naming the flag
(previously 30/42 edges, then a failure inside the wrong tool); `--peano=` and a
real `--peano=<dir>` both still reach 42/42.
