### PR TITLE
trace: add core EVENT_PC mode support

### DIFF
--- a/programming_guide/section-4/section-4b/README.md
+++ b/programming_guide/section-4/section-4b/README.md
@@ -63,6 +63,7 @@ The trace configuration chooses helpful default settings so you can trace your d
 * `coremem_events` - which 8 events do we use for all core mem in array. Search under [AIEXDialect](https://xilinx.github.io/mlir-aie/AIEXDialect.html) for MemEvent for the target device: [aie1](https://xilinx.github.io/mlir-aie/AIEXDialect.html#memeventaie) &middot; [aie2](https://xilinx.github.io/mlir-aie/AIEXDialect.html#memeventaie2) &middot; [aie2p](https://xilinx.github.io/mlir-aie/AIEXDialect.html#memeventaie2p).
 * `memtile_events` - which 8 events do we use for all memtiles in array. Search under [AIEXDialect](https://xilinx.github.io/mlir-aie/AIEXDialect.html) for MemTileEvent for the target device: [aie1](https://xilinx.github.io/mlir-aie/AIEXDialect.html#memtileeventaie) &middot; [aie2](https://xilinx.github.io/mlir-aie/AIEXDialect.html#memtileeventaie2) &middot; [aie2p](https://xilinx.github.io/mlir-aie/AIEXDialect.html#memtileeventaie2p).
 * `shimtile_events` - which 8 events do we use for all shimtiles in array. Search under [AIEXDialect](https://xilinx.github.io/mlir-aie/AIEXDialect.html) for ShimTileEvent for the target device: [aie1](https://xilinx.github.io/mlir-aie/AIEXDialect.html#shimtileeventaie) &middot; [aie2](https://xilinx.github.io/mlir-aie/AIEXDialect.html#shimtileeventaie2) &middot; [aie2p](https://xilinx.github.io/mlir-aie/AIEXDialect.html#shimtileeventaie2p).
+* `core_trace_mode` - core-tile trace encoding. The default is `TraceMode.EventTime`; use `TraceMode.EventPC` from `aie.dialects.aie` to capture the program counter when a selected core event occurs.
 
     ```python
     ...
@@ -386,6 +387,8 @@ Two side effects of the call worth knowing about:
 Once the packet trace text file is generated (`trace.txt`), we use a python-based trace parser ([parse.py](../../../python/utils/trace/parse.py)) to interpret the trace values and generate a waveform json file for visualization (with Perfetto). This is a step in the [Makefile](./Makefile) but can be executed from the command line as well.
 
 The `--mlir` argument should point to `input_with_addresses.mlir` from the `build` work directory, not the original source MLIR. This file contains the lowered register writes produced by the trace passes, which the parser uses to map raw trace packets back to named events.
+
+EVENT_PC traces produce thread-scoped instant events rather than cycle-based waveform intervals. Their `ts` values preserve capture order per tile, and `args.pc` contains the captured program counter; cycle summaries therefore apply only to the default EVENT_TIME mode.
 
 ```bash
 python ../../../python/utils/trace/parse.py \

--- a/python/iron/program.py
+++ b/python/iron/program.py
@@ -6,7 +6,10 @@
 
 import logging
 
-from ..dialects.aie import device
+from ..dialects.aie import (
+    TraceMode,  # pyright: ignore[reportAttributeAccessIssue]
+    device,
+)
 from ..extras.context import mlir_mod_ctx  # pyright: ignore[reportMissingImports]
 from ..helpers.dialects.func import FuncBase
 from ..utils import trace as trace_utils
@@ -50,6 +53,7 @@ class Program:
         self._coremem_events = None
         self._memtile_events = None
         self._shimtile_events = None
+        self._core_trace_mode = TraceMode.EventTime
 
     def enable_trace(
         self,
@@ -61,6 +65,7 @@ class Program:
         memtile_events: list | None = None,
         shimtile_events: list | None = None,
         egress_shim_col: int = 0,
+        core_trace_mode=TraceMode.EventTime,
     ):
         """Enable hardware tracing for this program.
 
@@ -90,6 +95,8 @@ class Program:
                 Defaults to None (uses hardware defaults).
             egress_shim_col (int, optional): Column of the shim tile used to
                 egress trace packets to DDR. Defaults to 0.
+            core_trace_mode (TraceMode, optional): Trace mode for core tiles.
+                Defaults to Event-Time.
         """
         self._trace_size = trace_size
         self._trace_workers = workers
@@ -98,6 +105,7 @@ class Program:
         self._coremem_events = coremem_events
         self._memtile_events = memtile_events
         self._shimtile_events = shimtile_events
+        self._core_trace_mode = core_trace_mode
         self._egress_shim_col = egress_shim_col
 
     def resolve_program(self, device_name="main"):
@@ -239,6 +247,7 @@ class Program:
                         coremem_events=self._coremem_events,
                         memtile_events=self._memtile_events,
                         shimtile_events=self._shimtile_events,
+                        core_trace_mode=self._core_trace_mode,
                     )
 
                 # Emit the runtime sequence body LAST: workers, their locks, and

--- a/python/utils/trace/__init__.py
+++ b/python/utils/trace/__init__.py
@@ -17,6 +17,8 @@ the register writes, packet flows, and shim DMA configuration that implement it.
       type. Call this once with all the tiles you want to trace. Per-tile-type
       event lists can be overridden with `coretile_events`, `coremem_events`,
       `memtile_events`, `shimtile_events`; otherwise sensible defaults are used.
+      Core traces default to `TraceMode.EventTime`; pass
+      `core_trace_mode=TraceMode.EventPC` to capture event program counters.
       Port activity is specified with `PortEvent` (see Port Events below).
 
 * `start_trace(trace_size, reuse_output_buffer=False, ...)`
@@ -45,8 +47,8 @@ the register writes, packet flows, and shim DMA configuration that implement it.
   `get_cycles_summary`, `print_cycles_summary`, `get_vector_time`,
   `split_trace_segments`, ...) are re-exported and documented in source.
 
-The high-level IRON entry point is `Runtime.enable_trace(...)`, which builds a
-`TraceConfig` and calls `configure_trace` / `start_trace` for you.
+The high-level IRON entry point is `Program.enable_trace(...)`, which forwards
+trace-unit options to `configure_trace` and coordinates runtime trace-buffer setup.
 
 ## The host trace buffer is a runtime_sequence operand
 

--- a/python/utils/trace/parse.py
+++ b/python/utils/trace/parse.py
@@ -90,12 +90,12 @@ def make_event_lists(commands):
 
 # testing a flattening of repeat commands
 def flatten_repeat_command(commands):
-    prev = 0
+    prev = None
     flat_commands = list()
     for c in commands:
         if c["type"] == "Repeat0" or c["type"] == "Repeat1":
-            for i in range(int(c["repeats"])):
-                flat_commands.append(prev)
+            if prev is not None:
+                flat_commands.extend([prev] * int(c["repeats"]))
         else:
             flat_commands.append(c)
             prev = c

--- a/python/utils/trace/parse.py
+++ b/python/utils/trace/parse.py
@@ -25,6 +25,7 @@ from aie.utils.trace.events import (
 from aie.utils.trace.utils import (
     convert_to_byte_stream,
     convert_to_commands,
+    decode_event_pc_stream,
     split_trace_segments,
     trace_pkts_de_interleave,
     trim_trace_pkts,
@@ -99,6 +100,27 @@ def flatten_repeat_command(commands):
             flat_commands.append(c)
             prev = c
     return flat_commands
+
+
+def _convert_to_commands_by_mode(byte_streams, trace_modes, zero=True):
+    event_pc_streams = []
+    event_time_streams = [dict() for _ in range(NUM_TRACE_TYPES)]
+    for trace_type, streams in enumerate(byte_streams):
+        for loc, stream in streams.items():
+            mode = trace_modes[trace_type].get(loc, 0)
+            if mode == 0:
+                event_time_streams[trace_type][loc] = stream
+            elif mode == 1:
+                event_pc_streams.append((trace_type, loc, stream))
+            else:
+                raise NotImplementedError(
+                    f"trace mode {mode} is not supported for type {trace_type} tile {loc}"
+                )
+
+    commands = convert_to_commands(event_time_streams, zero)
+    for trace_type, loc, stream in event_pc_streams:
+        commands[trace_type][loc] = decode_event_pc_stream(stream, zero)
+    return commands
 
 
 # This function assert an end event for all active events if:
@@ -178,6 +200,8 @@ def convert_commands_to_json(trace_events, commands, pid_events, events_module):
     for [tt, byte_stream_dict] in enumerate(commands):  # tt = trace type
 
         for loc, command in byte_stream_dict.items():  # row,col with list of commands
+            if any(c["type"] == "EventPC" for c in command):
+                command = flatten_repeat_command(command)
             timer = 0  # TODO Some way to set this or sync this between trace types and row,col
             # timer on each execution is the time for the last execution
             # so we by default will increment it by 1 for each event
@@ -208,8 +232,29 @@ def convert_commands_to_json(trace_events, commands, pid_events, events_module):
             cycles = 0
             multiple_list = list()
             event = None
+            capture_index = 0
             for c in command:
                 t = c["type"]
+                if t == "EventPC":
+                    for event_slot in range(NUM_EVENTS):
+                        if f"event{event_slot}" in c:
+                            trace_events.append(
+                                {
+                                    "name": lookup_event_name_by_type(
+                                        tt,
+                                        pid_events[tt][loc][event_slot],
+                                        events_module,
+                                    ),
+                                    "ts": capture_index,
+                                    "ph": "i",
+                                    "s": "t",
+                                    "pid": pid,
+                                    "tid": event_slot,
+                                    "args": {"pc": c["pc"]},
+                                }
+                            )
+                    capture_index += 1
+                    continue
                 if "Single" in t:
                     event = c["event"]
                     cycles = int(c["cycles"])
@@ -367,8 +412,10 @@ def thread_name_metadata(
 def parse_mlir_trace_events(mlir_module_str, colshift=None):
 
     pid_events = list()
+    trace_modes = list()
     for t in range(NUM_TRACE_TYPES):
         pid_events.append(dict())
+        trace_modes.append(dict())
 
     # These op classes / enums come through compiled dialect bindings that
     # pyright can't see; fetch them dynamically so the static checker is happy.
@@ -445,6 +492,9 @@ def parse_mlir_trace_events(mlir_module_str, colshift=None):
             col = col + colshift
         key = str(row) + "," + str(col)
 
+        if address == 0x340D0 and row != 0:
+            trace_modes[PacketType.CORE][key] = value & 0b11
+
         # core event 0
         if address == 0x340E0:  # 213216, match ignoring case
             if row == 0:  # shim
@@ -516,7 +566,7 @@ def parse_mlir_trace_events(mlir_module_str, colshift=None):
         # TODO shim event 0, 1 needs to also be defined
 
     logger.debug("Found labels: %s", pid_events)
-    return pid_events, events_module
+    return pid_events, trace_modes, events_module
 
 
 def lookup_event_name_by_type(trace_type, code, events_module):
@@ -647,7 +697,7 @@ def setup_trace_metadata(trace_events, pid_events, events_module):
 # Attempt to align the starting column of trace in the design (from 'events')
 # with the start first column observed in the trace ('commands'). This is needed
 # because the runtime/firmware can start the design on any valid column
-def align_column_start_index(events, commands):
+def _get_column_start_shift(events, commands):
     # find min column of commands
     min_commands_col = float("inf")
     for t in range(NUM_TRACE_TYPES):
@@ -664,9 +714,12 @@ def align_column_start_index(events, commands):
             if col < min_events_col:
                 min_events_col = col
 
-    # The shift is the difference between the expected and observed leftmost
-    # column for which trace was enabled (in 'events')
-    colshift = min_events_col - min_commands_col
+    return min_events_col - min_commands_col
+
+
+def align_column_start_index(events, commands, colshift=None):
+    if colshift is None:
+        colshift = _get_column_start_shift(events, commands)
 
     # Shift all event keys by colshift
     new_events = []
@@ -703,7 +756,9 @@ def parse_trace(trace_buffer, mlir_module_str, colshift=None):
     trace_pkts = [f"{int(word):08x}" for word in trace_buffer]
 
     # Parse MLIR to extract event configuration
-    pid_events, events_module = parse_mlir_trace_events(mlir_module_str, colshift)
+    pid_events, trace_modes, events_module = parse_mlir_trace_events(
+        mlir_module_str, colshift
+    )
 
     # Split buffer into segments to handle multi-channel trace buffers
     # (e.g. when distribute-channels splits data across two S2MM channels
@@ -732,12 +787,14 @@ def parse_trace(trace_buffer, mlir_module_str, colshift=None):
     # Convert to byte streams
     byte_streams = convert_to_byte_stream(trace_pkts_sorted)
 
-    # Convert byte streams to command dictionaries
-    commands = convert_to_commands(byte_streams, False)
-
     # Auto-align column indices if colshift not provided
     if colshift is None:
-        pid_events = align_column_start_index(pid_events, commands)
+        column_shift = _get_column_start_shift(pid_events, byte_streams)
+        pid_events = align_column_start_index(pid_events, byte_streams, column_shift)
+        trace_modes = align_column_start_index(trace_modes, byte_streams, column_shift)
+
+    # Convert byte streams to command dictionaries
+    commands = _convert_to_commands_by_mode(byte_streams, trace_modes, False)
 
     # Initialize trace events list
     trace_events = []
@@ -782,7 +839,9 @@ def main():
     try:
         with open(opts.mlir, "r") as mf:
             mlir_module_str = mf.read()
-        pid_events, events_module = parse_mlir_trace_events(mlir_module_str, colshift)
+        pid_events, trace_modes, events_module = parse_mlir_trace_events(
+            mlir_module_str, colshift
+        )
     except Exception as e:
         logger.error(
             "%s could not be opened. Check for valid MLIR file. %s", opts.mlir, e
@@ -836,11 +895,13 @@ def main():
     byte_streams = convert_to_byte_stream(trace_pkts_sorted)
     logger.debug("byte streams: %s", byte_streams)
 
-    commands_0 = convert_to_commands(byte_streams, False)
-    logger.debug("commands_0: %s", commands_0)
-
     if colshift is None:
-        pid_events = align_column_start_index(pid_events, commands_0)
+        column_shift = _get_column_start_shift(pid_events, byte_streams)
+        pid_events = align_column_start_index(pid_events, byte_streams, column_shift)
+        trace_modes = align_column_start_index(trace_modes, byte_streams, column_shift)
+
+    commands_0 = _convert_to_commands_by_mode(byte_streams, trace_modes, False)
+    logger.debug("commands_0: %s", commands_0)
 
     trace_events = list()
 

--- a/python/utils/trace/setup.py
+++ b/python/utils/trace/setup.py
@@ -384,6 +384,7 @@ def configure_trace(
     coremem_events=None,
     memtile_events=None,
     shimtile_events=None,
+    core_trace_mode=TraceMode.EventTime,
 ):
     """Generate aie.trace ops for a list of tiles.
 
@@ -401,6 +402,7 @@ def configure_trace(
             entry in the list.
         memtile_events: List of events for mem tile tracing (max 8).
         shimtile_events: List of events for shim tile tracing (max 8).
+        core_trace_mode: Trace mode for core tiles (default: Event-Time).
     """
     _configured_trace_names.clear()
 
@@ -518,7 +520,7 @@ def configure_trace(
         @trace(tile_op, trace_name)
         def trace_body():
             if is_core_trace:
-                trace_mode(TraceMode.EventTime)
+                trace_mode(core_trace_mode)
             # id auto-assigned in (col, row) order by
             # -aie-insert-trace-flows after placement.
             trace_packet(type=packet_type)

--- a/python/utils/trace/utils.py
+++ b/python/utils/trace/utils.py
@@ -400,6 +400,89 @@ def convert_to_commands(byte_stream_list, zero=True):
     return commands
 
 
+def decode_event_pc_stream(byte_stream, zero=True):
+    """Decode a mode-1 (EVENT_PC) trace byte stream into commands.
+
+    Mode 1 records the program counter of each traced event instead of a
+    cycle delta.  The opcode skeleton is shared with mode 0 (Start, DC,
+    Repeat0/1, Sync, Skip); only the per-event encoding differs -- the
+    mode-0 Single*/Multiple* opcodes are replaced by a single 4-byte
+    ``EventPC`` opcode carrying an 8-bit event mask and a 14-bit PC.
+
+    EventPC layout (32-bit word, MSB-first):
+        bits 31..26  opcode discriminator (0b110001)
+        bits 25..18  8-bit event mask (which of the 8 trace slots fired)
+        bits 17..14  reserved (zero in every observed capture)
+        bits 13..0   14-bit PC value
+
+    The mask is expanded into ``eventN`` keys, matching the mode-0
+    Multiple* convention; the PC is carried in a ``pc`` field.
+
+    Provenance: the byte-level skeleton is the mode-0 opcode table
+    documented openly in ``convert_to_commands`` above.  The EVENT_PC
+    extension was derived black-box, by diffing mode-0 and mode-1
+    captures of an identical kernel; every field follows from the
+    observed bytes.
+    """
+    commands = []
+    cursor = 0
+    n = len(byte_stream)
+    try:
+        while cursor < n:
+            b = byte_stream[cursor]
+            # Start: 1111 0X01 (0xF1/0xF5) + 7 timer bytes.  Same family as
+            # mode-0's 1111 0X00 Start, but bit 0 is the trace-mode
+            # discriminator (set for mode 1).  Big-endian 7-byte timer.
+            if (b & 0b11111011) == 0b11110001:
+                com = {"type": "Start", "timer_value": 0}
+                if not zero:
+                    for i in range(7):
+                        com["timer_value"] += (byte_stream[cursor + i + 1]) * (
+                            256 ** (6 - i)
+                        )
+                commands.append(com)
+                cursor = cursor + 8
+                continue
+            # Sync (decoder resync): 1111 1111 (0xFF), one byte.
+            if b == 0xFF:
+                commands.append({"type": "Event_Sync"})
+                cursor = cursor + 1
+                continue
+            # DC (don't-care padding): 1101 11xx + 3 bytes, no command.
+            if (b & 0b11111100) == 0b11011100:
+                cursor = cursor + 4
+                continue
+            # Repeat0: 1110 xxxx, 4-bit repeat count, one byte.
+            if (b & 0b11110000) == 0b11100000:
+                commands.append({"type": "Repeat0", "repeats": b & 0b1111})
+                cursor = cursor + 1
+                continue
+            # Repeat1: 1101 10xx + 1 byte, 10-bit repeat count.
+            if (b & 0b11111100) == 0b11011000:
+                repeats = (b & 0b11) * 256 + byte_stream[cursor + 1]
+                commands.append({"type": "Repeat1", "repeats": repeats})
+                cursor = cursor + 2
+                continue
+            # EventPC: 1100 01xx + 3 bytes (8b event mask + 14b PC)
+            if (b & 0b11111100) == 0b11000100:
+                b1 = byte_stream[cursor + 1]
+                b2 = byte_stream[cursor + 2]
+                b3 = byte_stream[cursor + 3]
+                mask = ((b & 0b11) << 6) | (b1 >> 2)
+                pc = ((b2 & 0b00111111) << 8) | b3
+                com = {"type": "EventPC", "pc": pc}
+                for i in range(8):
+                    if (mask >> i) & 0b1:
+                        com["event" + str(i)] = i
+                commands.append(com)
+                cursor = cursor + 4
+                continue
+            cursor = cursor + 1
+    except IndexError:
+        pass
+    return commands
+
+
 def trim_trace_pkts(trace_pkts):
     for i in range(len(trace_pkts)):
         if trace_pkts[i] == "fefefefe" or trace_pkts[i] == "FEFEFEFE":

--- a/test/python/test_trace_mode1_decode.py
+++ b/test/python/test_trace_mode1_decode.py
@@ -5,14 +5,39 @@
 
 # RUN: %python -m pytest %s -v
 
-"""Tests for mode-1 (EVENT_PC) trace byte-stream decoding.
+"""Tests for mode-1 (EVENT_PC) trace decoding and parsing.
 
 Field expectations are computed directly from the EventPC bit layout. The
 distilled sequence is capture-derived, but is not an independent decoder oracle.
 """
 
 import pytest
+from aie.dialects.aie import AIEDevice, TraceMode, device, tile
+from aie.extras.context import mlir_mod_ctx
+from aie.iron import Program, Runtime, Worker
+from aie.iron.device import NPU1
+from aie.utils.trace import configure_trace
+from aie.utils.trace.events import get_events_for_device
+from aie.utils.trace.parse import (
+    _convert_to_commands_by_mode,
+    convert_commands_to_json,
+    parse_mlir_trace_events,
+    parse_trace,
+)
 from aie.utils.trace.utils import decode_event_pc_stream
+
+MODE1_CONFIG_MLIR = """module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence @sequence() {
+      %address = arith.constant 213200 : i32
+      %value = arith.constant 5 : i32
+      aiex.npu.write32(%address, %value) {column = 2 : i32, row = 2 : i32} : i32, i32
+      %events_address = arith.constant 213216 : i32
+      %events_value = arith.constant 553648128 : i32
+      aiex.npu.write32(%events_address, %events_value) {column = 2 : i32, row = 2 : i32} : i32, i32
+    }
+  }
+}"""
 
 
 @pytest.mark.parametrize(
@@ -84,3 +109,117 @@ def test_distilled_hardware_capture():
         {"type": "Repeat0", "repeats": 7},
         {"type": "EventPC", "pc": 336, "event3": 3},
     ]
+
+
+def test_configure_trace_accepts_event_pc_mode():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def device_body():
+            configure_trace([tile(0, 2)], core_trace_mode=TraceMode.EventPC)
+
+    assert 'aie.trace.mode "Event-PC"' in str(ctx.module)
+
+
+def test_program_enable_trace_forwards_event_pc_mode():
+    worker = Worker(None)
+    program = Program(NPU1(), Runtime(lambda: None, []), workers=[worker])
+    program.enable_trace(
+        trace_size=8192,
+        workers=[worker],
+        core_trace_mode=TraceMode.EventPC,
+    )
+
+    assert 'aie.trace.mode "Event-PC"' in str(program.resolve_program())
+
+
+def test_parse_mlir_trace_events_returns_core_mode():
+    _, trace_modes, _ = parse_mlir_trace_events(MODE1_CONFIG_MLIR)
+
+    assert trace_modes == [{"2,2": 1}, {}, {}, {}]
+
+
+def test_command_dispatch_preserves_mode0_and_replaces_mode1():
+    byte_streams = [
+        {"2,0": [0x03], "2,1": [0xC4, 0x20, 0x01, 0x50]},
+        {},
+        {},
+        {},
+    ]
+    trace_modes = [{"2,1": 1}, {}, {}, {}]
+
+    assert _convert_to_commands_by_mode(byte_streams, trace_modes) == [
+        {
+            "2,0": [{"type": "Single0", "event": 0, "cycles": 3}],
+            "2,1": [{"type": "EventPC", "pc": 336, "event3": 3}],
+        },
+        {},
+        {},
+        {},
+    ]
+
+
+def test_command_dispatch_rejects_unsupported_mode():
+    with pytest.raises(NotImplementedError, match="mode 2.*2,1"):
+        _convert_to_commands_by_mode(
+            [{"2,1": [0x03]}, {}, {}, {}],
+            [{"2,1": 2}, {}, {}, {}],
+        )
+
+
+def test_event_pc_json_uses_capture_order_and_expands_repeats():
+    commands = [
+        {
+            "2,1": [
+                {"type": "EventPC", "pc": 336, "event3": 3, "event7": 7},
+                {"type": "Repeat0", "repeats": 2},
+                {"type": "EventPC", "pc": 528, "event3": 3},
+            ]
+        },
+        {},
+        {},
+        {},
+    ]
+    pid_events = [{"2,1": [0, 0, 0, 33, 0, 0, 0, 34, 42]}, {}, {}, {}]
+    trace_events = []
+
+    convert_commands_to_json(
+        trace_events, commands, pid_events, get_events_for_device("npu1_1col")
+    )
+
+    assert [
+        (event["ts"], event["tid"], event["name"], event["args"]["pc"])
+        for event in trace_events
+    ] == [
+        (0, 3, "INSTR_EVENT_0", 336),
+        (0, 7, "INSTR_EVENT_1", 336),
+        (1, 3, "INSTR_EVENT_0", 336),
+        (1, 7, "INSTR_EVENT_1", 336),
+        (2, 3, "INSTR_EVENT_0", 336),
+        (2, 7, "INSTR_EVENT_1", 336),
+        (3, 3, "INSTR_EVENT_0", 528),
+    ]
+    assert {(event["pid"], event["ph"], event["s"]) for event in trace_events} == {
+        (42, "i", "t")
+    }
+
+
+def test_parse_trace_aligns_mode_before_dispatch():
+    trace_buffer = [
+        0x00220002,
+        0xF1000000,
+        0,
+        0xC4200150,
+        0xE2FEFEFE,
+        0xC4200210,
+        0xFEFEFEFE,
+        0xFEFEFEFE,
+    ]
+
+    trace_events = parse_trace(trace_buffer, MODE1_CONFIG_MLIR)
+
+    assert [
+        (event["ts"], event["tid"], event["args"]["pc"])
+        for event in trace_events
+        if event["ph"] == "i"
+    ] == [(0, 3, 336), (1, 3, 336), (2, 3, 336), (3, 3, 528)]

--- a/test/python/test_trace_mode1_decode.py
+++ b/test/python/test_trace_mode1_decode.py
@@ -1,0 +1,86 @@
+# test_trace_mode1_decode.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python -m pytest %s -v
+
+"""Tests for mode-1 (EVENT_PC) trace byte-stream decoding.
+
+Field expectations are computed directly from the EventPC bit layout. The
+distilled sequence is capture-derived, but is not an independent decoder oracle.
+"""
+
+import pytest
+from aie.utils.trace.utils import decode_event_pc_stream
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        (
+            [0xC4, 0x20, 0x01, 0x50],
+            {"type": "EventPC", "pc": 336, "event3": 3},
+        ),
+        (
+            [0xC6, 0x24, 0x01, 0x50],
+            {
+                "type": "EventPC",
+                "pc": 336,
+                "event0": 0,
+                "event3": 3,
+                "event7": 7,
+            },
+        ),
+        (
+            [0xC4, 0x23, 0xC1, 0x50],
+            {"type": "EventPC", "pc": 336, "event3": 3},
+        ),
+    ],
+)
+def test_event_pc_fields(stream, expected):
+    assert decode_event_pc_stream(stream) == [expected]
+
+
+def test_shared_opcode_framing():
+    stream = (
+        [0xF1, 0, 0, 0, 0, 0x04, 0xE5, 0xF7]
+        + [0xDC, 0, 0, 0]
+        + [0xC4, 0x20, 0x01, 0x50]
+        + [0xE5, 0xD9, 0x34, 0xFF]
+    )
+
+    assert decode_event_pc_stream(stream, zero=False) == [
+        {"type": "Start", "timer_value": 321015},
+        {"type": "EventPC", "pc": 336, "event3": 3},
+        {"type": "Repeat0", "repeats": 5},
+        {"type": "Repeat1", "repeats": 308},
+        {"type": "Event_Sync"},
+    ]
+
+
+def test_start_rejects_other_opcode_families():
+    assert decode_event_pc_stream([0xF9] + [0] * 7) == []
+    assert decode_event_pc_stream([0xFD] + [0] * 7) == []
+
+
+def test_distilled_hardware_capture():
+    stream = (
+        [0xF1, 0, 0, 0, 0, 0x04, 0xE5, 0xF7]
+        + [0xC6, 0x00, 0x03, 0x30]
+        + [0xDB, 0xFF]
+        + [0xDA, 0xD0]
+        + [0xC6, 0x20, 0x03, 0x30]
+        + [0xE7]
+        + [0xC4, 0x20, 0x01, 0x50]
+    )
+
+    assert decode_event_pc_stream(stream, zero=False) == [
+        {"type": "Start", "timer_value": 321015},
+        {"type": "EventPC", "pc": 816, "event7": 7},
+        {"type": "Repeat1", "repeats": 1023},
+        {"type": "Repeat1", "repeats": 720},
+        {"type": "EventPC", "pc": 816, "event3": 3, "event7": 7},
+        {"type": "Repeat0", "repeats": 7},
+        {"type": "EventPC", "pc": 336, "event3": 3},
+    ]

--- a/test/python/test_trace_mode1_decode.py
+++ b/test/python/test_trace_mode1_decode.py
@@ -21,6 +21,7 @@ from aie.utils.trace.events import get_events_for_device
 from aie.utils.trace.parse import (
     _convert_to_commands_by_mode,
     convert_commands_to_json,
+    flatten_repeat_command,
     parse_mlir_trace_events,
     parse_trace,
 )
@@ -165,6 +166,12 @@ def test_command_dispatch_rejects_unsupported_mode():
             [{"2,1": [0x03]}, {}, {}, {}],
             [{"2,1": 2}, {}, {}, {}],
         )
+
+
+def test_orphan_repeat_is_ignored():
+    event = {"type": "EventPC", "pc": 336, "event3": 3}
+
+    assert flatten_repeat_command([{"type": "Repeat0", "repeats": 2}, event]) == [event]
 
 
 def test_event_pc_json_uses_capture_order_and_expands_repeats():


### PR DESCRIPTION
## Description

The trace dialect already represents `TraceMode.EventPC`, but high-level trace configuration always selected Event-Time and the parser decoded every stream as Event-Time. This PR adds the missing core-tile EVENT_PC (mode-1) path, following the direction in [discussion #3365](https://github.com/Xilinx/mlir-aie/discussions/3365).

This change:

- exposes `core_trace_mode=TraceMode.EventPC` through `configure_trace` and `Program.enable_trace`, while preserving `TraceMode.EventTime` as the default;
- reads each core tile's mode from the lowered `Trace_Control0` register write;
- dispatches EVENT_TIME streams through the existing decoder and EVENT_PC streams through a separate decoder;
- decodes the shared Start, DC, Repeat, and Sync framing plus the EVENT_PC event mask and 14-bit program counter;
- emits EVENT_PC records as thread-scoped instant events, using `ts` for per-tile capture order and `args.pc` for the captured program counter; and
- documents mode selection and the resulting trace-event semantics.

The EVENT_PC byte layout is capture-derived from black-box comparisons of EVENT_TIME and EVENT_PC traces from the same kernel. A manual NPU smoke test confirmed that the decoded program counters match instruction and return addresses in the compiled core ELF.

The existing EVENT_TIME decoder is left intact. Execution trace mode (mode 2) is intentionally outside this PR and produces an explicit unsupported-mode error rather than being misdecoded.

### Validation

- New EVENT_PC decoder and parser tests: 13 passed.
- Existing trace-focused lit tests: 5 passed.
- Existing mode-0 parser goldens: both exact matches.
- Ruff, Black, Pyright, REUSE, and copyright-format checks passed.
- Manual NPU smoke test completed successfully and produced eight decoded EVENT_PC instant events.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
