### PR TITLE
[wip][experiment]

### DIFF
--- a/test/aiecc/bss_mixed_segment_repro/README.md
+++ b/test/aiecc/bss_mixed_segment_repro/README.md
@@ -1,0 +1,61 @@
+# aie-rt ELF loader out-of-bounds read — minimal reproducer
+
+`aie-rt`'s `_XAie_LoadDataMemSection`
+(`driver/src/core/xaie_elfloader.c`) writes `p_memsz` bytes starting from a
+segment's file offset, but only substitutes a zeroed buffer when
+`p_filesz == 0`:
+
+```c
+SectionSize = Phdr->p_memsz;
+if (Phdr->p_filesz == 0U) Buffer = calloc(Phdr->p_memsz, sizeof(char));
+while (SectionSize > 0U) { ...Write(..., Buffer, BytesToWrite); Buffer += BytesToWrite; }
+```
+
+For the ordinary **mixed** `data`+`bss` segment (`0 < p_filesz < p_memsz`) it
+therefore reads `p_memsz - p_filesz` bytes past the segment's file contents and
+DMAs whatever follows in the ELF image (`.comment`, `.symtab`, …) into the tile.
+
+Per the System V gABI (`man 5 elf`, `PT_LOAD`): *"If the segment's memory size
+`p_memsz` is larger than the file size `p_filesz`, the 'extra' bytes are defined
+to hold the value 0."* Zeroing that gap is required of the loader.
+
+## Run
+
+```bash
+export PEANO_INSTALL_DIR=/path/to/llvm-aie
+./run.sh
+```
+
+Expected:
+
+```
+--- bug ---
+    segment: FileSiz 0x01000  MemSiz 0x01200
+    ELF .comment strings baked into the CDO: 1
+    >>> BUG: ...
+--- control ---
+    segment: FileSiz 0x00000  MemSiz 0x00200
+    ELF .comment strings baked into the CDO: 0
+    OK: no metadata leaked.
+```
+
+No hardware needed — the defect is visible in the CDO. To see the exact bytes
+that will be written where `zero_state[512]` should be all zeros:
+
+```python
+elf = open('work_bug/elfs_main_core_0_2/elfs_main_core_0_2.elf','rb').read()
+print(elf[0x12b0:0x12b0+0x200][:56])
+# b'\x00Linker: LLD 21.0.0 (https://github.com/Xilinx/llvm-aie '
+```
+
+## Fix
+
+Split the write at `p_filesz`: copy the real bytes, then write zeros for the
+remaining `p_memsz - p_filesz`.
+
+## Real-world impact
+
+In a Gemma4 decode layer this silently inverted a kernel's ping/pong selector
+(`static bool is_ksc_ping` received `'k'` from the string `"Linker"`), so every
+call read the wrong buffer — correct arithmetic on stale data. See
+`docs/AIE_RT_ELF_LOADER_BUG.md`.

--- a/test/aiecc/bss_mixed_segment_repro/bss_k.cc
+++ b/test/aiecc/bss_mixed_segment_repro/bss_k.cc
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+// .data (PROGBITS): initialised, so it occupies file bytes
+__attribute__((used, retain))
+volatile uint8_t initialised[4096] = { 1 };
+
+// .bss (NOBITS): C++ guarantees all-zero before first use
+volatile uint8_t zero_state[512];
+
+extern "C" void bss_probe(uint8_t *out) {
+    for (int i = 0; i < 512; i++) out[i] = zero_state[i];
+    out[0] = (uint8_t)(out[0] + (initialised[0] - initialised[0]));  // keep .data live
+}

--- a/test/aiecc/bss_mixed_segment_repro/bss_k_control.cc
+++ b/test/aiecc/bss_mixed_segment_repro/bss_k_control.cc
@@ -1,0 +1,8 @@
+#include <stdint.h>
+// CONTROL: .bss only, no initialised data. The linker then emits a separate
+// PT_LOAD with p_filesz == 0, which aie-rt DOES handle (its calloc path), so
+// this variant loads correct zeros.
+volatile uint8_t zero_state[512];
+extern "C" void bss_probe(uint8_t *out) {
+    for (int i = 0; i < 512; i++) out[i] = zero_state[i];
+}

