### PR TITLE
[aiecc] Downgrade LLVM 24 narrow-float decimal literals for Peano

### DIFF
--- a/test/aiecc/Inputs/peano_float_decimal_kernel.ll
+++ b/test/aiecc/Inputs/peano_float_decimal_kernel.ll
@@ -1,0 +1,47 @@
+; Copyright (C) 2026 Advanced Micro Devices, Inc.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; A merge-mode ("inline") kernel artifact carrying narrow float constants in
+; every position downgradeIRForPeano has to reason about. Owned by
+; peano_compat_float_decimal_merge.mlir.
+;
+; The merge linker reprints this module with aiecc's LLVM, which spells a
+; float/half constant as a short decimal whenever that decimal round-trips in
+; the narrow type -- a spelling Peano's older parser rejects. The constants are
+; written here in the hex form so the intent is fixed whatever a given LLVM
+; prints; the reprint is what introduces the decimals.
+;
+; The (ptr, ptr) signature is aiecc's bare-pointer memref calling convention.
+
+target triple = "aie2"
+
+; Typed position: a constant array, the shape the LUT in a real attention
+; kernel takes. 2.5 is exact as a double and must survive as printed.
+@lut_f = linkonce_odr global [4 x float] [float 0x400921FA00000000,
+                                          float 0x3FBC28F5C0000000,
+                                          float 0xBF6A8292A0000000,
+                                          float 2.500000e+00], align 4
+; Same, for half, which takes its own 16-bit hex form.
+@lut_h = linkonce_odr global [2 x half] [half 0xH2F0A, half 0xH4100], align 2
+
+define linkonce_odr void @merge_kernel(ptr %in, ptr %out) #0 {
+entry:
+  %x = load float, ptr %in, align 4
+  %l = load float, ptr @lut_f, align 4
+  %s = fadd float %x, %l
+  ; Bare operand position: the constant carries no type keyword of its own and
+  ; takes float from the instruction.
+  %r = fmul float %s, 0x3FBC28F5C0000000
+  ; Mixed-type line: the double must keep its decimal spelling, which Peano
+  ; accepts, rather than be rewritten under the float semantics named later on
+  ; the same line.
+  %d = fptrunc double 1.100000e-01 to float
+  %rd = fadd float %r, %d
+  %h = load half, ptr @lut_h, align 2
+  %hf = fpext half %h to float
+  %acc = fadd float %rd, %hf
+  store float %acc, ptr %out, align 4
+  ret void
+}
+
+attributes #0 = { alwaysinline }

--- a/test/aiecc/peano_compat_float_decimal.mlir
+++ b/test/aiecc/peano_compat_float_decimal.mlir
@@ -1,0 +1,65 @@
+//===- peano_compat_float_decimal.mlir - downgradeIRForPeano float -------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test: LLVM 24 prints a `float` constant as a short decimal
+// whenever that decimal round-trips in float; older LLVM required it to round
+// trip as a double and printed hex otherwise. Peano's opt still demands exact
+// representability and rejects the decimal with "floating point constant
+// invalid for type", so downgradeIRForPeano must rewrite it -- in the typed
+// position a constant array gives (`[4 x float] [float 3.141590e+00, ...]`)
+// and in the bare operand one an instruction gives (`fmul float %v,
+// 1.100000e-01`), where the type comes from the instruction.
+//
+// The whole peano path runs here, so Peano's own opt decides: drop the rewrite
+// and this fails at `opted_{0}.ll` with that error.
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: aiecc --tmpdir %t %s
+// RUN: FileCheck %s --input-file %t/peano-compat_main_core_0_2.ll \
+// RUN:   --implicit-check-not="float 3.141590e+00" \
+// RUN:   --implicit-check-not="float 1.100000e-01" \
+// RUN:   --implicit-check-not="float -3.236090e-03"
+
+// The exactly representable literals Peano already accepts stay decimal, so
+// the rewrite stays narrow.
+// CHECK-DAG: 0x400921FA00000000
+// CHECK-DAG: 0x3FBC28F5C0000000
+// CHECK-DAG: 0xBF6A8292A0000000
+// CHECK-DAG: 2.500000e+00
+
+module {
+  aie.device(npu2) {
+    %tile = aie.tile(0, 2)
+    %buf_in = aie.buffer(%tile) {sym_name = "in"} : memref<4xf32>
+    %buf_out = aie.buffer(%tile) {sym_name = "out"} : memref<4xf32>
+    // Typed position: an initialized constant array. 2.5 is exact as a double
+    // and must be left as printed; the other three are not.
+    %lut = aie.buffer(%tile) {
+      sym_name = "lut",
+      initial_value = dense<[3.141590e+00, 1.100000e-01, -3.236090e-03,
+                             2.500000e+00]> : tensor<4xf32>
+    } : memref<4xf32>
+
+    %core = aie.core(%tile) {
+      %c0 = arith.constant 0 : index
+      %c4 = arith.constant 4 : index
+      %c1 = arith.constant 1 : index
+      // Bare operand position: the constant carries no type keyword of its own.
+      %k = arith.constant 1.100000e-01 : f32
+      scf.for %i = %c0 to %c4 step %c1 {
+        %v = memref.load %buf_in[%i] : memref<4xf32>
+        %l = memref.load %lut[%i] : memref<4xf32>
+        %s = arith.addf %v, %l : f32
+        %r = arith.mulf %s, %k : f32
+        memref.store %r, %buf_out[%i] : memref<4xf32>
+      }
+      aie.end
+    }
+  }
+}

