### PR TITLE
[tests] Add trace step to matmul single_core bf16 lit variants

### DIFF
--- a/programming_examples/basic/matrix_multiplication/single_core/tests/run_makefile_bf16.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/tests/run_makefile_bf16.lit
@@ -9,3 +9,5 @@
 // RUN: make -f %S/../Makefile clean
 // RUN: env dtype_in=bf16 dtype_out=bf16 m=32 k=32 n=32 M=512 K=512 N=512 make -f %S/../Makefile
 // RUN: %run_on_npu1% env dtype_in=bf16 dtype_out=bf16 m=32 k=32 n=32 M=512 K=512 N=512 make -f %S/../Makefile run
+// RUN: make -f %S/../Makefile clean
+// RUN: %run_on_npu1% env dtype_in=bf16 dtype_out=bf16 m=32 k=32 n=32 M=512 K=512 N=512 make -f %S/../Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/tests/run_strix_makefile_bf16.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/tests/run_strix_makefile_bf16.lit
@@ -9,3 +9,5 @@
 // RUN: make -f %S/../Makefile clean
 // RUN: env dtype_in=bf16 dtype_out=bf16 m=32 k=32 n=32 M=512 K=512 N=512 emulate_bfloat16_mmul_with_bfp16=0 make -f %S/../Makefile devicename=npu2
 // RUN: %run_on_npu2% env dtype_in=bf16 dtype_out=bf16 m=32 k=32 n=32 M=512 K=512 N=512 emulate_bfloat16_mmul_with_bfp16=0 make -f %S/../Makefile run devicename=npu2
+// RUN: make -f %S/../Makefile clean
+// RUN: %run_on_npu2% env dtype_in=bf16 dtype_out=bf16 m=32 k=32 n=32 M=512 K=512 N=512 emulate_bfloat16_mmul_with_bfp16=0 make -f %S/../Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/tests/run_strix_makefile_bf16_emulated.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/tests/run_strix_makefile_bf16_emulated.lit
@@ -9,3 +9,5 @@
 // RUN: make -f %S/../Makefile clean
 // RUN: env dtype_in=bf16 dtype_out=f32 m=32 k=32 n=32 M=512 K=512 N=512 emulate_bfloat16_mmul_with_bfp16=1 make -f %S/../Makefile devicename=npu2
 // RUN: %run_on_npu2% env dtype_in=bf16 dtype_out=f32 m=32 k=32 n=32 M=512 K=512 N=512 emulate_bfloat16_mmul_with_bfp16=1 make -f %S/../Makefile run devicename=npu2
+// RUN: make -f %S/../Makefile clean
+// RUN: %run_on_npu2% env dtype_in=bf16 dtype_out=f32 m=32 k=32 n=32 M=512 K=512 N=512 emulate_bfloat16_mmul_with_bfp16=1 make -f %S/../Makefile trace devicename=npu2


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description
  
The bf16 and bf16-emulated lit configs for `matrix_multiplication/single_core` never picked up the `make trace` step that the other dtype variants (i16/i32, i8, col_maj) already run — this was a copy-paste gap from when the bf16 variants were added in #2391, after the trace-in-lit convention already existed elsewhere. As a result bf16 trace was silently untested.
  
This adds the missing `make -f %S/../Makefile trace` step (with matching `make clean` beforehand) to:
- `run_makefile_bf16.lit` (npu1)
- `run_strix_makefile_bf16.lit` (npu2)
- `run_strix_makefile_bf16_emulated.lit` (npu2, bfp16-emulated)
  
### Context: #2135
  
While investigating #2135 ("Enabling trace for matmul single_core causes intermittent functional failure when run"), I found the underlying bug already fixed: the trace BD buffer-length register was being programmed in bytes instead of 32-bit words, causing the trace DMA to overrun the host buffer by 4x (explaining the "make the buffer 4x bigger" workaround in that issue's comments). That conversion now happens centrally in `AIEInsertTraceFlows.cpp` (`bufferSizeBytes / 4`) and is pinned against regression by `test_insert_trace_flows*.mlir` (exact FileCheck'd buffer_length values, no hardware required).

I verified on Phoenix (npu1) hardware that `single_core` matmul with trace enabled passes reliably (15/15 runs, no crash) and produces a well-formed decoded trace (~37-39k events) for both the default and bf16 dtype configs. The only remaining gap was this bf16 lit coverage, which this PR closes.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
