### PR TITLE
[AIE] fail on incomplete packet-flow routing

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -538,6 +538,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         if (analyzer.processedFlows[srcPoint])
           continue;
         SwitchSettings settings = analyzer.flowSolutions[srcPoint];
+        // Track whether the source's own switch connection survives routing.
+        bool srcRouted = false;
         // add connections for all the Switchboxes in SwitchSettings
         for (const auto &[curr, setting] : settings) {
           assert(setting.srcs.size() == setting.dsts.size());
@@ -549,6 +551,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
             if (!findPathToDest(settings, currTile, dest.bundle, dest.channel,
                                 destCoords, destPort.bundle, destPort.channel))
               continue;
+            if (currTile == srcSB && src.bundle == srcPort.bundle &&
+                src.channel == srcPort.channel)
+              srcRouted = true;
             Connect connect = {{src.bundle, src.channel},
                                {dest.bundle, dest.channel}};
             if (std::find(
@@ -562,6 +567,15 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
                 ctrlPkt ? *ctrlPkt : false;
           }
         }
+        if (!srcRouted)
+          return pktFlowOp.emitOpError()
+                 << "packet flow source (" << srcCoords.col << ", "
+                 << srcCoords.row << ") " << stringifyWireBundle(srcPort.bundle)
+                 << srcPort.channel << " could not be routed to destination ("
+                 << destCoords.col << ", " << destCoords.row << ") "
+                 << stringifyWireBundle(destPort.bundle) << destPort.channel
+                 << "; the pathfinder produced an incomplete routing for this "
+                    "placement.";
       }
     }
   }

--- a/test/create-packet-flows/incomplete_route_edge_merge.mlir
+++ b/test/create-packet-flows/incomplete_route_edge_merge.mlir
@@ -9,27 +9,22 @@
 
 // Regression test: the pathfinder must not SILENTLY drop a packet_source.
 //
