### PR TITLE
ci: run the ATB artifact suite nightly, not on every PR

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -217,7 +217,13 @@ jobs:
             esac
           }
 
-          SUITES="check-aie concurrency refs guide atb"
+          # gemm_asymmetric_tile_buffering reproduces a paper rather than gating
+          # a regression, and is ~6 min of an 18-24 min job that does not shrink
+          # on a bigger host. Nightly, plus test-ryzen-ai for on-demand runs.
+          SUITES="check-aie concurrency refs guide"
+          if [ "$GITHUB_EVENT_NAME" = schedule ] || [ "$GITHUB_REF_NAME" = test-ryzen-ai ]; then
+            SUITES="$SUITES atb"
+          fi
 
           # Only treat FAILED_SUITE as valid if it EXACTLY names a known suite
           # (fixed-string match, not a glob) -- else force the full re-run path.


### PR DESCRIPTION
## Problem

`gemm_asymmetric_tile_buffering` runs on every PR and costs a quarter to two
fifths of the aie2p-8col device job. Measured on three aie2p-8col merge-queue
jobs, 2026-08-03:

| runner | lit workers | ATB | whole job | share |
|---|---|---|---|---|
| aie4 | 12 | 5.61 min | 17.51 min | 32% |
| aie6 | 12 | 7.72 | 19.56 | 39% |
| aie8 | 4 | 6.08 | 23.84 | 26% |

It does not shrink on a bigger host. For the memory reason the file's own comment
gives, it already has its own `-j4` invocation and 1200 s timeout, serialized by
lit's `atb_chess` group, so its share rises as the rest of the job gets faster.
It contributes nothing on aie2-4col, where the same suite reports ~0.01 s.

These three configs reproduce a published result (arXiv 2511.16041). They are an
artifact, not a regression gate on the compiler.

## Fix

Run the `atb` suite on the existing nightly `cron: '0 0 * * *'`, and on
`test-ryzen-ai` so a kernel change can still be exercised on demand. No new
trigger, no change to how the suite runs when it does run.

#3104 raised running the Chess tests nightly rather than on every run. This does
it for the one that costs the most.

## Coverage

This is a real reduction: presubmit no longer builds or runs the three ATB
configs, so a change that breaks only them surfaces at the next nightly, against
a later commit than the one that caused it. `check-reference-designs` already
excludes them via `LIT_FILTER_OUT`, so nothing else in presubmit covers them
today either.

## Test

None: a workflow file is only exercised by a run. The gate is one bash
conditional, checked standalone against every `(event, ref)` pair that can occur:

| event | ref | atb |
|---|---|---|
| `pull_request`, `merge_group` | PR/queue ref | excluded |
| `push` | `test-ryzen-ai`, its only trigger | included |
| `schedule` | `main` | included |

The retry path needs no change: it iterates `$SUITES`, and `FAILED_SUITE` is
validated against that same list.
