### PR TITLE
[aiecc] Keep the merged module's alignment when downgrading for Peano

### DIFF
--- a/test/aiecc/Inputs/peano_float_decimal_kernel.ll
+++ b/test/aiecc/Inputs/peano_float_decimal_kernel.ll
@@ -1,0 +1,47 @@
+; Copyright (C) 2026 Advanced Micro Devices, Inc.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; A merge-mode ("inline") kernel artifact carrying narrow float constants in
+; every position downgradeIRForPeano has to reason about. Owned by
+; peano_compat_float_decimal_merge.mlir.
+;
+; The merge linker reprints this module with aiecc's LLVM, which spells a
+; float/half constant as a short decimal whenever that decimal round-trips in
+; the narrow type -- a spelling Peano's older parser rejects. The constants are
+; written here in the hex form so the intent is fixed whatever a given LLVM
+; prints; the reprint is what introduces the decimals.
+;
+; The (ptr, ptr) signature is aiecc's bare-pointer memref calling convention.
+
+target triple = "aie2"
+
+; Typed position: a constant array, the shape the LUT in a real attention
+; kernel takes. 2.5 is exact as a double and must survive as printed.
+@lut_f = linkonce_odr global [4 x float] [float 0x400921FA00000000,
+                                          float 0x3FBC28F5C0000000,
+                                          float 0xBF6A8292A0000000,
+                                          float 2.500000e+00], align 4
+; Same, for half, which takes its own 16-bit hex form.
+@lut_h = linkonce_odr global [2 x half] [half 0xH2F0A, half 0xH4100], align 2
+
+define linkonce_odr void @merge_kernel(ptr %in, ptr %out) #0 {
+entry:
+  %x = load float, ptr %in, align 4
+  %l = load float, ptr @lut_f, align 4
+  %s = fadd float %x, %l
+  ; Bare operand position: the constant carries no type keyword of its own and
+  ; takes float from the instruction.
+  %r = fmul float %s, 0x3FBC28F5C0000000
+  ; Mixed-type line: the double must keep its decimal spelling, which Peano
+  ; accepts, rather than be rewritten under the float semantics named later on
+  ; the same line.
+  %d = fptrunc double 1.100000e-01 to float
+  %rd = fadd float %r, %d
+  %h = load half, ptr @lut_h, align 2
+  %hf = fpext half %h to float
+  %acc = fadd float %rd, %hf
+  store float %acc, ptr %out, align 4
+  ret void
+}
+
+attributes #0 = { alwaysinline }

--- a/test/aiecc/Inputs/peano_merge_intrinsics_kernel.ll
+++ b/test/aiecc/Inputs/peano_merge_intrinsics_kernel.ll
@@ -14,6 +14,9 @@
 ;     becomes llvm.fabs, a multiply-add llvm.fmuladd, a clamp smax/smin.
 ;   * llvm.lifetime.start/end carrying the size operand Peano requires and a
 ;     newer LLVM drops.
+;   * an over-aligned alloca and over-aligned accesses to it, whose alignment
+;     the post-link downgrade must not strip -- opt cannot re-derive it, and the
+;     core misbehaves without it.
 ;
 ; The (ptr, ptr) signature is aiecc's bare-pointer memref calling convention.
 
@@ -21,7 +24,7 @@ target triple = "aie2"
 
 define linkonce_odr void @merge_kernel(ptr %in, ptr %out) #0 {
 entry:
-  %scratch = alloca [4 x float], align 4
+  %scratch = alloca [4 x float], align 64
   call void @llvm.lifetime.start.p0(i64 16, ptr %scratch)
   br label %body
 
@@ -35,9 +38,11 @@ body:
   ; |v| * v + v staged through the local buffer: llvm.fabs / llvm.fmuladd.
   %v = sitofp i32 %clamped to float
   %mag = call float @llvm.fabs.f32(float %v)
+  ; Over-aligned, matching the alloca. ABI alignment for float is 4, so a
+  ; downgrade that strips these is observable: they come back as `align 4`.
   %slot = getelementptr inbounds [4 x float], ptr %scratch, i32 0, i32 0
