### PR TITLE
[aiecc] Keep expanding arith float min/max after the LLVM 24 bump

### DIFF
--- a/test/aiecc/peano_compat_minmax_expand.mlir
+++ b/test/aiecc/peano_compat_minmax_expand.mlir
@@ -1,0 +1,49 @@
+//===- peano_compat_minmax_expand.mlir - arith min/max must be expanded ---===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test: the core pipeline must keep expanding arith's min/max ops
+// into cmp+select. LLVM 24 moved those patterns behind the arith-expand options
+// `include-min-max-f` / `include-min-max-i`, which default to false because a
+// normal backend prefers the direct llvm.intr.{maxnum,minnum,smax,...}
+// lowering. Peano's AIE2 GlobalISel has no rule for the resulting G_FMAXNUM /
+// G_FMINNUM, so llc aborts with "unable to legalize instruction" and the whole
+// core fails to build. The IR actually handed to Peano's opt must therefore
+// carry no min/max intrinsic.
+
+// REQUIRES: peano
+
+// RUN: aiecc --tmpdir %t %s
+// RUN: FileCheck %s --input-file %t/peano-compat_main_core_0_2.ll \
+// RUN:   --implicit-check-not=llvm.maxnum --implicit-check-not=llvm.minnum
+
+// CHECK: define void @core_0_2()
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_2 = aie.tile(0, 2)
+    %buf_in = aie.buffer(%tile_0_2) {sym_name = "buf_in"} : memref<256xf32>
+    %buf_out = aie.buffer(%tile_0_2) {sym_name = "buf_out"} : memref<256xf32>
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c256 = arith.constant 256 : index
+      %lo = arith.constant -1.0 : f32
+      %hi = arith.constant 1.0 : f32
+
+      // Scalar f32 clamp: maxnumf then minnumf, the shape a softmax-style
+      // reduction lowers to.
+      scf.for %i = %c0 to %c256 step %c1 {
+        %val = memref.load %buf_in[%i] : memref<256xf32>
+        %mx = arith.maxnumf %val, %lo : f32
+        %mn = arith.minnumf %mx, %hi : f32
+        memref.store %mn, %buf_out[%i] : memref<256xf32>
+      }
+      aie.end
+    }
+  }
+}

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -740,7 +740,20 @@ getCoreLLVMLoweringPipeline(mlir::MLIRContext *ctx, llvm::StringRef deviceName,
   pm->addPass(mlir::createCSEPass());
   pm->addPass(mlir::memref::createExpandStridedMetadataPass());
   pm->addPass(mlir::createLowerAffinePass());
-  pm->addPass(mlir::arith::createArithExpandOpsPass());
+  {
+    // LLVM 24 moved the min/max expansion patterns behind arith-expand options
+    // that default to false, on the grounds that arith-to-llvm can lower these
+    // ops straight to the llvm.intr.{maxnum,minnum,...} intrinsics. Peano's
+    // AIE2 GlobalISel has no rule for the resulting G_FMAXNUM/G_FMINNUM, so llc
+    // aborts with "unable to legalize instruction" and the core never builds.
+    // Keep the cmpf/select expansion for the floating-point ops.
+    //
+    // Only the float half is needed: scalar integer min/max is already taken
+    // care of before this point, so include-min-max-i is left at its default.
+    mlir::arith::ArithExpandOpsPassOptions arithOpts;
+    arithOpts.includeMinMaxF = true;
+    pm->addPass(mlir::arith::createArithExpandOpsPass(arithOpts));
+  }
   pm->addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
   pm->addPass(mlir::createConvertFuncToLLVMPass(
       mlir::ConvertFuncToLLVMPassOptions{/*useBarePtrCallConv=*/true}));


### PR DESCRIPTION
## Problem

Since the LLVM 24 bump (#3491), any design with a scalar floating-point min/max in a core fails to build. Peano's `llc` aborts:

```
LLVM ERROR: unable to legalize instruction: %41:_(s32) = G_FMAXNUM %40:_, %33:_ (in function: core_3_2)
```

## Root cause

LLVM 24 moved `arith-expand`'s min/max expansion patterns behind two new options, `include-min-max-f` and `include-min-max-i`, **both defaulting to false**. The upstream rationale is that arith-to-llvm can lower these ops straight to `llvm.intr.{maxnum,minnum,smax,...}`, which is a single instruction on a normal backend.

Peano's AIE2 GlobalISel has no rule for `G_FMAXNUM`/`G_FMINNUM`, so for us that intrinsic is a dead end rather than an optimisation. `buildCorePipeline` calls `createArithExpandOpsPass()` with defaults, so `arith.maxnumf` now survives all the way to `llc`.

The version difference reproduces on its own:

```console
$ mlir-opt --arith-expand    # on:  arith.maxnumf %a, %b : f32
LLVM 23 → arith.cmpf ugt + arith.select + arith.cmpf uno + arith.select
LLVM 24 → arith.maxnumf %arg0, %arg1 : f32          # untouched
```

And `llc` rejects the intrinsic in isolation, so this is a long-standing Peano gap that the default flip newly exposes rather than a Peano regression:

```llvm
define float @f(float %a, float %b) {
  %m = call float @llvm.maxnum.f32(float %a, float %b)
  ret float %m
}
```
```
$ llc --march=aie2 probe.ll
LLVM ERROR: unable to legalize instruction: G_FMAXNUM
```

## Fix

Set `includeMinMaxF` on the pass options to restore the pre-LLVM-24 `cmpf`/`select` expansion.

Only the float half is set. The integer ops are already handled before `arith-expand` runs — scalar `arith.maxsi`/`minsi` are promoted to `aievec.max`/`aievec.min` by `LowerScalarM{ax,in}SIOpToAIEVec*Op`, and the unsigned vector forms got cmp+select patterns in #3491. I probed i32 and ui32 scalar min/max through the same pipeline and both build fine with `include-min-max-i` left at its default, so this keeps the change scoped to what is actually broken.

## How it was found

Bumping mlir-air's mlir-aie pin past v1.4.0. Its `test/xrt/41_triton_softmax` — a softmax whose reduction body is a scalar `arith.maxnumf` — went from passing to failing. Bisected to the LLVM bump by building the whole stack both ways:

| mlir-aie | LLVM | result |
|---|---|---|
| `0bfcd503` (= `ab85f611^`) | 23 (`46fcb339`) | **pass** |
| `ab85f611` (#3491) | 24 (`56bcc187`) | **fail** — `G_FMAXNUM` |
| `3e0486c0` (main) | 24 | **fail** |

Newest Peano nightly at time of writing (`21.0.0.2026080601+f4a72c27`) does not help.

## Testing

- New `test/aiecc/peano_compat_minmax_expand.mlir` — a scalar f32 clamp (`maxnumf` then `minnumf`) in a core; asserts the IR handed to Peano's `opt` carries no min/max intrinsic. **Fails without this change** (on `G_FMINNUM`), passes with it.
- `check-aie`: the failure set is identical before and after apart from that new test. (This machine has 78 pre-existing `npu-xrt` host-compile failures from a missing `test_lib` include dir, unrelated and unchanged.)
- mlir-air's npu1 Peano hardware suite on a Phoenix part: **32/33 → 33/33**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