-// This is a high-fan-in merge (5 shim DMA senders in cols 2..6 ->
-// a single memtile S2MM at (0,1) DMA:0) with the mem_tile placed at the column-0
-// edge and a per-column control-packet overlay competing for switch resources.
-// For this one-sided-edge placement the congestion-aware router produces a
-// solution whose per-tile switch settings do not form a complete source->dest
-// path for the col2 and col4 senders: findPathToDest() rejects those source
-// connections in AIECreatePathFindFlows, so no shim_mux is emitted for them.
-// The design used to compile "successfully" while silently delivering only 3 of
-// the 5 packets on device. The pass must instead fail loudly. (A central
-// mem_tile placement routes all 5 and is unaffected.)
+// Five same-id packet sources merge into a single mem_tile S2MM DMA channel.
+// Same-id flows cannot share a switch channel, so each source needs its own path
+// to the destination. The congestion-aware pathfinder does not find a complete
+// assignment for this placement and drops one source's connection, producing an
+// incomplete routing. The design used to compile "successfully" while silently
+// delivering only four of the five sources on device. The pass must instead fail
+// loudly.
 
 module {
   aie.device(npu2) {
-    %shim_noc_tile_0_0 = aie.tile(0, 0)
-    %shim_noc_tile_2_0 = aie.tile(2, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
-    %shim_noc_tile_3_0 = aie.tile(3, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
-    %shim_noc_tile_4_0 = aie.tile(4, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
-    %shim_noc_tile_5_0 = aie.tile(5, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
-    %shim_noc_tile_6_0 = aie.tile(6, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
-    %mem_tile_0_1 = aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
-    %shim_noc_tile_1_0 = aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %mem_tile_0_1 = aie.tile(0, 1)
+    %shim_noc_tile_2_0 = aie.tile(2, 0)
+    %shim_noc_tile_3_0 = aie.tile(3, 0)
+    %shim_noc_tile_4_0 = aie.tile(4, 0)
+    %shim_noc_tile_5_0 = aie.tile(5, 0)
+    %shim_noc_tile_6_0 = aie.tile(6, 0)
     // expected-error @+1 {{could not be routed to destination}}
     aie.packet_flow(0) {
       aie.packet_source<%shim_noc_tile_2_0, DMA : 0>
@@ -51,30 +46,5 @@ module {
       aie.packet_source<%shim_noc_tile_6_0, DMA : 0>
       aie.packet_dest<%mem_tile_0_1, DMA : 0>
     } {keep_pkt_header = true}
-    aie.flow(%mem_tile_0_1, DMA : 0, %shim_noc_tile_1_0, DMA : 0)
-    aie.packet_flow(15) {
-      aie.packet_source<%shim_noc_tile_2_0, TileControl : 0>
-      aie.packet_dest<%shim_noc_tile_2_0, South : 0>
-    } {keep_pkt_header = true, priority_route = true}
-    aie.packet_flow(15) {
-      aie.packet_source<%shim_noc_tile_3_0, TileControl : 0>
-      aie.packet_dest<%shim_noc_tile_3_0, South : 0>
-    } {keep_pkt_header = true, priority_route = true}
-    aie.packet_flow(15) {
-      aie.packet_source<%shim_noc_tile_4_0, TileControl : 0>
-      aie.packet_dest<%shim_noc_tile_4_0, South : 0>
-    } {keep_pkt_header = true, priority_route = true}
-    aie.packet_flow(15) {
-      aie.packet_source<%shim_noc_tile_5_0, TileControl : 0>
-      aie.packet_dest<%shim_noc_tile_5_0, South : 0>
-    } {keep_pkt_header = true, priority_route = true}
-    aie.packet_flow(15) {
-      aie.packet_source<%shim_noc_tile_6_0, TileControl : 0>
-      aie.packet_dest<%shim_noc_tile_6_0, South : 0>
-    } {keep_pkt_header = true, priority_route = true}
-    aie.packet_flow(15) {
-      aie.packet_source<%shim_noc_tile_1_0, TileControl : 0>
-      aie.packet_dest<%shim_noc_tile_1_0, South : 0>
-    } {keep_pkt_header = true, priority_route = true}
   }
 }

--- a/test/create-packet-flows/incomplete_route_edge_merge.mlir
+++ b/test/create-packet-flows/incomplete_route_edge_merge.mlir
@@ -1,0 +1,80 @@
+//===- incomplete_route_edge_merge.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-create-pathfinder-flows --verify-diagnostics %s
+
+// Regression test: the pathfinder must not SILENTLY drop a packet_source.
+//
+// This is a high-fan-in merge (5 shim DMA senders in cols 2..6 ->
+// a single memtile S2MM at (0,1) DMA:0) with the mem_tile placed at the column-0
+// edge and a per-column control-packet overlay competing for switch resources.
+// For this one-sided-edge placement the congestion-aware router produces a
+// solution whose per-tile switch settings do not form a complete source->dest
+// path for the col2 and col4 senders: findPathToDest() rejects those source
+// connections in AIECreatePathFindFlows, so no shim_mux is emitted for them.
+// The design used to compile "successfully" while silently delivering only 3 of
+// the 5 packets on device. The pass must instead fail loudly. (A central
+// mem_tile placement routes all 5 and is unaffected.)
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    %shim_noc_tile_2_0 = aie.tile(2, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %shim_noc_tile_3_0 = aie.tile(3, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %shim_noc_tile_4_0 = aie.tile(4, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %shim_noc_tile_5_0 = aie.tile(5, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %shim_noc_tile_6_0 = aie.tile(6, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %mem_tile_0_1 = aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
+    %shim_noc_tile_1_0 = aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    // expected-error @+1 {{could not be routed to destination}}
+    aie.packet_flow(0) {
+      aie.packet_source<%shim_noc_tile_2_0, DMA : 0>
+      aie.packet_dest<%mem_tile_0_1, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%shim_noc_tile_3_0, DMA : 0>
+      aie.packet_dest<%mem_tile_0_1, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%shim_noc_tile_4_0, DMA : 0>
+      aie.packet_dest<%mem_tile_0_1, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%shim_noc_tile_5_0, DMA : 0>
+      aie.packet_dest<%mem_tile_0_1, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%shim_noc_tile_6_0, DMA : 0>
+      aie.packet_dest<%mem_tile_0_1, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.flow(%mem_tile_0_1, DMA : 0, %shim_noc_tile_1_0, DMA : 0)
+    aie.packet_flow(15) {
+      aie.packet_source<%shim_noc_tile_2_0, TileControl : 0>
+      aie.packet_dest<%shim_noc_tile_2_0, South : 0>
+    } {keep_pkt_header = true, priority_route = true}
+    aie.packet_flow(15) {
+      aie.packet_source<%shim_noc_tile_3_0, TileControl : 0>
+      aie.packet_dest<%shim_noc_tile_3_0, South : 0>
+    } {keep_pkt_header = true, priority_route = true}
+    aie.packet_flow(15) {
+      aie.packet_source<%shim_noc_tile_4_0, TileControl : 0>
+      aie.packet_dest<%shim_noc_tile_4_0, South : 0>
+    } {keep_pkt_header = true, priority_route = true}
+    aie.packet_flow(15) {
+      aie.packet_source<%shim_noc_tile_5_0, TileControl : 0>
+      aie.packet_dest<%shim_noc_tile_5_0, South : 0>
+    } {keep_pkt_header = true, priority_route = true}
+    aie.packet_flow(15) {
+      aie.packet_source<%shim_noc_tile_6_0, TileControl : 0>
+      aie.packet_dest<%shim_noc_tile_6_0, South : 0>
+    } {keep_pkt_header = true, priority_route = true}
+    aie.packet_flow(15) {
+      aie.packet_source<%shim_noc_tile_1_0, TileControl : 0>
+      aie.packet_dest<%shim_noc_tile_1_0, South : 0>
+    } {keep_pkt_header = true, priority_route = true}
+  }
+}


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

The congestion-aware pathfinder (`--aie-create-pathfinder-flows`) can produce a routing solution whose per-tile switch settings do not form a complete source -> dest path for every declared packet source. This shows up with high-fan-in merges when the destination sits at a column edge. In `AIEPathfinderPass::runOnPacketFlow` the "reject false broadcast" `findPathToDest()` guard then drops the source's own connection, so no source connect is emitted and the sender is silently omitted -- the design compiles cleanly but under-delivers on device with no diagnostic.

This PR tracks whether each declared packet source keeps a surviving connection to its destination and emits an op error when it does not, turning a silent miscompile into a compile-time diagnostic that names the source and destination that could not be connected.

Adds a regression test `test/create-packet-flows/incomplete_route_edge_merge.mlir` that must now fail loudly. The underlying limitation -- that some column-edge high-fan-in placements cannot be routed at all -- is separate and remains open.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))