--- a/test/aiecc/bss_mixed_segment_repro/bssmin.mlir
+++ b/test/aiecc/bss_mixed_segment_repro/bssmin.mlir
@@ -1,0 +1,30 @@
+// Minimal reproducer: a core whose kernel has BOTH initialised data (.data,
+// PROGBITS) and zero-initialised statics (.bss, NOBITS). The linker places them
+// in one PT_LOAD with p_memsz > p_filesz -- the ELF-spec representation of .bss.
+// The kernel copies its .bss out, so a correct load yields all zeros.
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<512xi8>>
+
+    func.func private @bss_probe(memref<512xi8>) attributes {link_with = "bss_k.o"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %sv = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<512xi8>>
+      %e = aie.objectfifo.subview.access %sv[0] : !aie.objectfifosubview<memref<512xi8>> -> memref<512xi8>
+      func.call @bss_probe(%e) : (memref<512xi8>) -> ()
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+
+    aie.runtime_sequence(%out : memref<512xi8>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c512 = arith.constant 512 : i64
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c512][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<512xi8>
+      aiex.npu.dma_wait {symbol = @of_out}
+    }
+  }
+}

--- a/test/aiecc/bss_mixed_segment_repro/run.sh
+++ b/test/aiecc/bss_mixed_segment_repro/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Minimal reproducer for the aie-rt ELF loader out-of-bounds read.
+#
+# Builds a one-core design twice and inspects the generated CDO. No hardware
+# required -- the defect is visible in the configuration image itself.
+#
+#   BUG variant     kernel has .data AND .bss -> one PT_LOAD with
+#                   0 < p_filesz < p_memsz. aie-rt writes p_memsz bytes from a
+#                   p_filesz-sized buffer, so ELF .comment bytes land in .bss.
+#   CONTROL variant kernel has .bss only -> separate PT_LOAD with p_filesz == 0,
+#                   which aie-rt handles correctly (its calloc path).
+#
+# Usage: ./run.sh [workdir]     (needs PEANO_INSTALL_DIR and aiecc on PATH)
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+W="${1:-/tmp/aie-rt-bss-repro}"
+: "${PEANO_INSTALL_DIR:?set PEANO_INSTALL_DIR}"
+AIECC="${AIECC:-$(command -v aiecc)}"
+CXX="$PEANO_INSTALL_DIR/bin/clang++"
+RE="$PEANO_INSTALL_DIR/bin/llvm-readelf"
+mkdir -p "$W"; cd "$W"; cp "$HERE/bssmin.mlir" .
+
+run_variant () { # $1=source $2=tag
+  "$CXX" --target=aie2p-none-unknown-elf -std=c++20 -O2 -DNDEBUG -c "$HERE/$1" -o bss_k.o
+  rm -rf "work_$2"; mkdir -p "work_$2"
+  "$AIECC" bssmin.mlir --peano="$PEANO_INSTALL_DIR" \
+      --get-xclbin --xclbin-name="$W/$2.xclbin" \
+      --get-npu-insts --npu-insts-name="$W/$2.insts.bin" \
+      --tmpdir="$W/work_$2" --output-dir="$W/work_$2" >/dev/null 2>&1
+  local elf="work_$2/elfs_main_core_0_2/elfs_main_core_0_2.elf"
+  local cdo="work_$2/cdo_main/main_aie_cdo_elfs.bin"
+  echo "--- $2 ---"
+  "$RE" -lW "$elf" | awk '/LOAD/ && $7=="RW" {printf "    segment: FileSiz %s  MemSiz %s\n", $5, $6}'
+  local n; n=$(grep -c -a "Linker: LLD" "$cdo" 2>/dev/null || true)
+  echo "    ELF .comment strings baked into the CDO: ${n:-0}"
+  if [ "${n:-0}" != "0" ]; then
+    echo "    >>> BUG: the configuration image carries ELF metadata that will be"
+    echo "        DMA'd into the tile where zero-initialised statics belong."
+  else
+    echo "    OK: no metadata leaked."
+  fi
+}
+
+run_variant bss_k.cc         bug
+run_variant bss_k_control.cc control


### PR DESCRIPTION
# aie-rt ELF loader reads out of bounds on mixed `.data`+`.bss` segments, corrupting zero-initialised statics

## Summary

`_XAie_LoadDataMemSection` in `third_party/aie-rt/driver/src/core/xaie_elfloader.c` writes `p_memsz` bytes starting from a `PT_LOAD` segment's file offset, but only substitutes a zeroed buffer when `p_filesz == 0`. For the ordinary **mixed** `data`+`bss` segment (`0 < p_filesz < p_memsz`) it reads `p_memsz - p_filesz` bytes **past the end of the segment's file contents** and DMAs whatever follows in the ELF image (`.comment`, `.symtab`, …) into tile data memory — exactly where zero-initialised statics are supposed to live.

This is silent. Kernels get plausible-but-wrong numerical results.

Reproducer branch: **`bss-mixed-segment-repro`**, `test/aiecc/bss_mixed_segment_repro/` (no hardware required).

## The defect

`third_party/aie-rt/driver/src/core/xaie_elfloader.c`, submodule `e2aca22` (line numbers for current `Xilinx/aie-rt` master in parentheses — the function is byte-identical apart from error-message strings):