-  store float %mag, ptr %slot, align 4
-  %mag.reloaded = load float, ptr %slot, align 4
+  store float %mag, ptr %slot, align 64
+  %mag.reloaded = load float, ptr %slot, align 64
   %acc = call float @llvm.fmuladd.f32(float %mag.reloaded, float %v, float %v)
   %res = fptosi float %acc to i32
   %out.ptr = getelementptr inbounds i32, ptr %out, i32 %i

--- a/test/aiecc/peano_compat_float_decimal.mlir
+++ b/test/aiecc/peano_compat_float_decimal.mlir
@@ -1,0 +1,65 @@
+//===- peano_compat_float_decimal.mlir - downgradeIRForPeano float -------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test: LLVM 24 prints a `float` constant as a short decimal
+// whenever that decimal round-trips in float; older LLVM required it to round
+// trip as a double and printed hex otherwise. Peano's opt still demands exact
+// representability and rejects the decimal with "floating point constant
+// invalid for type", so downgradeIRForPeano must rewrite it -- in the typed
+// position a constant array gives (`[4 x float] [float 3.141590e+00, ...]`)
+// and in the bare operand one an instruction gives (`fmul float %v,
+// 1.100000e-01`), where the type comes from the instruction.
+//
+// The whole peano path runs here, so Peano's own opt decides: drop the rewrite
+// and this fails at `opted_{0}.ll` with that error.
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: aiecc --tmpdir %t %s
+// RUN: FileCheck %s --input-file %t/peano-compat_main_core_0_2.ll \
+// RUN:   --implicit-check-not="float 3.141590e+00" \
+// RUN:   --implicit-check-not="float 1.100000e-01" \
+// RUN:   --implicit-check-not="float -3.236090e-03"
+
+// The exactly representable literals Peano already accepts stay decimal, so
+// the rewrite stays narrow.
+// CHECK-DAG: 0x400921FA00000000
+// CHECK-DAG: 0x3FBC28F5C0000000
+// CHECK-DAG: 0xBF6A8292A0000000
+// CHECK-DAG: 2.500000e+00
+
+module {
+  aie.device(npu2) {
+    %tile = aie.tile(0, 2)
+    %buf_in = aie.buffer(%tile) {sym_name = "in"} : memref<4xf32>
+    %buf_out = aie.buffer(%tile) {sym_name = "out"} : memref<4xf32>
+    // Typed position: an initialized constant array. 2.5 is exact as a double
+    // and must be left as printed; the other three are not.
+    %lut = aie.buffer(%tile) {
+      sym_name = "lut",
+      initial_value = dense<[3.141590e+00, 1.100000e-01, -3.236090e-03,
+                             2.500000e+00]> : tensor<4xf32>
+    } : memref<4xf32>
+
+    %core = aie.core(%tile) {
+      %c0 = arith.constant 0 : index
+      %c4 = arith.constant 4 : index
+      %c1 = arith.constant 1 : index
+      // Bare operand position: the constant carries no type keyword of its own.
+      %k = arith.constant 1.100000e-01 : f32
+      scf.for %i = %c0 to %c4 step %c1 {
+        %v = memref.load %buf_in[%i] : memref<4xf32>
+        %l = memref.load %lut[%i] : memref<4xf32>
+        %s = arith.addf %v, %l : f32
+        %r = arith.mulf %s, %k : f32
+        memref.store %r, %buf_out[%i] : memref<4xf32>
+      }
+      aie.end
+    }
+  }
+}

