### PR TITLE
[AIEVec] Treat signless matmul operands as signed, in one shared rule

### DIFF
--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -653,14 +653,9 @@ def AIEVec_MatMulOp:
 
     Operand signedness is carried in the integer element types: a signed
     element type (`si8`) sets the MAC `signX`/`signY` bit, an unsigned type
-    (`ui8`) clears it. Prefer spelling the signedness out.
-
-    A signless element type (`i8`) falls back to the pre-existing asymmetric
-    behavior -- lhs treated as unsigned, rhs as signed. That fallback is kept
-    only for compatibility with IR written before signedness was expressible
-    here; it is not a recommended default, and it disagrees with
-    `aievec.matmul_aie2p`, which defaults signless operands to signed.
-    Reconciling the two is left to a follow-up.
+    (`ui8`) clears it. A signless element type (`i8`) is treated as signed.
+    Each operand is resolved independently, and `aievec.matmul_aie2p` follows
+    the same rule.
 
     Currently, this intrinsic supports the following type combinations:
 
@@ -699,9 +694,9 @@ def AIEVec_MatMulOp_AIE2P:
     AMD AIEv2P-specific intrinsic that performs a matrix multiplication
     between `lhs` and `rhs`, and accumulates the result in `acc`.
 
-    As for `aievec.matmul`, operand signedness is carried in the integer
-    element types (`si8`/`ui8`) so the integer MAC configuration word can set
-    its `signX`/`signY` bits. A signless element type defaults to signed.
+    Operand signedness is carried in the integer element types exactly as for
+    `aievec.matmul`: `si8` sets the MAC `signX`/`signY` bit, `ui8` clears it,
+    and a signless element type is treated as signed.
 
     Currently, this intrinsic supports the following type combinations:
 

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -4248,6 +4248,28 @@ static Value lookThroughShapeCasts(Value v) {
   return v;
 }
 