```c
267 (266)  static AieRC _XAie_LoadDataMemSection(XAie_DevInst *DevInst, XAie_LocType Loc,
278 (277)      const unsigned char *Buffer = SectionPtr;   // = ElfMem + Phdr->p_offset
...
295 (294)      SectionSize = Phdr->p_memsz;                // <-- writes memsz bytes
298           /* Check if file size is 0. If yes, allocate memory and init to 0 */
299 (298)      if(Phdr->p_filesz == 0U) {
300 (299)          Buffer = (const unsigned char *)calloc(Phdr->p_memsz, sizeof(char));
308           }
310 (309)      while(SectionSize > 0U) {
...
345 (345)          RC = XAie_DataMemBlockWrite(DevInst, TgtLoc, (u32)Addr,
346                        (const void*)Buffer, BytesToWrite);
...
357 (358)          Buffer += BytesToWrite;                 // <-- walks past end of file data
358           }
```

and the caller, line 433-434 (434-435):

```c
433  if(Phdr->p_type == (u32)PT_LOAD) {
434      SectionPtr = ElfMem + Phdr->p_offset;
```

`Buffer` points into the ELF image and has only `p_filesz` valid bytes, but the loop writes `p_memsz`. Three cases exist; only two are handled:

| segment | handled? |
|---|---|
| pure data, `p_memsz == p_filesz` | yes |
| pure bss, `p_filesz == 0` | yes (the `calloc` path at line 299) |
| **mixed data+bss, `0 < p_filesz < p_memsz`** | **no — OOB read** |

## Why the mixed case is the normal case

Per the System V gABI (`man 5 elf`, `PT_LOAD`):

> "The bytes from the file are mapped to the beginning of the memory segment.
> **If the segment's memory size `p_memsz` is larger than the file size
> `p_filesz`, the "extra" bytes are defined to hold the value 0** and to follow
> the segment's initialized area. The file size may not be larger than the
> memory size."

That is *the* representation of `.bss` in a loadable image, and zeroing the gap is a requirement on the loader. Measured incidence:

| binaries | `PT_LOAD` with `memsz > filesz` |
|---|---|
| Chess-built AIE cores (27-core design) | 27 / 27 |
| Peano-built AIE cores (same design) | 25 / 27 |
| `/bin/ls`, `/bin/bash`, `/usr/bin/python3`, `/usr/bin/objdump` | 1 of 4 segments each |

## Reproducer

```bash
git checkout bss-mixed-segment-repro
export PEANO_INSTALL_DIR=/path/to/llvm-aie
export AIECC=/path/to/aiecc                     # optional if aiecc is on PATH
./test/aiecc/bss_mixed_segment_repro/run.sh /tmp/bssrepro
```

Output:

```
--- bug ---
    segment: FileSiz 0x01000  MemSiz 0x01200
    ELF .comment strings baked into the CDO: 1
    >>> BUG: the configuration image carries ELF metadata that will be
        DMA'd into the tile where zero-initialised statics belong.
--- control ---
    segment: FileSiz 0x00000  MemSiz 0x00200
    ELF .comment strings baked into the CDO: 0
    OK: no metadata leaked.
```

The kernel is 13 lines (`bss_k.cc`): a 4096-byte initialised array (forces `.data`, PROGBITS) plus `volatile uint8_t zero_state[512]` (`.bss`, NOBITS). The control drops the initialised array, so the linker emits a separate `p_filesz == 0` segment, which the `calloc` path handles correctly — isolating the trigger.

### Manual verification

```bash
W=/tmp/bssrepro/work_bug
llvm-readelf -lW $W/elfs_main_core_0_2/elfs_main_core_0_2.elf | grep LOAD
#   LOAD 0x0000a0 0x00000000 0x00000000 0x00210 0x00210 R E 0x10
#   LOAD 0x0002b0 0x00078004 0x00078004 0x01000 0x01200 RW  0x4     <-- filesz < memsz

llvm-readelf -S $W/elfs_main_core_0_2/elfs_main_core_0_2.elf | grep -E '\.data|\.comment|\.bss'
#   [ 2] .data    PROGBITS 00078004 0002b0 001000
#   [ 3] .comment PROGBITS 00000000 0012b0 0000c5     <-- at 0x2b0 + 0x1000
#   [ 8] .bss     NOBITS   00079004 0012b0 000200
```

The overrun source is segment offset `0x2b0` + `p_filesz` `0x1000` = `0x12b0`, which is `.comment`:

