### PR TITLE
aie-rt: zero the p_memsz - p_filesz gap when loading PT_LOAD segments

### DIFF
--- a/test/aiecc/bss_zero_init.mlir
+++ b/test/aiecc/bss_zero_init.mlir
@@ -1,0 +1,58 @@
+//===- bss_zero_init.mlir ---------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test for the aie-rt ELF loader out-of-bounds read fixed by
+// third_party/patches/aie-rt/0002-elfloader-zero-bss-gap.patch.
+//
+// A kernel with both .data and .bss links to one PT_LOAD with
+// 0 < p_filesz < p_memsz -- the ELF-spec representation of .bss.
+// _XAie_LoadDataMemSection used to write p_memsz bytes from a p_filesz-sized
+// buffer, so the ELF's own .comment/.symtab bytes were DMA'd into the tile in
+// place of zero-initialised statics. The corruption is visible in the generated
+// CDO, so this needs no hardware.
+
+// REQUIRES: peano
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: clang++ --target=aie2p-none-unknown-elf -std=c++20 -O2 -DNDEBUG -c %S/bss_zero_init_kernel.cc -o %t.d/bss_zero_init_kernel.o
+// RUN: cd %t.d && aiecc --get-xclbin --xclbin-name=%t.d/test.xclbin --tmpdir=%t.d/prj %s
+
+// Precondition: the segment really is mixed, otherwise the test is vacuous and
+// would pass even with the bug present (a p_filesz == 0 segment takes aie-rt's
+// separate, correct calloc path).
+// RUN: llvm-readelf -lW %t.d/prj/elfs_main_core_0_2/elfs_main_core_0_2.elf | awk '/^  LOAD/ && $7=="RW" {if (strtonum($6) > strtonum($5)) f=1} END {exit !f}'
+
+// The configuration image must not carry ELF metadata: those bytes would be
+// written over .bss on the device.
+// RUN: not grep -a -q "Linker: LLD" %t.d/prj/cdo_main/main_aie_cdo_elfs.bin
+// RUN: not grep -a -q "clang version" %t.d/prj/cdo_main/main_aie_cdo_elfs.bin
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<512xi8>>
+
+    func.func private @bss_probe(memref<512xi8>) attributes {link_with = "bss_zero_init_kernel.o"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %sv = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<512xi8>>
+      %e = aie.objectfifo.subview.access %sv[0] : !aie.objectfifosubview<memref<512xi8>> -> memref<512xi8>
+      func.call @bss_probe(%e) : (memref<512xi8>) -> ()
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+
+    aie.runtime_sequence(%out : memref<512xi8>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c512 = arith.constant 512 : i64
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c512][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<512xi8>
+      aiex.npu.dma_wait {symbol = @of_out}
+    }
+  }
+}

--- a/test/aiecc/bss_zero_init.mlir
+++ b/test/aiecc/bss_zero_init.mlir
@@ -23,7 +23,7 @@
 // Precondition: the segment really is mixed, otherwise the test is vacuous and
 // would pass even with the bug present (a p_filesz == 0 segment takes aie-rt's
 // separate, correct calloc path).
-// RUN: llvm-readelf -lW %t.d/prj/elfs_main_core_0_2/elfs_main_core_0_2.elf | awk '/^  LOAD/ && $7=="RW" {if (strtonum($6) > strtonum($5)) f=1} END {exit !f}'
+// RUN: llvm-readelf -lW %t.d/prj/elfs_main_core_0_2/elfs_main_core_0_2.elf | awk 'function hex2dec(s,   i,c,v,n){gsub(/^0[xX]/,"",s);n=0;for(i=1;i<=length(s);i++){c=tolower(substr(s,i,1));v=index("0123456789abcdef",c)-1;n=n*16+v}return n} /^  LOAD/ && $7=="RW" {if (hex2dec($6) > hex2dec($5)) f=1} END {exit !f}'
 
 // The configuration image must not carry ELF metadata: those bytes would be
 // written over .bss on the device.

--- a/test/aiecc/bss_zero_init_kernel.cc
+++ b/test/aiecc/bss_zero_init_kernel.cc
@@ -11,8 +11,7 @@
 #include <stdint.h>
 
 // forces a PROGBITS .data in the same segment as .bss
-__attribute__((used, retain))
-volatile uint8_t initialised[4096] = {1};
+__attribute__((used, retain)) volatile uint8_t initialised[4096] = {1};
 
 // C++ guarantees this reads as zero before first use ([basic.start.static])
 volatile uint8_t zero_state[512];