+// If `v` is defined by a signedness-carrying unrealized_conversion_cast --
+// which is how VectorToAIEVec attaches si*/ui* to an otherwise signless
+// operand -- return the signedness it carries and advance `v` past it, so the
+// intrinsic consumes the signless input and the cast is left dead for
+// canonicalization rather than leaking to LLVM translation.
+//
+// A cast whose result element type is not explicitly signed or unsigned is
+// left in place: it is some other type conversion, and dropping it would
+// silently change the operand.
+static std::optional<bool> peelSignednessCast(Value &v) {
+  auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>();
+  if (!castOp)
+    return std::nullopt;
+  auto vecTy = dyn_cast<VectorType>(v.getType());
+  auto intTy =
+      vecTy ? dyn_cast<IntegerType>(vecTy.getElementType()) : IntegerType();
+  if (!intTy || intTy.isSignless())
+    return std::nullopt;
+  v = castOp.getInputs()[0];
+  return intTy.isSigned();
+}
+
 // The result of resolving one integer matmul operand.
 struct ResolvedMatMulOperand {
   // The value the MAC intrinsic should consume, with any widening op and any
@@ -4278,17 +4300,7 @@ struct ResolvedMatMulOperand {
 // Both aievec.matmul and aievec.matmul_aie2p resolve signedness through this
 // function. They previously each had their own copy and had drifted apart.
 static ResolvedMatMulOperand resolveMatMulOperand(Value v) {
-  std::optional<bool> castSigned;
-  if (auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (auto vecTy = dyn_cast<VectorType>(v.getType()))
-      if (auto intTy = dyn_cast<IntegerType>(vecTy.getElementType())) {
-        if (intTy.isSigned())
-          castSigned = true;
-        else if (intTy.isUnsigned())
-          castSigned = false;
-      }
-    v = castOp.getInputs()[0];
-  }
+  std::optional<bool> castSigned = peelSignednessCast(v);
 
   Value orig = lookThroughShapeCasts(v);
   if (auto extSIOp = orig.getDefiningOp<arith::ExtSIOp>())
@@ -4299,8 +4311,8 @@ static ResolvedMatMulOperand resolveMatMulOperand(Value v) {
     return {v, *castSigned};
 
   auto vecTy = dyn_cast<VectorType>(v.getType());
-  auto intTy = vecTy ? dyn_cast<IntegerType>(vecTy.getElementType())
-                     : IntegerType();
+  auto intTy =
+      vecTy ? dyn_cast<IntegerType>(vecTy.getElementType()) : IntegerType();
   return {v, !(intTy && intTy.isUnsigned())};
 }
 
@@ -4742,17 +4754,14 @@ class MatMulOpAIE2pConversion
     Value acc = op.getAcc();
 
     // Signedness follows the same rule as aievec.matmul; see
-    // resolveMatMulOperand. Only the signedness is taken from it here: the
+    // resolveMatMulOperand. Only the signedness is taken from it here -- the
     // shape checks below match on the original operand types, so the operand
-    // values keep their existing treatment (strip the signedness-carrying cast
-    // so it is left dead for canonicalization rather than leaking to LLVM
-    // translation).
+    // values are only advanced past a signedness-carrying cast, not past a
+    // widening op.
     bool lhsIsSigned = resolveMatMulOperand(lhs).isSigned;
     bool rhsIsSigned = resolveMatMulOperand(rhs).isSigned;
-    if (auto c = lhs.getDefiningOp<UnrealizedConversionCastOp>())
-      lhs = c.getInputs()[0];
-    if (auto c = rhs.getDefiningOp<UnrealizedConversionCastOp>())
-      rhs = c.getInputs()[0];
+    peelSignednessCast(lhs);
+    peelSignednessCast(rhs);
 
     auto lhsVecTy = cast<VectorType>(op.getLhs().getType());
     auto rhsVecTy = cast<VectorType>(op.getRhs().getType());

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -4239,6 +4239,71 @@ public:
   }
 };
 
+// Look through vector.shape_cast ops to find the defining op. The
+// VectorToAIEVec pass inserts shape_casts (via reshapeLeadingUnitDims) between
+// the extension ops and the matmul, which would otherwise hide the signedness.
+static Value lookThroughShapeCasts(Value v) {
+  while (auto castOp = v.getDefiningOp<vector::ShapeCastOp>())
+    v = castOp.getSource();
+  return v;
+}
+
+// The result of resolving one integer matmul operand.
+struct ResolvedMatMulOperand {
+  // The value the MAC intrinsic should consume, with any widening op and any
+  // signedness-carrying cast peeled off.
+  Value narrowed;
+  // Whether that value is to be treated as signed, i.e. whether the MAC
+  // configuration word's signX (lhs) / signY (rhs) bit should be set.
+  bool isSigned;
+};
+
+// Recover the signedness of an integer matmul operand. MLIR integers are
+// signless, so it has to come from context; in priority order:
+//
+//   1. an arith.extsi / arith.extui feeding the operand -- peel it and take
+//      its signedness;
+//   2. an unrealized_conversion_cast to a signed/unsigned element type, which
+//      is how VectorToAIEVec carries signedness across the peel it performs.
+//      Peel it too, so the intrinsic consumes the signless value and the cast
+//      is left dead for canonicalization rather than leaking to LLVM;
+//   3. an explicitly signed or unsigned element type;
+//   4. otherwise the element type is signless -- treat it as signed.
+//
+// Case 4 matches the conventional reading of a signless integer, and is the
+// more useful default: the shapes that reach it are the ones whose operand
+// type is already a legal AIE2 narrow type (so nothing was extended), which in
+// practice means i16/i32 operands carrying signed data.
+//
+// Both aievec.matmul and aievec.matmul_aie2p resolve signedness through this
+// function. They previously each had their own copy and had drifted apart.
+static ResolvedMatMulOperand resolveMatMulOperand(Value v) {
+  std::optional<bool> castSigned;
+  if (auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (auto vecTy = dyn_cast<VectorType>(v.getType()))
+      if (auto intTy = dyn_cast<IntegerType>(vecTy.getElementType())) {
+        if (intTy.isSigned())
+          castSigned = true;
+        else if (intTy.isUnsigned())
+          castSigned = false;
+      }
+    v = castOp.getInputs()[0];
+  }
+
+  Value orig = lookThroughShapeCasts(v);
+  if (auto extSIOp = orig.getDefiningOp<arith::ExtSIOp>())
+    return {lookThroughShapeCasts(extSIOp.getIn()), true};
+  if (auto extUIOp = orig.getDefiningOp<arith::ExtUIOp>())
+    return {lookThroughShapeCasts(extUIOp.getIn()), false};
+  if (castSigned)
+    return {v, *castSigned};
+
+  auto vecTy = dyn_cast<VectorType>(v.getType());
+  auto intTy = vecTy ? dyn_cast<IntegerType>(vecTy.getElementType())
+                     : IntegerType();
+  return {v, !(intTy && intTy.isUnsigned())};
+}
+
 class MatMulOpConversion
     : public mlir::ConvertOpToLLVMPattern<aievec::MatMulOp> {
   using ConvertOpToLLVMPattern<aievec::MatMulOp>::ConvertOpToLLVMPattern;
@@ -4258,29 +4323,9 @@ class MatMulOpConversion
     Value rhs = op.getRhs();
     Value acc = op.getAcc();
 
-    // The VectorToAIEVec pass carries operand signedness in the element type
-    // (si8/ui8) via an unrealized_conversion_cast from a signless value.
-    // Capture the signedness from the cast result type, then continue with the
-    // signless input so the cast is left dead (DCE'd) rather than leaking to
-    // LLVM.
-    auto castSignedness = [](Value &v) -> std::optional<bool> {
-      auto c = v.getDefiningOp<UnrealizedConversionCastOp>();
-      if (!c)
-        return std::nullopt;
-      std::optional<bool> isSigned;
-      if (auto vt = dyn_cast<VectorType>(v.getType()))
-        if (auto it = dyn_cast<IntegerType>(vt.getElementType())) {
-          if (it.isSigned())
-            isSigned = true;
-          else if (it.isUnsigned())
-            isSigned = false;
-        }
-      v = c.getInputs()[0];
-      return isSigned;
-    };
-    std::optional<bool> lhsCastSigned = castSignedness(lhs);
-    std::optional<bool> rhsCastSigned = castSignedness(rhs);
-
+    // Recover operand signedness, and narrow each operand to the value the MAC
+    // should consume. Deferred until after the bf16 case below, which has no
+    // signedness to speak of.
     auto accVecTy = cast<VectorType>(acc.getType());
     if (isa<Float32Type>(accVecTy.getElementType()))
       // <4x8xbf16> x <8x4xbf16> + <4x4xf32>
@@ -4291,63 +4336,19 @@ class MatMulOpConversion
                   /*sub_mul=*/0, /*sub_acc1=*/0, /*sub_acc2=*/0,
                   /*sub_mask=*/0)};
 
