### PR TITLE
docs: fix strict mkdocs build broken by #3436, add PR-time docs build check

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -437,3 +437,40 @@ jobs:
 
       - name: Check copyright notice format
         run: python utils/check_copyright_format.py
+
+  docs-build:
+    name: Docs site build (mkdocs --strict)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get the project repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      # docs/programming_guide and docs/aiecc are gitignored symlinks into the
+      # repo tree (see generateDocs.yml), recreated here so the nav's
+      # referenced pages exist for the strict build.
+      - name: Link programming_guide into docs tree
+        run: ln -s ../programming_guide docs/programming_guide
+
+      - name: Link aiecc docs into docs tree
+        run: ln -s ../tools/aiecc docs/aiecc
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: docs/requirements-mkdocs.txt
+
+      - name: Install MkDocs packages
+        run: pip install -r docs/requirements-mkdocs.txt
+
+      # This is the same strict build generateDocs.yml runs at deploy time
+      # (mike wraps `mkdocs build --strict`), minus the Doxygen/dialect-docs
+      # pieces, which need a full LLVM build and aren't worth the cost on
+      # every PR: mkdocstrings resolves Python docstrings via static analysis
+      # (griffe), not by importing the compiled aie extension, so this still
+      # catches broken docstrings, cross-references, and nav entries without
+      # building anything. The dialect doc pages ship as committed stub files
+      # (docs/AIEDialect.md etc.) precisely so this build works without them.
+      - name: Build docs site (strict)
+        run: mkdocs build --strict

--- a/python/iron/program.py
+++ b/python/iron/program.py
@@ -34,9 +34,9 @@ class Program:
 
         Args:
             device (Device): The device used to generate the final MLIR for the design.
-                Accepts the ``Device | None`` returned by
-                [`get_current_device`][iron.get_current_device] directly and raises
-                if no device has been selected, so callers need not narrow it first.
+                Accepts the ``Device | None`` returned by ``iron.get_current_device``
+                directly and raises if no device has been selected, so callers need
+                not narrow it first.
             rt (Runtime): The runtime object for the design.
             workers (list[Worker] | None, optional): The Workers to run on the
                 device. Defaults to None (no workers). Workers are passed here


### PR DESCRIPTION
## Description

- `program.py`'s docstring linked `[get_current_device][iron.get_current_device]`, but that symbol is documented on `docs/api/iron.md` only as a plain-text table entry (it's re-exported from `aie.utils`, not rendered via a mkdocstrings `:::` block). With no anchor for `mkdocs-autorefs` to resolve, the strict build aborted — this broke last night's `generateDocs` deploy on `main` (failed at the `Deploy with mike` step). Fixed by making the reference plain text, matching its sibling two lines below.
- Added a `docs-build` job to `lintAndFormat.yml` that runs `mkdocs build --strict` on every PR. mkdocstrings resolves Python docstrings via static analysis (griffe), not by importing the compiled `aie` extension, so this catches broken docstrings/cross-refs/nav entries in ~6s without a full LLVM build — no need to wait for the expensive `generateDocs` deploy job to find out.


## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