--- a/test/aiecc/peano_compat_float_decimal_merge.mlir
+++ b/test/aiecc/peano_compat_float_decimal_merge.mlir
@@ -1,0 +1,63 @@
+//===- peano_compat_float_decimal_merge.mlir - post-link float decimals --===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The merge is where a float constant crosses LLVM versions as text, so it is
+// where the LLVM 24 spelling of one bites: the linker reprints the kernel with
+// aiecc's LLVM, which writes a float/half constant as a short decimal whenever
+// that decimal round-trips in the narrow type, and Peano's parser -- which
+// still demands exact representability -- rejects it with "floating point
+// constant invalid for type". This is the failure a fused-decode attention
+// kernel hit on its exp2 lookup table.
+//
+// downgradeIRForPeano runs again after the link for exactly this reason, so
+// check its output covers every position the constants appear in.
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: aiecc --tmpdir %t %s
+// RUN: FileCheck %s --input-file %t/peano-linked_main_core_0_2.ll \
+// RUN:   --implicit-check-not="float 3.141590e+00" \
+// RUN:   --implicit-check-not="float 1.100000e-01" \
+// RUN:   --implicit-check-not="float -3.236090e-03" \
+// RUN:   --implicit-check-not="half 1.099850e-01" \
+// RUN:   --implicit-check-not=", 1.100000e-01"
+
+// Typed array: the three inexact literals in hex, the exact one untouched.
+// CHECK-DAG: 0x400921FA00000000
+// CHECK-DAG: 0xBF6A8292A0000000
+// CHECK-DAG: float 2.500000e+00
+// Bare operand, taking float from the instruction.
+// CHECK-DAG: fmul float %{{.*}}, 0x3FBC28F5C0000000
+// Half takes its own 16-bit form; the exact one is left alone.
+// CHECK-DAG: half 0xH2F0A
+// CHECK-DAG: half 2.500000e+00
+// A double on a float-typed line keeps the spelling Peano accepts.
+// CHECK-DAG: fptrunc double 1.100000e-01
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xf32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xf32>>
+
+    func.func private @merge_kernel(memref<16xf32>, memref<16xf32>) attributes {link_with = "Inputs/peano_float_decimal_kernel.ll", link_with_mode = "merge"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %subview_in = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<16xf32>>
+      %elem_in = aie.objectfifo.subview.access %subview_in[0] : !aie.objectfifosubview<memref<16xf32>> -> memref<16xf32>
+      %subview_out = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<16xf32>>
+      %elem_out = aie.objectfifo.subview.access %subview_out[0] : !aie.objectfifosubview<memref<16xf32>> -> memref<16xf32>
+      func.call @merge_kernel(%elem_in, %elem_out) : (memref<16xf32>, memref<16xf32>) -> ()
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+  }
+}

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -47,6 +47,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -467,7 +467,8 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
         continue;
       }
       // Copy quoted strings verbatim: they can hold anything that looks like a
-      // literal (a version string, an escaped byte array).
+      // literal (a version string, an escaped byte array). A quote inside one
+      // is printed as `\22`, never `\"`, so the next bare quote terminates it.
       if (c == '"') {
         size_t end = result.find('"', i + 1);
         end = (end == std::string::npos) ? result.size() : end + 1;

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -41,6 +41,7 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -434,6 +435,134 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
         pos = hexEnd;
       }
     }