-    // Helper: look through vector.shape_cast ops to find the defining op.
-    // The VectorToAIEVec pass inserts shape_casts (via reshapeLeadingUnitDims)
-    // between the extension ops and the matmul, which hides the signedness.
-    auto lookThroughShapeCasts = [](Value v) -> Value {
-      while (auto castOp = v.getDefiningOp<vector::ShapeCastOp>())
-        v = castOp.getSource();
-      return v;
-    };
+    ResolvedMatMulOperand lhsResolved = resolveMatMulOperand(lhs);
+    ResolvedMatMulOperand rhsResolved = resolveMatMulOperand(rhs);
+    lhs = lhsResolved.narrowed;
+    rhs = rhsResolved.narrowed;
+    int signX = lhsResolved.isSigned ? 1 : 0;
+    int signY = rhsResolved.isSigned ? 1 : 0;
 
-    int signX = 0, signY = 0;
     auto lhsVecTy = cast<VectorType>(lhs.getType());
     auto lhsScaTy = cast<IntegerType>(lhsVecTy.getElementType());
-    Value lhsOrig = lookThroughShapeCasts(lhs);
-    if (auto extSIOp = lhsOrig.getDefiningOp<arith::ExtSIOp>()) {
-      lhs = lookThroughShapeCasts(extSIOp.getIn());
-      lhsVecTy = cast<VectorType>(lhs.getType());
-      lhsScaTy = cast<IntegerType>(lhsVecTy.getElementType());
-      signX = 1;
-    } else if (auto extUIOp = lhsOrig.getDefiningOp<arith::ExtUIOp>()) {
-      lhs = lookThroughShapeCasts(extUIOp.getIn());
-      lhsVecTy = cast<VectorType>(lhs.getType());
-      lhsScaTy = cast<IntegerType>(lhsVecTy.getElementType());
-    } else if (lhsCastSigned.has_value()) {
-      // Signedness carried in the operand element type (si8/ui8).
-      signX = *lhsCastSigned ? 1 : 0;
-    } else if (lhsScaTy.isSigned()) {
-      signX = 1;
-    } else if (lhsScaTy.isUnsigned()) {
-      signX = 0;
-    } else {
-      // Signless (e.g. hand-written aievec.matmul IR): default lhs to unsigned
-      // (activation input is typically uint8).
-      signX = 0;
-    }
     auto lhsShape = lhsVecTy.getShape();
 
     auto rhsVecTy = cast<VectorType>(rhs.getType());
     auto rhsScaTy = cast<IntegerType>(rhsVecTy.getElementType());
