### PR TITLE
[AIE][AIEX] Do not abort on an unplaced tile in the DMA passes

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -134,7 +134,11 @@ def TileElement : OpInterface<"TileElement", [
   ];
 
   let extraClassDeclaration = [{
+    // Requires a placed tile: fatally errors if the tile is still logical.
     TileOp getTileOp();
+    // Null when the tile is still logical, so callers that run before
+    // placement can defer instead of aborting.
+    TileOp tryGetTileOp();
   }];
 
   let extraTraitClassDeclaration = [{

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1297,6 +1297,9 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
 
   let extraClassDeclaration = [{
     AIE::TileOp getTileOp();
+    // Null when the tile is still an aie.logical_tile, so passes that can run
+    // before placement defer instead of aborting inside getTileOp().
+    AIE::TileOp tryGetTileOp();
     std::optional<uint32_t> getFirstBdId();
     // The repeat count as an OpFoldResult: the runtime operand if present, else
     // the compile-time attribute. Mirrors dma_bd's offset/len duality.
@@ -1310,6 +1313,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
 
   let extraClassDefinition = [{
     AIE::TileOp DMAConfigureTaskOp::getTileOp() { return cast<AIE::TileElement>(this->getOperation()).getTileOp(); }
+    AIE::TileOp DMAConfigureTaskOp::tryGetTileOp() { return cast<AIE::TileElement>(this->getOperation()).tryGetTileOp(); }
   }];
 
   let hasVerifier = 1;

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1370,10 +1370,13 @@ DeviceOp::getForSymbolInModuleOrError(mlir::ModuleOp module,
 // TileElement
 //===----------------------------------------------------------------------===//
 
-TileOp TileElement::getTileOp() {
+TileOp TileElement::tryGetTileOp() {
   auto element = cast<TileElement>(this->getOperation());
-  Operation *definingOp = element.getTile().getDefiningOp();
-  if (auto tileOp = dyn_cast_or_null<TileOp>(definingOp))
+  return dyn_cast_or_null<TileOp>(element.getTile().getDefiningOp());
+}
+
+TileOp TileElement::getTileOp() {
+  if (auto tileOp = tryGetTileOp())
     return tileOp;
   llvm::report_fatal_error("Calling getTileOp requires TileOp.");
 }

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -32,6 +32,18 @@ using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::AIEX;
 
+// This pass emits absolute tile coordinates, so it cannot run before placement
+// has substituted a concrete `aie.tile` for an `aie.logical_tile`.  Report that
+// instead of calling getTileOp(), which fatally errors on an unplaced tile.
+static LogicalResult emitUnplacedTileError(Operation *op,
+                                           DMAConfigureTaskOp task_op) {
+  auto err = op->emitOpError(
+      "Cannot lower a DMA task whose tile is not placed; run placement first.");
+  if (task_op.getOperation() != op)
+    err.attachNote(task_op.getLoc()) << "Task configured here.";
+  return err;
+}
+
 struct DMAStartTaskOpPattern : OpConversionPattern<DMAStartTaskOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -44,7 +56,9 @@ struct DMAStartTaskOpPattern : OpConversionPattern<DMAStartTaskOp> {
       // which we will lower once it has been rewritten into a DMAStartTaskOp.
       return failure();
     }
-    AIE::TileOp tile = task_op.getTileOp();
+    AIE::TileOp tile = task_op.tryGetTileOp();
+    if (!tile)
+      return emitUnplacedTileError(op, task_op);
     Location loc = op.getLoc();
 
     // The bd_id for the queue push: the runtime pool value (dynamic free-list)
@@ -131,7 +145,9 @@ struct DMAAwaitTaskOpPattern : OpConversionPattern<DMAAwaitTaskOp> {
           << "Consider adding attribute `issue_token=true` here.";
       return err;
     }
-    AIE::TileOp tile = task_op.getTileOp();
+    AIE::TileOp tile = task_op.tryGetTileOp();
+    if (!tile)
+      return emitUnplacedTileError(op, task_op);
     Location loc = op.getLoc();
     rewriter.replaceOpWithNewOp<NpuSyncOp>(
         op, createConstantI32(rewriter, loc, tile.getCol()),
@@ -920,7 +936,9 @@ struct AIEDMATasksToNPUPass
 
   LogicalResult rewriteSingleDMAConfigureTaskOp(DMAConfigureTaskOp op) {
     OpBuilder builder(op);
-    AIE::TileOp tile = op.getTileOp();
+    AIE::TileOp tile = op.tryGetTileOp();
+    if (!tile)
+      return emitUnplacedTileError(op, op);
 
     if (!op.use_empty()) {
       auto err = op.emitOpError("Cannot lower while op still has uses.");

--- a/lib/Dialect/AIEX/Transforms/AIEDecomposeLargeDmaBd.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDecomposeLargeDmaBd.cpp
@@ -189,7 +189,9 @@ static bool isUnderRuntimeControlFlow(AIE::DMABDOp op) {
 static std::optional<std::pair<AIE::TileOp, Operation *>>
 resolveTaskAndTile(AIE::DMABDOp op) {
   if (auto cfg = op->getParentOfType<DMAConfigureTaskOp>()) {
-    AIE::TileOp tile = cfg.getTileOp();
+    // Decomposition is a shape rewrite, so an unplaced tile is not an error
+    // here: decline and let the pattern run again after placement.
+    AIE::TileOp tile = cfg.tryGetTileOp();
     if (!tile)
       return std::nullopt;
     return std::make_pair(tile, cfg.getOperation());

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/unplaced-tile-bad.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/unplaced-tile-bad.mlir
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
+
+// This pass emits absolute tile coordinates, so it cannot lower a task whose
+// tile is still an aie.logical_tile. Before the tryGetTileOp guard this call
+// reached TileElement::getTileOp() and aborted the process with
+// "LLVM ERROR: Calling getTileOp requires TileOp." instead of diagnosing.
+
+module {
+  aie.device(npu1) {
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+
+    aie.runtime_sequence(%arg0: memref<32xi8>) {
+      // expected-error@+1 {{Cannot lower a DMA task whose tile is not placed}}
+      %t = aiex.dma_configure_task(%shim, MM2S, 0) {
+          aie.dma_bd(%arg0 : memref<32xi8> offset = 0 len = 32) {bd_id = 0 : i32}
+          aie.end
+      }
+    }
+  }
+}

--- a/test/dialect/AIEX/decompose_large_dma_unplaced_tile.mlir
+++ b/test/dialect/AIEX/decompose_large_dma_unplaced_tile.mlir
@@ -1,0 +1,31 @@
+//===- decompose_large_dma_unplaced_tile.mlir -------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-decompose-large-dma-bd %s | FileCheck %s
+
+// Decomposition is a shape rewrite, so an unplaced tile is not an error here:
+// the pattern declines and runs again once placement substitutes a concrete
+// aie.tile. Before the tryGetTileOp guard, resolveTaskAndTile reached
+// TileElement::getTileOp() and aborted the process instead.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: %[[SHIM:.*]] = aie.logical_tile<ShimNOCTile>(?, ?)
+// CHECK: aiex.dma_configure_task(%[[SHIM]], MM2S, 0)
+// CHECK: aie.dma_bd
+
+module {
+  aie.device(npu1) {
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+
+    aie.runtime_sequence(%arg0: memref<32xi8>) {
+      %t = aiex.dma_configure_task(%shim, MM2S, 0) {
+          aie.dma_bd(%arg0 : memref<32xi8> offset = 0 len = 32) {bd_id = 0 : i32}
+          aie.end
+      }
+    }
+  }
+}


### PR DESCRIPTION
Found while following up your `getStaticStrides()` question on #3463: the same
sweep turned this up nearby, and it is unrelated to that BD sizes/strides
family, so it is its own PR.

### Problem

`TileElement::getTileOp()` reports a fatal error when the tile is an
`aie.logical_tile`. Two passes call it unguarded, so `aie-opt` aborts instead of
diagnosing, on well-formed input:

```
$ aie-opt --aie-dma-tasks-to-npu unplaced.mlir
LLVM ERROR: Calling getTileOp requires TileOp.
```

(`unplaced.mlir` is an `aiex.dma_configure_task` on an
`aie.logical_tile<ShimNOCTile>(?, ?)`; `--aie-decompose-large-dma-bd` aborts the
same way.) `aiecc` always places before either lowering pipeline, so this is
reachable through `aie-opt`'s per-pass flags rather than a full compile: the
cost is a crash instead of an error, not bad output.

The tree already avoids the call twice without naming why.
`DMAConfigureTaskForOp::verify()` hand-rolls the safe form under "Do not call
`allocOp.getTileOp()`: it hard-asserts when the allocation is still bound to an
unplaced (logical) tile", and `resolveTaskAndTile` guards with
`if (!tile) return std::nullopt;` after a call that cannot return null.

### Fix

`tryGetTileOp()` beside `getTileOp()`, null when the tile is still logical.
`getTileOp()` delegates to it, so a placed tile behaves exactly as before.

The passes then diverge by what they need: `aie-dma-tasks-to-npu` emits absolute
column/row and so reports an error; `aie-decompose-large-dma-bd` is a shape
rewrite and declines, running again after placement.

`aiex.core_reset` and `aiex.dma_channel_reset` reach `getTileOp()` the same way,
but their verifiers reject a tile operand not produced by an `aie.tile`, so the
call is unreachable there. Checked rather than assumed.

### Test

`unplaced-tile-bad.mlir` (the diagnostic) and
`decompose_large_dma_unplaced_tile.mlir` (the design left untouched); both abort
without this change. Substituting `aie.tile(0, 0)` gives byte-identical output
before and after, and `check-aie` is unchanged against `main`.