+  }
+  // LLVM 24 prints a 'float'/'half' constant as a short decimal whenever that
+  // decimal round-trips in the *narrow* type; older LLVM required it to round
+  // trip as a double and printed hex otherwise. Peano's parser still demands
+  // exact representability, so it rejects what LLVM 24 prints ("floating point
+  // constant invalid for type") in both the typed position ('float
+  // 1.100000e-01') and the bare operand one ('fmul float %x, 1.100000e-01').
+  //
+  // A bare operand takes its type from the instruction, so tokenize and track
+  // the last type keyword seen on the line. That also keeps a mixed-type line
+  // ('call void @f(float 1.1, double 2.2)') from being rewritten under the
+  // wrong semantics. 'bfloat' and 'double' set the type but are left alone:
+  // double decimals always round-trip, and bfloat is handled below.
+  {
+    enum class FPTy { None, Float, Half };
+    std::string out;
+    out.reserve(result.size());
+    FPTy lineTy = FPTy::None;
+    size_t i = 0;
+    auto isNameChar = [](char c) {
+      return std::isalnum(static_cast<unsigned char>(c)) || c == '_' ||
+             c == '.' || c == '$' || c == '-';
+    };
+    while (i < result.size()) {
+      char c = result[i];
+      if (c == '\n') {
+        lineTy = FPTy::None;
+        out += c;
+        ++i;
+        continue;
+      }
+      // Copy quoted strings verbatim: they can hold anything that looks like a
+      // literal (a version string, an escaped byte array).
+      if (c == '"') {
+        size_t end = result.find('"', i + 1);
+        end = (end == std::string::npos) ? result.size() : end + 1;
+        out.append(result, i, end - i);
+        i = end;
+        continue;
+      }
+      // Names (%v, @g, !12) and keywords are consumed whole, so a digit inside
+      // one is never mistaken for a constant, and 'bfloat' never matches as
+      // 'float'.
+      if (c == '%' || c == '@' || c == '!' || c == '#' ||
+          std::isalpha(static_cast<unsigned char>(c)) || c == '_') {
+        size_t end = i + 1;
+        while (end < result.size() && isNameChar(result[end]))
+          ++end;
+        llvm::StringRef word(result.data() + i, end - i);
+        if (word == "float")
+          lineTy = FPTy::Float;
+        else if (word == "half")
+          lineTy = FPTy::Half;
+        else if (word == "bfloat" || word == "double")
+          lineTy = FPTy::None;
+        out.append(result, i, end - i);
+        i = end;
+        continue;
+      }
+      bool isNumStart =
+          std::isdigit(static_cast<unsigned char>(c)) ||
+          ((c == '-' || c == '+') && i + 1 < result.size() &&
+           std::isdigit(static_cast<unsigned char>(result[i + 1])));
+      if (!isNumStart) {
+        out += c;
+        ++i;
+        continue;
+      }
+      size_t end = i + 1;
+      while (end < result.size() &&
+             (std::isalnum(static_cast<unsigned char>(result[end])) ||
+              result[end] == '.' ||
+              ((result[end] == '+' || result[end] == '-') &&
+               (result[end - 1] == 'e' || result[end - 1] == 'E'))))
+        ++end;
+      llvm::StringRef num(result.data() + i, end - i);
+      // Only decimals are at risk; the hex forms already say exactly what they
+      // mean, and an integer is not a float constant.
+      bool isDecimal =
+          num.contains('.') || num.contains('e') || num.contains('E');
+      if (lineTy == FPTy::None || !isDecimal || num.starts_with("0x")) {
+        out.append(num.data(), num.size());
+        i = end;
+        continue;
+      }
+      const llvm::fltSemantics &sem = lineTy == FPTy::Half
+                                          ? llvm::APFloat::IEEEhalf()
+                                          : llvm::APFloat::IEEEsingle();
+      llvm::APFloat val(llvm::APFloat::IEEEdouble());
+      auto parsed =
+          val.convertFromString(num, llvm::APFloat::rmNearestTiesToEven);
+      if (!parsed) {
+        llvm::consumeError(parsed.takeError());
+        out.append(num.data(), num.size());
+        i = end;
+        continue;
+      }
+      bool lost = false;
+      llvm::APFloat narrow = val;
+      narrow.convert(sem, llvm::APFloat::rmNearestTiesToEven, &lost);
+      if (!lost) {
+        // Exactly representable, so Peano accepts the decimal as printed.
+        out.append(num.data(), num.size());
+        i = end;
+        continue;
+      }
+      // 'half' takes its own 16-bit hex form; 'float' is spelled as the double
+      // it widens to.
+      uint64_t bits;
+      int digits;
+      if (lineTy == FPTy::Half) {
+        out += "0xH";
+        bits = narrow.bitcastToAPInt().getZExtValue();
+        digits = 4;
+      } else {
+        bool ignored = false;
+        llvm::APFloat wide = narrow;
+        wide.convert(llvm::APFloat::IEEEdouble(),
+                     llvm::APFloat::rmNearestTiesToEven, &ignored);
+        out += "0x";
+        bits = wide.bitcastToAPInt().getZExtValue();
+        digits = 16;
+      }
+      for (int shift = (digits - 1) * 4; shift >= 0; shift -= 4)
+        out += "0123456789ABCDEF"[(bits >> shift) & 0xFu];
+      i = end;
+    }
+    result = std::move(out);
   }
   // Rewrite decimal bfloat16 literals ('bfloat N.NNe+NN', an LLVM 23 printing
   // form) to the bit-exact '0xR<4hex>' form Peano's older LLVM only accepts.

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -444,6 +444,11 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
   // constant invalid for type") in both the typed position ('float
   // 1.100000e-01') and the bare operand one ('fmul float %x, 1.100000e-01').
   //
