### PR TITLE
ci: lock the device, not the whole test

### DIFF
--- a/test/npu-xrt/lit.local.cfg
+++ b/test/npu-xrt/lit.local.cfg
@@ -13,4 +13,12 @@ config.excludes.add("util.py")
 # Design script driven by matmul_whole_array_dynamic/run.lit, not a test itself.
 config.excludes.add("whole_array_dynamic.py")
 
-config.parallelism_group = "npu-xrt"
+# Device dispatch is serialized inside utils/run_on_npu.py, around the dispatch
+# only, so each test's compile -- ~99% of its wall time, and no device needed --
+# runs in parallel. That lock is flock-based; where fcntl is unavailable there is
+# no lock, so the lit-level group has to stay in force. Keying both on the same
+# import is what keeps this from drifting out of sync with run_on_npu.py.
+try:
+    import fcntl  # noqa: F401
+except ImportError:
+    config.parallelism_group = "npu-xrt"

--- a/test/npu-xrt/reconfigure_loadpdi/run_ctrlpkt.lit
+++ b/test/npu-xrt/reconfigure_loadpdi/run_ctrlpkt.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: %aiecc -v --get-full-elf --load-pdi-to-ctrl-pkt --get-ctrlpkt --no-xchesscc --no-xbridge %S/aie.mlir
 // RUN: %host_clang -o test %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
 // RUN: %run_on_npu2% ./test

--- a/test/npu-xrt/reconfigure_loadpdi/run_ctrlpkt.lit
+++ b/test/npu-xrt/reconfigure_loadpdi/run_ctrlpkt.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/reconfigure_loadpdi/run_loadpdi.lit
+++ b/test/npu-xrt/reconfigure_loadpdi/run_loadpdi.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/reconfigure_loadpdi/run_loadpdi.lit
+++ b/test/npu-xrt/reconfigure_loadpdi/run_loadpdi.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: %aiecc -v --get-full-elf --no-xchesscc --no-xbridge %S/aie.mlir
 // RUN: %host_clang -o test %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
 // RUN: %run_on_npu2% ./test

--- a/test/npu-xrt/reconfigure_loadpdi/run_write32s.lit
+++ b/test/npu-xrt/reconfigure_loadpdi/run_write32s.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: %aiecc -v --get-full-elf --expand-load-pdis --no-xchesscc --no-xbridge %S/aie.mlir
 // RUN: %host_clang -o test %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
 // RUN: ./test

--- a/test/npu-xrt/reconfigure_loadpdi/run_write32s.lit
+++ b/test/npu-xrt/reconfigure_loadpdi/run_write32s.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_loadpdi.lit
+++ b/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_loadpdi.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_loadpdi.lit
+++ b/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_loadpdi.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: %aiecc -v --get-full-elf --no-xchesscc --no-xbridge %S/aie.mlir
 // RUN: %host_clang -o test.exe %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
 // RUN: %run_on_npu2% ./test.exe

--- a/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_write32s.lit
+++ b/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_write32s.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: %aiecc -v --get-full-elf --expand-load-pdis --no-xchesscc --no-xbridge %S/aie.mlir
 // RUN: %host_clang -o test.exe %S/test.cpp -std=c++17 %host_link_flags %xrt_flags
 // RUN: %run_on_npu2% ./test.exe

--- a/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_write32s.lit
+++ b/test/npu-xrt/reconfigure_loadpdi_persistent_memtile/run_write32s.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/xrt_handle_lifetime/run_ordered.lit
+++ b/test/npu-xrt/xrt_handle_lifetime/run_ordered.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir

--- a/test/npu-xrt/xrt_handle_lifetime/run_ordered.lit
+++ b/test/npu-xrt/xrt_handle_lifetime/run_ordered.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/xrt_handle_lifetime/run_stale_instr_bo.lit
+++ b/test/npu-xrt/xrt_handle_lifetime/run_stale_instr_bo.lit
@@ -7,9 +7,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/test/npu-xrt/xrt_handle_lifetime/run_stale_instr_bo.lit
+++ b/test/npu-xrt/xrt_handle_lifetime/run_stale_instr_bo.lit
@@ -4,6 +4,15 @@
 // REQUIRES: ryzen_ai, peano
 // XFAIL: system-windows
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir

--- a/test/npu-xrt/xrt_handle_lifetime/run_stale_io_bos.lit
+++ b/test/npu-xrt/xrt_handle_lifetime/run_stale_io_bos.lit
@@ -3,6 +3,15 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
+// Sibling tests in this directory write the same artifact names, and lit's
+// working directory is the test DIRECTORY rather than the test file, so they
+// would clobber each other if they ever ran concurrently.  Give each test its
+// own directory (%t is per test file), the way the makefile-driven examples
+// already do.  This is what lets the device lock replace the capacity-1
+// parallelism group without the tests racing on their artifacts.
+//
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: cd %t.d
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir

--- a/test/npu-xrt/xrt_handle_lifetime/run_stale_io_bos.lit
+++ b/test/npu-xrt/xrt_handle_lifetime/run_stale_io_bos.lit
@@ -6,9 +6,7 @@
 // Sibling tests in this directory write the same artifact names, and lit's
 // working directory is the test DIRECTORY rather than the test file, so they
 // would clobber each other if they ever ran concurrently.  Give each test its
-// own directory (%t is per test file), the way the makefile-driven examples
-// already do.  This is what lets the device lock replace the capacity-1
-// parallelism group without the tests racing on their artifacts.
+// own directory (%t is per test file).
 //
 // RUN: rm -rf %t.d && mkdir -p %t.d
 // RUN: cd %t.d

--- a/utils/run_on_npu.py
+++ b/utils/run_on_npu.py
@@ -146,12 +146,7 @@ def run_command(command: list[str]) -> tuple[int, str]:
 
 # Main entry point.
 # The NPU cannot sustain concurrent dispatch, so device runs must be serialized.
-# lit does that today by putting the whole test directory in a capacity-1
-# parallelism group, which also serializes each test's COMPILE, and compilation
-# is ~99% of a device test's wall time and needs no device at all.
-#
-# Serialize here instead, around the dispatch only, so lit is free to run the
-# tests in parallel. Properties that matter:
+# Serialize around the dispatch only, so lit is free to run the tests in parallel. 
 #   * flock is released by the kernel when the fd closes or the process dies, so
 #     a crashed or timed-out test cannot wedge the queue.
 #   * the lock file lives at a stable path and is never unlinked: flock is per
@@ -159,7 +154,6 @@ def run_command(command: list[str]) -> tuple[int, str]:
 #   * it is machine-wide, which is stronger than a lit parallelism group; that
 #     only serializes within one lit invocation, and gives nothing if a second
 #     job on the same host also touches the device.
-#   * keyed on the NPU kind, so npu1 and npu2 dispatches do not block each other.
 # AIE_NPU_NO_DEVICE_LOCK=1 opts out, for tests that exercise concurrency itself.
 @contextlib.contextmanager
 def device_lock(npu_kind: str):

--- a/utils/run_on_npu.py
+++ b/utils/run_on_npu.py
@@ -146,7 +146,7 @@ def run_command(command: list[str]) -> tuple[int, str]:
 
 # Main entry point.
 # The NPU cannot sustain concurrent dispatch, so device runs must be serialized.
-# Serialize around the dispatch only, so lit is free to run the tests in parallel. 
+# Serialize around the dispatch only, so lit is free to run the tests in parallel.
 #   * flock is released by the kernel when the fd closes or the process dies, so
 #     a crashed or timed-out test cannot wedge the queue.
 #   * the lock file lives at a stable path and is never unlinked: flock is per

--- a/utils/run_on_npu.py
+++ b/utils/run_on_npu.py
@@ -4,11 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from collections import deque
+import contextlib
 import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
+
+try:
+    import fcntl
+except ImportError:  # Windows
+    fcntl = None
 
 # Retry configuration
 TRANSIENT_FAILURE_TEXT = "No such device"
@@ -138,6 +145,47 @@ def run_command(command: list[str]) -> tuple[int, str]:
 
 
 # Main entry point.