--- a/test/aiecc/peano_compat_float_decimal_merge.mlir
+++ b/test/aiecc/peano_compat_float_decimal_merge.mlir
@@ -1,0 +1,63 @@
+//===- peano_compat_float_decimal_merge.mlir - post-link float decimals --===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The merge is where a float constant crosses LLVM versions as text, so it is
+// where the LLVM 24 spelling of one bites: the linker reprints the kernel with
+// aiecc's LLVM, which writes a float/half constant as a short decimal whenever
+// that decimal round-trips in the narrow type, and Peano's parser -- which
+// still demands exact representability -- rejects it with "floating point
+// constant invalid for type". This is the failure a fused-decode attention
+// kernel hit on its exp2 lookup table.
+//
+// downgradeIRForPeano runs again after the link for exactly this reason, so
+// check its output covers every position the constants appear in.
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: aiecc --tmpdir %t %s
+// RUN: FileCheck %s --input-file %t/peano-linked_main_core_0_2.ll \
+// RUN:   --implicit-check-not="float 3.141590e+00" \
+// RUN:   --implicit-check-not="float 1.100000e-01" \
+// RUN:   --implicit-check-not="float -3.236090e-03" \
+// RUN:   --implicit-check-not="half 1.099850e-01" \
+// RUN:   --implicit-check-not=", 1.100000e-01"
+
+// Typed array: the three inexact literals in hex, the exact one untouched.
+// CHECK-DAG: 0x400921FA00000000
+// CHECK-DAG: 0xBF6A8292A0000000
+// CHECK-DAG: float 2.500000e+00
+// Bare operand, taking float from the instruction.
+// CHECK-DAG: fmul float %{{.*}}, 0x3FBC28F5C0000000
+// Half takes its own 16-bit form; the exact one is left alone.
+// CHECK-DAG: half 0xH2F0A
+// CHECK-DAG: half 2.500000e+00
+// A double on a float-typed line keeps the spelling Peano accepts.
+// CHECK-DAG: fptrunc double 1.100000e-01
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xf32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xf32>>
+
+    func.func private @merge_kernel(memref<16xf32>, memref<16xf32>) attributes {link_with = "Inputs/peano_float_decimal_kernel.ll", link_with_mode = "merge"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %subview_in = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<16xf32>>
+      %elem_in = aie.objectfifo.subview.access %subview_in[0] : !aie.objectfifosubview<memref<16xf32>> -> memref<16xf32>
+      %subview_out = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<16xf32>>
+      %elem_out = aie.objectfifo.subview.access %subview_out[0] : !aie.objectfifosubview<memref<16xf32>> -> memref<16xf32>
+      func.call @merge_kernel(%elem_in, %elem_out) : (memref<16xf32>, memref<16xf32>) -> ()
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+  }
+}

--- a/test/aiecc/peano_compat_merge_link.mlir
+++ b/test/aiecc/peano_compat_merge_link.mlir
@@ -20,7 +20,7 @@
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: aiecc --tmpdir %t %s
-// RUN: FileCheck %s --check-prefix=LINKED --input-file %t/peano-linked_main_core_0_2.ll --implicit-check-not=nocreateundeforpoison --implicit-check-not=", align "
+// RUN: FileCheck %s --check-prefix=LINKED --input-file %t/peano-linked_main_core_0_2.ll --implicit-check-not=nocreateundeforpoison
 // RUN: FileCheck %s --check-prefix=OPTED --input-file %t/opted_main_core_0_2.ll --implicit-check-not=@merge_kernel
 
 // The kernel arrived, and the merged text is back in a dialect Peano parses: no
@@ -32,6 +32,16 @@
 // LINKED-DAG: call void @llvm.lifetime.end.p0(i64 -1,
 // LINKED-DAG: declare void @llvm.lifetime.start.p0(i64 immarg,
 // LINKED-DAG: declare void @llvm.lifetime.end.p0(i64 immarg,