-    Value rhsOrig = lookThroughShapeCasts(rhs);
-    if (auto extSIOp = rhsOrig.getDefiningOp<arith::ExtSIOp>()) {
-      rhs = lookThroughShapeCasts(extSIOp.getIn());
-      rhsVecTy = cast<VectorType>(rhs.getType());
-      rhsScaTy = cast<IntegerType>(rhsVecTy.getElementType());
-      signY = 1;
-    } else if (auto extUIOp = rhsOrig.getDefiningOp<arith::ExtUIOp>()) {
-      rhs = lookThroughShapeCasts(extUIOp.getIn());
-      rhsVecTy = cast<VectorType>(rhs.getType());
-      rhsScaTy = cast<IntegerType>(rhsVecTy.getElementType());
-    } else if (rhsCastSigned.has_value()) {
-      // Signedness carried in the operand element type (si8/ui8).
-      signY = *rhsCastSigned ? 1 : 0;
-    } else if (rhsScaTy.isUnsigned()) {
-      signY = 0;
-    } else {
-      // Signed element type or signless: default rhs to signed.
-      signY = 1;
-    }
 
     unsigned lhsBitWidth = lhsScaTy.getWidth();
     unsigned rhsBitWidth = rhsScaTy.getWidth();
@@ -4740,11 +4741,14 @@ class MatMulOpAIE2pConversion
     Value rhs = op.getRhs();
     Value acc = op.getAcc();
 
-    // The VectorToAIEVec pass carries operand signedness in the element type
-    // (si8/ui8) via an unrealized_conversion_cast from a signless value. Read
-    // signedness from the cast result type below, but feed the intrinsic the
-    // signless input so the cast is left dead (and DCE'd) rather than leaking
-    // to LLVM translation.
+    // Signedness follows the same rule as aievec.matmul; see
+    // resolveMatMulOperand. Only the signedness is taken from it here: the
+    // shape checks below match on the original operand types, so the operand
+    // values keep their existing treatment (strip the signedness-carrying cast
+    // so it is left dead for canonicalization rather than leaking to LLVM
+    // translation).
+    bool lhsIsSigned = resolveMatMulOperand(lhs).isSigned;
+    bool rhsIsSigned = resolveMatMulOperand(rhs).isSigned;
     if (auto c = lhs.getDefiningOp<UnrealizedConversionCastOp>())
       lhs = c.getInputs()[0];
     if (auto c = rhs.getDefiningOp<UnrealizedConversionCastOp>())