+# The NPU cannot sustain concurrent dispatch, so device runs must be serialized.
+# lit does that today by putting the whole test directory in a capacity-1
+# parallelism group, which also serializes each test's COMPILE, and compilation
+# is ~99% of a device test's wall time and needs no device at all.
+#
+# Serialize here instead, around the dispatch only, so lit is free to run the
+# tests in parallel. Properties that matter:
+#   * flock is released by the kernel when the fd closes or the process dies, so
+#     a crashed or timed-out test cannot wedge the queue.
+#   * the lock file lives at a stable path and is never unlinked: flock is per
+#     INODE, so deleting and recreating the file would let two holders through.
+#   * it is machine-wide, which is stronger than a lit parallelism group; that
+#     only serializes within one lit invocation, and gives nothing if a second
+#     job on the same host also touches the device.
+#   * keyed on the NPU kind, so npu1 and npu2 dispatches do not block each other.
+# AIE_NPU_NO_DEVICE_LOCK=1 opts out, for tests that exercise concurrency itself.
+@contextlib.contextmanager
+def device_lock(npu_kind: str):
+    if os.environ.get("AIE_NPU_NO_DEVICE_LOCK"):
+        yield
+        return
+    # No flock here. test/npu-xrt/lit.local.cfg keys on the same import and keeps
+    # the lit-level npu-xrt parallelism group on these platforms, so dispatch stays
+    # serialized -- just at test granularity rather than at dispatch granularity.
+    if fcntl is None:
+        yield
+        return
+    lock_dir = os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir()
+    lock_path = os.path.join(lock_dir, f"mlir-aie-npu-{npu_kind}.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o666)
+    t0 = time.perf_counter()
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        waited = time.perf_counter() - t0
+        if waited > 1.0:
+            log(f"waited {waited:.1f}s for the {npu_kind} device lock")
+        yield
+    finally:
+        os.close(fd)  # releases the lock
+
+
 def main() -> int:
     if len(sys.argv) < 3:
         print("usage: run_on_npu.py <npu-kind> <command> [args...]", file=sys.stderr)
@@ -154,8 +202,12 @@ def main() -> int:
     )
     launched_command = wrapped_command(xrt_dir, command)
 
+    npu_kind = sys.argv[1]
     for attempt in range(1, MAX_ATTEMPTS + 1):
-        returncode, recent_output = run_command(launched_command)
+        # Held across one attempt only: the retry backoff below must not keep
+        # the device reserved while it sleeps.
+        with device_lock(npu_kind):
+            returncode, recent_output = run_command(launched_command)
         if returncode == 0:
             return 0
         if TRANSIENT_FAILURE_TEXT not in recent_output:


### PR DESCRIPTION
## Problem

`test/npu-xrt/lit.local.cfg` puts the whole directory in the capacity-1 `npu-xrt` parallelism group.
The NPU cannot take concurrent dispatch, so something has to serialize, but the group also serializes
each test's compile, which is nearly all of a device test's wall time and needs no device.

Measured on an AIE2P box over the whole npu-xrt filter: 197.55s at `-j1`, 189.71s at `-j12`. Twelve
workers requested, same wall time, eleven idle. The device-only portion of one of these tests is
about 20ms.

## Fix

Serialize at the dispatch instead. Every device run already goes through `utils/run_on_npu.py`, so an
`flock` there covers dispatch and nothing else, and lit schedules the tests freely. It is keyed on
NPU kind, released by the kernel on process death, and `AIE_NPU_NO_DEVICE_LOCK=1` opts out. Where
`fcntl` is unavailable the lit group stays in force.

Moving eight `.lit` files to `%t.d` is the precondition: lit's working directory is the test
directory, and sibling tests there write the same artifact names (all three of
`xrt_handle_lifetime`'s write `aie.xclbin` and `test.exe`). Invisible serialized, a clobber in
parallel.

## Test

```
197.55s  -j1,  parallelism group   (before)
189.71s  -j12, parallelism group   (before)
 47-67s  -j12, device lock         (after, three runs)
```

56 passed / 3 failed in every run before and after; the three are pre-existing and unrelated
(`test_cascade_flow`, `test_compile_link`, `test_device_override`). The lock was checked at 12, 64
and 256 contenders: no overlapping critical sections.

## Memory

This does not raise the concurrency ceiling. `buildAndTestRyzenAI.yml` already picks `-j` from the
runner's actual RAM (`-j4` under 48GB, `-j12` otherwise); npu-xrt now runs under that ceiling instead
of below it. If the suite proves memory-heavy, the narrower fix is a parallelism group for the
specific tests, as `gemm_asymmetric_tile_buffering` has via `atb_chess`, rather than the whole
directory.