+
+// The merged module keeps its `align`, unlike the pre-link downgrade (see
+// peano_compat_align_strip.mlir). Stripping it here demotes the kernel's
+// over-aligned scratch buffer to the type's ABI alignment (64 -> 4) and drops
+// the load/store alignment the kernel was compiled against, which miscompiles
+// the core: an inline attention kernel built that way hangs its tile. Both
+// halves are pinned -- exempting only the alloca still miscompiles it.
+// LINKED-DAG: alloca [4 x float], align 64
+// LINKED-DAG: store float %{{.*}}, ptr %{{.*}}, align 64
+// LINKED-DAG: load float, ptr %{{.*}}, align 64
 
 // Peano's opt then folds the alwaysinline kernel in and dead-strips the
 // linkonce_odr definition: no `@merge_kernel` survives (--implicit-check-not

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -257,7 +257,8 @@ patchCoreElfFiles(mlir::ModuleOp src,
 //===----------------------------------------------------------------------===//
 
 // Strip LLVM-23-only features Peano's older opt/llc can't parse.
-inline std::string downgradeIRForPeano(llvm::StringRef ir) {
+inline std::string downgradeIRForPeano(llvm::StringRef ir,
+                                       bool stripAlign = true) {
   std::string result = ir.str();
   auto erasePattern = [&](llvm::StringRef pat, auto trail) {
     for (size_t p = 0; (p = result.find(pat.str(), p)) != std::string::npos;) {
@@ -374,10 +375,12 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
   // program memory and overflowing AIE core memory. Do not remove without
   // confirming the i8 matmul still fits program memory.
   //
-  // Applies after the merge too: llvm-link reprints the module and reintroduces
-  // `align` (with ABI defaults) on the very instructions this stripped before
-  // linking, so a merged core would otherwise reach opt fully annotated.
-  {
+  // Pre-link only. The merged module keeps its `align`: the kernel arrives
+  // already annotated by its own clang, and re-stripping demotes an
+  // over-aligned alloca to the type's ABI alignment (an `aie::linear_approx`
+  // LUT falls from 64 to 4) and drops the load/store alignment the kernel was
+  // compiled against, which miscompiles the core.
+  if (stripAlign) {
     const std::string alignPat = ", align ";
     size_t pos = 0;
     while ((pos = result.find(alignPat, pos)) != std::string::npos) {

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -41,6 +41,7 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -434,6 +435,134 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
         pos = hexEnd;
       }
     }
+  }
+  // LLVM 24 prints a 'float'/'half' constant as a short decimal whenever that
+  // decimal round-trips in the *narrow* type; older LLVM required it to round
+  // trip as a double and printed hex otherwise. Peano's parser still demands
+  // exact representability, so it rejects what LLVM 24 prints ("floating point
+  // constant invalid for type") in both the typed position ('float
+  // 1.100000e-01') and the bare operand one ('fmul float %x, 1.100000e-01').
+  //
+  // A bare operand takes its type from the instruction, so tokenize and track
+  // the last type keyword seen on the line. That also keeps a mixed-type line
+  // ('call void @f(float 1.1, double 2.2)') from being rewritten under the
+  // wrong semantics. 'bfloat' and 'double' set the type but are left alone:
+  // double decimals always round-trip, and bfloat is handled below.
+  {
+    enum class FPTy { None, Float, Half };
+    std::string out;
+    out.reserve(result.size());
+    FPTy lineTy = FPTy::None;
+    size_t i = 0;
+    auto isNameChar = [](char c) {
+      return std::isalnum(static_cast<unsigned char>(c)) || c == '_' ||
+             c == '.' || c == '$' || c == '-';
+    };
+    while (i < result.size()) {
+      char c = result[i];
+      if (c == '\n') {
+        lineTy = FPTy::None;
+        out += c;
+        ++i;
+        continue;
+      }
+      // Copy quoted strings verbatim: they can hold anything that looks like a
+      // literal (a version string, an escaped byte array).
+      if (c == '"') {
+        size_t end = result.find('"', i + 1);
+        end = (end == std::string::npos) ? result.size() : end + 1;
+        out.append(result, i, end - i);
+        i = end;
+        continue;
+      }
+      // Names (%v, @g, !12) and keywords are consumed whole, so a digit inside
+      // one is never mistaken for a constant, and 'bfloat' never matches as
+      // 'float'.
+      if (c == '%' || c == '@' || c == '!' || c == '#' ||
+          std::isalpha(static_cast<unsigned char>(c)) || c == '_') {
+        size_t end = i + 1;
+        while (end < result.size() && isNameChar(result[end]))
+          ++end;
+        llvm::StringRef word(result.data() + i, end - i);
+        if (word == "float")
+          lineTy = FPTy::Float;
+        else if (word == "half")
+          lineTy = FPTy::Half;
+        else if (word == "bfloat" || word == "double")
+          lineTy = FPTy::None;
+        out.append(result, i, end - i);
+        i = end;
+        continue;
+      }
+      bool isNumStart =
+          std::isdigit(static_cast<unsigned char>(c)) ||
+          ((c == '-' || c == '+') && i + 1 < result.size() &&
+           std::isdigit(static_cast<unsigned char>(result[i + 1])));
+      if (!isNumStart) {
+        out += c;
+        ++i;
+        continue;
+      }
+      size_t end = i + 1;
+      while (end < result.size() &&
+             (std::isalnum(static_cast<unsigned char>(result[end])) ||
+              result[end] == '.' ||
+              ((result[end] == '+' || result[end] == '-') &&
+               (result[end - 1] == 'e' || result[end - 1] == 'E'))))
+        ++end;
+      llvm::StringRef num(result.data() + i, end - i);
+      // Only decimals are at risk; the hex forms already say exactly what they
+      // mean, and an integer is not a float constant.
+      bool isDecimal =
+          num.contains('.') || num.contains('e') || num.contains('E');
+      if (lineTy == FPTy::None || !isDecimal || num.starts_with("0x")) {
+        out.append(num.data(), num.size());
+        i = end;
+        continue;
+      }
+      const llvm::fltSemantics &sem = lineTy == FPTy::Half
+                                          ? llvm::APFloat::IEEEhalf()
+                                          : llvm::APFloat::IEEEsingle();
+      llvm::APFloat val(llvm::APFloat::IEEEdouble());
+      auto parsed =
+          val.convertFromString(num, llvm::APFloat::rmNearestTiesToEven);
+      if (!parsed) {
+        llvm::consumeError(parsed.takeError());
+        out.append(num.data(), num.size());
+        i = end;
+        continue;
+      }
+      bool lost = false;
+      llvm::APFloat narrow = val;
+      narrow.convert(sem, llvm::APFloat::rmNearestTiesToEven, &lost);
+      if (!lost) {
+        // Exactly representable, so Peano accepts the decimal as printed.
+        out.append(num.data(), num.size());
+        i = end;
+        continue;
+      }
+      // 'half' takes its own 16-bit hex form; 'float' is spelled as the double
+      // it widens to.
+      uint64_t bits;
+      int digits;
+      if (lineTy == FPTy::Half) {
+        out += "0xH";
+        bits = narrow.bitcastToAPInt().getZExtValue();
+        digits = 4;
+      } else {
+        bool ignored = false;
+        llvm::APFloat wide = narrow;
+        wide.convert(llvm::APFloat::IEEEdouble(),
+                     llvm::APFloat::rmNearestTiesToEven, &ignored);
+        out += "0x";
+        bits = wide.bitcastToAPInt().getZExtValue();
+        digits = 16;
+      }
+      for (int shift = (digits - 1) * 4; shift >= 0; shift -= 4)
+        out += "0123456789ABCDEF"[(bits >> shift) & 0xFu];
+      i = end;
+    }
+    result = std::move(out);
   }
   // Rewrite decimal bfloat16 literals ('bfloat N.NNe+NN', an LLVM 23 printing
   // form) to the bit-exact '0xR<4hex>' form Peano's older LLVM only accepts.

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -181,7 +181,9 @@ buildObjectSubgraph(EdgeWithTypedOutput<ModRef> &lowered,
       .input()
       .output("-o");
   auto &peanoCompat =
-      llvmIR.map<std::string>("peano-compat_{0}.ll", downgradeIRForPeano);
+      llvmIR.map<std::string>("peano-compat_{0}.ll", [](llvm::StringRef ir) {
+        return downgradeIRForPeano(ir);
+      });
   // Merge the core's merge-mode link artifacts (`link_merge_files`) into the
   // downgraded core IR before opt; with the kernel marked alwaysinline that
   // inlines its body into the core, leaving no func.call and no separate kernel
@@ -262,7 +264,7 @@ buildObjectSubgraph(EdgeWithTypedOutput<ModRef> &lowered,
                                << out.filePath << "': " << ec.message() << "\n";
                   return mlir::failure();
                 }
-                os << downgradeIRForPeano(merged);
+                os << downgradeIRForPeano(merged, /*stripAlign=*/false);
                 out.value = File{};
                 return mlir::success();
               })


### PR DESCRIPTION
> Stacked on #3528 — that PR's commit is the parent here, so review only the second commit. Rebase to `main` once #3528 lands.

## Problem

`downgradeIRForPeano` strips `, align N`. That was introduced pre-link, where the rationale still holds (retaining `align` made Peano's capped-O1 opt skip vectorizing the matmul K-loop). #3493 moved the kernel merge in-process and ran the same downgrade **again on the merged module** — and there the strip is destructive.

An `alloca`'s alignment is not an annotation opt can re-derive. Once the text is gone, re-parsing gives the type's ABI alignment, so an over-aligned stack object is silently demoted:

```llvm
-  %lin_aprox = alloca %"struct.aie::linear_approx", align 64
+  %lin_aprox = alloca %"struct.aie::linear_approx", align 4
```

`aie::linear_approx` is the LUT helper behind the softmax `exp` in an inline attention kernel. At 4-byte alignment the core misbehaves and the tile hangs — an NPU decode wedged with `ERT_CMD_STATE_TIMEOUT` after a handful of tokens. Before #3493 the kernel was merged by an external `llvm-link` and never re-downgraded, so its alignment survived.

## Fix

Strip pre-link only. The merged module keeps its `align`: the kernel arrives already annotated by its own clang, and the core module was stripped before the merge, so the vectorization rationale is unaffected.

I first tried the narrower fix of exempting only `alloca` and continuing to strip loads/stores. It is **not** sufficient — the model still failed its numerical gate (1 of 2 prompts), because the merged kernel also depends on the load/store alignment it was compiled against. Hence the whole post-link strip goes.

## Validation

Two AMD NPU2 LLM decode models that hung with this defect now pass their top-k-vs-HF-bf16 gate (`topk_passed: 2, topk_failed: 0` each) on the pinned toolchain:

| model | before | after |
|---|---|---|
| `llama32_1b_q4nx` | `decode dispatch pos7 ERT_CMD_STATE_TIMEOUT` | PASS |
| `llama32_3b_q4nx` | same | PASS |

Localized by A/B against the pre-#3493 toolchain: identical `input_physical.mlir`, identical instruction histograms, and of 27 cores only the 8 merge-mode ones differed in their object/ELF — with this single alignment line as the only semantic difference. Swapping just the pre-#3493 xclbin into an otherwise post-bump run also passes, confirming the defect is in the core code and not the instruction stream.

Keeping the alignment also produces **smaller** code here: the attention core ELF drops from 11512 to 9444 bytes (176KB vs 193KB across all cores).

## Tests

`peano_compat_merge_link.mlir` asserted `--implicit-check-not=", align "` on the merged module — precisely the behaviour that has to go — so it now pins the alignment instead, and its kernel's scratch buffer is over-aligned to make the demotion observable. Verified the new assertion fails against an unpatched `aiecc` (`LINKED-DAG: alloca [4 x float], align 64` — expected string not found) and passes with the fix. All 8 `peano_compat_*` tests pass, including `peano_compat_align_strip.mlir`, which covers the pre-link strip that is retained.

One residual risk worth a reviewer's eye: the merged module now reaches opt with the ABI-default `align` that the reprint adds back to *core* instructions. That did not regress program memory in my workload (it shrank), but the i8 matmul the original note names is the case to sanity-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)