```bash
python3 -c "
elf=open('$W/elfs_main_core_0_2/elfs_main_core_0_2.elf','rb').read()
oob=elf[0x12b0:0x12b0+0x200]
print(oob[:56]); print('nonzero:', sum(1 for b in oob if b), '/512')"
# b'\x00Linker: LLD 21.0.0 (https://github.com/Xilinx/llvm-aie '
# nonzero: 280 /512
```

So `zero_state[512]`, which C++ guarantees is all-zero before first use ([basic.start.static]), is loaded with 280 nonzero bytes. Those bytes are then visible in the configuration image itself:

```bash
strings -n 8 $W/cdo_main/main_aie_cdo_elfs.bin | grep -E 'Linker|clang version'
# Linker: LLD 21.0.0 (https://github.com/Xilinx/llvm-aie c9c5ecb7...)
# clang version 21.0.0 (https://github.com/Xilinx/llvm-aie c9c5e...)
```

The predicted 32-byte pattern from the ELF is present in the CDO at offset `0x12b0`.

## Real-world impact

Found while porting a Gemma4 decode layer (27 cores, NPU2/AIE2P). The kernel keeps its double-buffer selectors in `.bss`:

```c
static bool is_ql_ping  = false;   // toggled each call
static bool is_ksc_ping = false;
```

Its `.bss` sat at `0x7f040`, and the overrun fed it the same `.comment` string. `is_ksc_ping` received `0x6b` = `'k'` (from `"Linker"`). The generated toggle is `(v ^ 1) & 1`, so **bit 0** selects the phase — `'k'` is odd, so the ping/pong phase was inverted for the entire run and every call read the stale buffer. Correct arithmetic on wrong data: the model answered "17 x 23" with **397** instead of 391, with prose that stayed fluent for ~70 characters before diverging. It took a long time to find precisely because nothing crashes.

Two confirmations from that design:

1. **Relinking the same object at nine different `.bss` addresses**, and
   predicting pass/fail purely from bit 0 of the two overrun bytes, matches
   hardware **9/9** (each verdict stable across 3 reruns):

   | `.bss` | ql | ksc | predicted | observed |
   |---|---|---|---|---|
   | 0x7f040 | 0x00 | 0x6b | FAIL | FAIL |
   | 0x7f060 | 0x68 | 0x63 | FAIL | FAIL |
   | 0x7f080 | 0x32 | 0x38 | PASS | PASS |
   | 0x7f0a0 | 0x29 | 0x61 | FAIL | FAIL |
   | 0x7f0c0 | 0x67 | 0x75 | FAIL | FAIL |
   | 0x7f100 | 0x61 | 0x00 | FAIL | FAIL |
   | 0x7f200 | 0x00 | 0x04 | PASS | PASS |
   | 0x7f400 | 0x00 | 0x10 | PASS | PASS |
   | 0x7f800 | 0x0d | 0x01 | FAIL | FAIL |

2. **Holding the address fixed and changing only initialisation.** Same address
   `0x7f040`, identical code, statics moved from `.bss` (NOBITS) into a custom
   `SHT_PROGBITS` section of zeros: `0/3` → `3/3` passing (3 runs each).

Ruled out along the way: timing/races (a spin loop swept 1 → 2,000,000, an 8× wall-clock change, moves nothing), alignment (`0x7f080` passes while the *more*-aligned `0x7f100` and `0x7f800` fail), overwrite by another core (no
design buffer on that tile is allocated above `0x0e040`), and compiler codegen (the kernels are bit-identical to Chess standalone).

## Affects both toolchains

This is not Peano-specific. Chess-built cores take the same loader path and 27/27 of them have mixed segments; Chess currently escapes only because the bytes trailing its data segment happen to be benign — its CDO does not contain
its own `.comment` string (`chess_separator`: 0 occurrences). It is luck, not correctness.

## Suggested fix

In `_XAie_LoadDataMemSection`, split the write at `p_filesz`: copy the real bytes, then write zeros for the remaining `p_memsz - p_filesz`. This restores the gABI guarantee and fixes both toolchains.

Note the current `p_filesz == 0` special case becomes redundant under a general split (it is just the degenerate case where the copy length is zero).

## Environment

- mlir-aie `2606526b`, `third_party/aie-rt` submodule `e2aca22` (2024-06-28)
- Upstream `Xilinx/aie-rt` master: `_XAie_LoadDataMemSection` is byte-identical
  apart from error-message strings, so the bug is **unfixed upstream**
- Peano / llvm-aie `c9c5ecb7` (clang 21.0.0)
- Chess: Vitis 2024.2 AIE Essentials
- Device: NPU2 / AIE2P (Ryzen AI 7 350)

## Not yet done

The suggested fix has not been built or tested. Only the ELF-side equivalent (materialising the statics as `SHT_PROGBITS` zeros) has been validated on hardware.