+  // llvm/llvm-project@41c214f0b115 ("[AsmWriter] Change the output syntax of
+  // floating-point literals", #190649) moved that round-trip check onto the
+  // value's own semantics and retired the legacy '0x<16hex>' spelling for
+  // 'f0x', which the pass below this one rewrites.
+  //
   // A bare operand takes its type from the instruction, so tokenize and track
   // the last type keyword seen on the line. That also keeps a mixed-type line
   // ('call void @f(float 1.1, double 2.2)') from being rewritten under the


### PR DESCRIPTION
## Problem

LLVM 24 changed how the AsmWriter spells a narrow float constant: it now prints a short decimal whenever that decimal round-trips **in the narrow type**, where older LLVM required it to round-trip as a double and fell back to hex otherwise. So a `float` LUT that LLVM 23 printed as

```llvm
@activation_lut_ab = global [256 x float] [float 0xBF6A8292A0000000, ...]
```

now comes out as

```llvm
@activation_lut_ab = global [256 x float] [float -3.236090e-03, ...]
```

Peano's parser (LLVM 21) still demands exact representability and rejects it:

```
opt: peano-linked_seg_core_4_5.ll:32:102: error: floating point constant invalid for type
@activation_lut_ab = dso_local global [256 x float] [float -0.000000e+00, float -3.236090e-03, ...
                                                                          ^
```

`downgradeIRForPeano` already handles the sibling LLVM 23 spellings (`f0x`, `inf`/`nan`, bfloat decimals), but not this one. Any merge-mode kernel carrying a lookup table fails at `opted_{0}.ll`; downstream this took out the fused-decode attention kernels (their `exp2` LUT) after the LLVM 23 -> 24 bump.

## Fix

Rewrite only the literals Peano would reject — parse the decimal, round to the target semantics with `APFloat`, and emit the hex form if that loses information (`0x<16hex>` for `float`, `0xH<4hex>` for `half`). Exactly representable decimals are left as printed, so the rewrite stays narrow and is idempotent. The rewrite is value-preserving: canonicalizing the module under LLVM 24 before and after diffs clean, and the LUT element above comes back as the bit-identical hex Peano's own clang emits.

A bare operand (`fmul float %x, 1.100000e-01`) is affected too and has no type keyword of its own, so the pass tokenizes and tracks the last type keyword on the line. That also prevents a mixed-type line (`fptrunc double 1.1e-01 to float`) from being rewritten under the wrong semantics — `double` and `bfloat` set the type but are left alone, since double decimals always round-trip and bfloat is handled by the existing passes below.

## Tests

Two new lit tests, both verified to fail without the fix (`floating point constant invalid for type`) and pass with it:

- `peano_compat_float_decimal.mlir` — pre-link path: typed constant array plus a bare operand, with an exactly representable literal that must stay decimal.
- `peano_compat_float_decimal_merge.mlir` — post-link path, which is where the bug actually bit. A hand-written merge-mode kernel (`Inputs/peano_float_decimal_kernel.ll`) covers every position: typed `[4 x float]` and `[2 x half]` arrays, a bare `fmul` operand, exact literals that must survive untouched, an already-hex literal (idempotence), and a mixed-type `double`/`float` line.

The full `aiecc` lit suite is unchanged locally; all 8 `peano_compat_*` tests pass. (15 xclbin-packaging tests fail in my environment for want of `xclbinutil`, with or without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)