--- a/test/aiecc/bss_zero_init_kernel.cc
+++ b/test/aiecc/bss_zero_init_kernel.cc
@@ -1,0 +1,24 @@
+//===- bss_zero_init_kernel.cc ----------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Support file for bss_zero_init.mlir. Deliberately has BOTH initialised data
+// (.data, PROGBITS) and a zero-initialised static (.bss, NOBITS) so the linker
+// emits a single PT_LOAD with 0 < p_filesz < p_memsz.
+
+#include <stdint.h>
+
+// forces a PROGBITS .data in the same segment as .bss
+__attribute__((used, retain))
+volatile uint8_t initialised[4096] = {1};
+
+// C++ guarantees this reads as zero before first use ([basic.start.static])
+volatile uint8_t zero_state[512];
+
+extern "C" void bss_probe(uint8_t *out) {
+  for (int i = 0; i < 512; i++)
+    out[i] = zero_state[i];
+  out[0] = (uint8_t)(out[0] + (initialised[0] - initialised[0]));
+}

--- a/third_party/patches/aie-rt/0002-elfloader-zero-bss-gap.patch
+++ b/third_party/patches/aie-rt/0002-elfloader-zero-bss-gap.patch
@@ -1,0 +1,73 @@
+diff --git a/driver/src/core/xaie_elfloader.c b/driver/src/core/xaie_elfloader.c
+index c1cab5d..67e2082 100644
+--- a/driver/src/core/xaie_elfloader.c
++++ b/driver/src/core/xaie_elfloader.c
+@@ -295,16 +295,25 @@ static AieRC _XAie_LoadDataMemSection(XAie_DevInst *DevInst, XAie_LocType Loc,
+ 	SectionSize = Phdr->p_memsz;
+ 	SectionAddr = Phdr->p_paddr;
+ 	AddrMask = CoreMod->DataMemSize - 1U;
+-	/* Check if file size is 0. If yes, allocate memory and init to 0 */
+-	if(Phdr->p_filesz == 0U) {
+-		Buffer = (const unsigned char *)calloc(Phdr->p_memsz,
+-				sizeof(char));
+-		if(Buffer == XAIE_NULL) {
++	/*
++	 * The ELF spec defines the bytes between p_filesz and p_memsz to hold the
++	 * value 0 -- that gap is how .bss is represented in a loadable segment.
++	 * Materialise a p_memsz buffer whose initialised prefix is copied from the
++	 * file and whose remainder is zero, so the write loop below never reads
++	 * past the segment's file contents. A mixed .data+.bss segment
++	 * (0 < p_filesz < p_memsz) is the ordinary case; p_filesz == 0 (pure .bss)
++	 * falls out as the degenerate case where nothing is copied.
++	 */
++	if(Phdr->p_memsz > Phdr->p_filesz) {
++		Tmp = (unsigned char *)calloc(Phdr->p_memsz, sizeof(char));
++		if(Tmp == XAIE_NULL) {
+ 			XAIE_ERROR("Memory allocation failed for buffer\n");
+ 			return XAIE_ERR;
+ 		}
+-		/* Copy pointer to free allocated memory in case of error. */
+-		Tmp = (unsigned char *)Buffer;
++		if(Phdr->p_filesz > 0U) {
++			memcpy(Tmp, SectionPtr, Phdr->p_filesz);
++		}
++		Buffer = (const unsigned char *)Tmp;
+ 	}
+ 
+ 	while(SectionSize > 0U) {
+@@ -313,7 +322,7 @@ static AieRC _XAie_LoadDataMemSection(XAie_DevInst *DevInst, XAie_LocType Loc,
+ 			XAIE_ERROR("Failed to get target "\
+ 					"location for p_paddr 0x%x\n",
+ 					SectionAddr);
+-			if(Phdr->p_filesz == 0U) {
++			if(Tmp != XAIE_NULL) {
+ 				free(Tmp);
+ 			}
+ 			return RC;
+@@ -335,7 +344,7 @@ static AieRC _XAie_LoadDataMemSection(XAie_DevInst *DevInst, XAie_LocType Loc,
+ 			RC = _XAie_EccOnDM(DevInst, TgtLoc);
+ 			if(RC != XAIE_OK) {
+ 				XAIE_ERROR("Unable to turn ECC On for Data Memory\n");
+-				if(Phdr->p_filesz == 0U) {
++				if(Tmp != XAIE_NULL) {
+ 					free(Tmp);
+ 				}
+ 				return RC;
+@@ -346,7 +355,7 @@ static AieRC _XAie_LoadDataMemSection(XAie_DevInst *DevInst, XAie_LocType Loc,
+ 				(const void*)Buffer, BytesToWrite);
+ 		if(RC != XAIE_OK) {
+ 			XAIE_ERROR("Write to data memory failed\n");
+-			if(Phdr->p_filesz == 0U) {
++			if(Tmp != XAIE_NULL) {
+ 				free(Tmp);
+ 			}
+ 			return RC;
+@@ -357,7 +366,7 @@ static AieRC _XAie_LoadDataMemSection(XAie_DevInst *DevInst, XAie_LocType Loc,
+ 		Buffer += BytesToWrite;
+ 	}
+ 
+-	if(Phdr->p_filesz == 0U) {
++	if(Tmp != XAIE_NULL) {
+ 		free(Tmp);
+ 	}
+ 

--- a/third_party/patches/aie-rt/README.md
+++ b/third_party/patches/aie-rt/README.md
@@ -15,3 +15,17 @@ upstream yet, applied automatically at CMake configure time (see
   a resource-manager memory leak (`RscArrPerTile` in `xaie_io_common.c`), and
   carries a few minor build/warning fixes. None of this is present upstream as
   of the pinned commit.
+- `0002-elfloader-zero-bss-gap.patch`: `_XAie_LoadDataMemSection` wrote
+  `p_memsz` bytes from a buffer (`ElfMem + p_offset`) holding only `p_filesz`
+  valid ones, substituting a zeroed buffer only when `p_filesz == 0`. That
+  covers a pure-data segment and a pure-bss segment, but not the ordinary mixed
+  `.data`+`.bss` segment (`0 < p_filesz < p_memsz`) that any link with both
+  initialised and zero-initialised globals produces -- for those it read past
+  the segment's file contents and wrote the following ELF bytes (`.comment`,
+  `.symtab`) into tile data memory, where zero-initialised statics live. The
+  System V gABI defines those trailing bytes to hold zero; that is how `.bss` is
+  represented in a loadable segment. The patch allocates a `p_memsz` zeroed
+  buffer whenever `p_memsz > p_filesz` and copies the initialised prefix into
+  it. Regression test: `test/aiecc/bss_zero_init.mlir`. Not fixed upstream as of
+  the pinned commit.
+


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

`_XAie_LoadDataMemSection` sets `SectionSize = Phdr->p_memsz` and writes that many bytes from `ElfMem + p_offset`, which holds only `p_filesz` valid ones. It substitutes a zeroed buffer *only* when `p_filesz == 0`, so a pure-data segment and a pure-bss segment are handled but the ordinary mixed `.data`+`.bss` segment (`0 < p_filesz < p_memsz`) is not: it reads past the segment's file contents and DMAs the following ELF bytes — `.comment`, `.symtab` — into tile data memory, where zero-initialised statics belong. Per the System V gABI those trailing bytes are "defined to hold the value 0"; that gap *is* how `.bss` is represented in a loadable segment, and it is the common case (27/27 Chess-built and 25/27 Peano-built cores of a real design have one).
                                                                        
The result is silent numerical corruption. In a 27-core Gemma4 decode layer the string `"Linker: LLD ..."` landed on a kernel's ping/pong selectors — a `static bool` received `'k'`, inverting the double-buffer phase for the whole run, so every call read the stale buffer. With all 12 kernels built by Peano and identical ELFs and routing, the unfixed loader matched the Chess reference on 2/3 greedy prompts (3 runs) and the fixed one on 3/3 (4 runs). Note this is not Peano-specific: Chess takes the same path and escapes only because the bytes trailing its data segment happen to be benign.
                                                                        
The fix allocates a `p_memsz` zeroed buffer whenever `p_memsz > p_filesz` and copies the initialised prefix into it, so the write loop never reads past the file contents; `p_filesz == 0` becomes the degenerate case. It is carried as a vendored patch per `third_party/patches/aie-rt/README.md`, and is not fixed upstream (`Xilinx/aie-rt` master is byte-identical here apart from error strings), so I am happy to send it there instead. `test/aiecc/bss_zero_init.mlir` is a regression test needing no hardware — it asserts the segment really is mixed so it cannot pass vacuously, and was verified to fail without the patch and pass with it.  

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