@@ -4773,11 +4777,9 @@ class MatMulOpAIE2pConversion
           accLanes == 64) {
         // Uses I512.I512.ACC2048 (64 lanes of i8 -> 64 lanes of i32).
         // Base conf for amode=0/bmode=1 is bmode<<3 = 8; signedness lives in
-        // signX (bit 9) / signY (bit 8). PROTOTYPE: read signedness from the
-        // operand element TYPE (si8 -> signed, ui8 -> unsigned, signless i8 ->
-        // signed default), instead of lhsSigned/rhsSigned attributes.
-        int signX = lhsIntTy.isUnsigned() ? 0 : 1;
-        int signY = rhsIntTy.isUnsigned() ? 0 : 1;
+        // signX (bit 9) / signY (bit 8).
+        int signX = lhsIsSigned ? 1 : 0;
+        int signY = rhsIsSigned ? 1 : 0;
         int conf = 8 | (signX << 9) | (signY << 8);
         return {DecodedMatMulOp::Kind::I8_8x8x8_I512_ACC2048, lhs, rhs, acc,
                 conf};

--- a/test/Conversion/AIEVecToLLVM/matmul.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul.mlir
@@ -33,6 +33,8 @@ func.func @matmul(%A : vector<4x8xbf16>, %B : vector<8x4xbf16>,
 
 // -----
 
+// Signless element types are treated as signed, so this matches the
+// si8 x si8 case below (conf 776).
 func.func @matmul(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
                   %C : vector<4x8xi32>) -> vector<4x8xi32> {
   %0 = aievec.matmul %A, %B, %C : vector<4x8xi8>, vector<8x8xi8>
@@ -50,7 +52,7 @@ func.func @matmul(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
 // CHECK-SAME:                      vector<8x8xi8> to vector<64xi8>
 // CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
 // CHECK-SAME:                      vector<4x8xi32> to vector<32xi32>
-// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(264 : i32) : i32
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(776 : i32) : i32
 // CHECK:      %[[C0I32:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:      %[[IFA2512b:.*]] = llvm.bitcast %[[FA]] : vector<32xi8> to vector<8xi32>
 // CHECK:      %[[IFA:.*]] = "xllvm.intr.aie2.set.I512.I256"(%[[IFA2512b]],
@@ -87,7 +89,7 @@ func.func @matmul(%A : vector<4x2xi32>, %B : vector<2x4xi16>,
 // CHECK-SAME:                      vector<2x4xi16> to vector<8xi16>
 // CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
 // CHECK-SAME:                      vector<4x4xi64> to vector<16xi64>
-// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(258 : i32) : i32
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(770 : i32) : i32
 // CHECK:      %[[C0I32:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:      %[[IFA2512b:.*]] = llvm.bitcast %[[FA]] : vector<8xi32> to
 // CHECK-SAME:                      vector<8xi32>
@@ -178,3 +180,67 @@ func.func @matmul_i8i8_signed_unsigned(%A : vector<4x8xsi8>, %B : vector<8x8xui8
 // CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
 // CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
 
+
+// -----
+
+// Signedness is resolved per operand, so a signless operand does not disturb an
+// explicitly-typed partner. conf base for this shape is 0x008; signX is bit 9,
+// signY bit 8.
+
+func.func @matmul_i8i8_signless_lhs_unsigned_rhs(%A : vector<4x8xi8>, %B : vector<8x8xui8>,
+                                                 %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xi8>, vector<8x8xui8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i8i8_signless_lhs_unsigned_rhs
+// signless lhs -> signed (signX=1), ui8 rhs -> unsigned (signY=0) -> 0x208
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(520 : i32) : i32
+// CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
+// CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
+
+// -----
+
+func.func @matmul_i8i8_unsigned_lhs_signless_rhs(%A : vector<4x8xui8>, %B : vector<8x8xi8>,
+                                                 %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xui8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i8i8_unsigned_lhs_signless_rhs
+// ui8 lhs -> unsigned (signX=0), signless rhs -> signed (signY=1) -> 0x108
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(264 : i32) : i32
+// CHECK:      "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(
+// CHECK-SAME:   %{{.*}}, %{{.*}}, %{{.*}}, %[[CONF]])
+
+// -----
+
+// The two mixed-precision shapes the VectorToAIEVec contraction pattern
+// actually emits: the lhs is already a legal AIE2 narrow type so nothing is
+// extended and it stays signless, while the rhs picks up si8/si16 from the
+// arith.extsi that was peeled. See @contracti16i8i32 and @contracti32i16i64 in
+// test/Conversion/VectorToAIEVec/test-contract.mlir.
+
+func.func @matmul_i16si8_signless_lhs(%A : vector<4x4xi16>, %B : vector<4x8xsi8>,
+                                      %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x4xi16>, vector<4x8xsi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: @matmul_i16si8_signless_lhs
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(784 : i32) : i32
+
+// -----
+
+func.func @matmul_i32si16_signless_lhs(%A : vector<4x2xi32>, %B : vector<2x4xsi16>,
+                                       %C : vector<4x4xi64>) -> vector<4x4xi64> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x2xi32>, vector<2x4xsi16>
+                                  into vector<4x4xi64>
+  return %0 : vector<4x4xi64>
+}
+
+// CHECK-LABEL: @matmul_i32si16_signless_lhs
+// CHECK:      %[[CONF:.*]] = llvm.mlir.constant(770 : i32) : i32


### PR DESCRIPTION
Follow-up to #3489, addressing @andrej's [review question](https://github.com/Xilinx/mlir-aie/pull/3489#discussion_r3722874854): *"Is there really a reason to keep this historically weird implementation? Why not just make both unsigned for signless types for consistency?"*

No good reason — it was preserved for backward compatibility, not by design. Agreed the asymmetry should go. This makes signless **signed** rather than unsigned, for the reasons below.

## Why signed rather than unsigned

The signless fallback is not only a hand-written-IR concern. When an operand's type is already a legal AIE2 narrow type, the `VectorToAIEVec` contraction pattern's first `create` succeeds, nothing is peeled, and no signedness is attached — so **generated code** lands on it:

| `vector.contract` shape | matmul operands | conf | signX | signY |
|---|---|---|---|---|
| `4x2 i16 × 2x8 i16 → 4x8 i32` | both signless | 280 | 0 | 1 |
| `4x4 i16 × 4x4 i16 → 4x4 i64` | both signless | 314 | 0 | 1 |
| `2x4 i16 × 4x8 i16 → 2x8 i64` | both signless | 282 | 0 | 1 |

Mixed shapes hit it too, with a natively-wide signless lhs beside a correctly typed rhs — `@contracti16i8i32` emits `vector<4x4xi16>, vector<4x8xsi8>` and `@contracti32i16i64` emits `vector<4x2xi32>, vector<2x4xsi16>` (both in `test-contract.mlir` today).

Those operands carry signed data in practice, so treating the lhs as unsigned is wrong. Making **both** unsigned would additionally clear `signY`, turning `zext(A) × sext(B)` into `zext(A) × zext(B)` — worse than the status quo for exactly these shapes. Signed is also the conventional reading of a signless integer, and it is what `aievec.matmul_aie2p` already does.

## Change

Resolve signless as signed, and route both lowerings through one `resolveMatMulOperand()` so they cannot diverge again — each having its own copy is how they drifted apart in the first place. Per-operand resolution is otherwise unchanged: `extsi`/`extui` still win, then the `si8`/`ui8` cast `VectorToAIEVec` materializes, then an explicit element type. `aievec.matmul_aie2p` keeps its behavior by construction, and now also honors `extsi`/`extui`. Drops the stale `PROTOTYPE:` comment left over from #3489.

## Changed expectations

Both AIE2, both signless-lhs:

| case | before | after |
|---|---|---|
| `4x8 i8 × 8x8 i8` | 264 | **776** (now agrees with `matmul_aie2p`'s signless default) |
| `4x2 i32 × 2x4 i16` | 258 | **770** |

## Tests

The two mixed generated shapes are pinned at the conf level for the first time (**784** and **770**) — `test-contract.mlir` only checked the matmul operand types, which is exactly why nothing caught this. Also added signless-lhs/`ui8`-rhs (**520**) and `ui8`-lhs/signless-rhs (**264**) to show each operand resolves independently and a signless operand does not disturb an explicitly-typed partner.

`check-aie` on current `main` with the pinned LLVM 24 wheel: 891 passed, 0 non-`python/` failures (the 20 `python/` failures are pre-existing in my environment and reproduce on a clean `main` build).

## No hardware run

The signless path is unreachable from the Triton i8 flow — that goes through `extsi` and gets an explicit `si8`, which #3489 validated on NPU1 and NPU2. Exercising it needs a native i16/i32 matmul kernel and there is none in tree. Worth adding one so this class of bug has ongoing coverage; happy to file that separately.