### PR TITLE
[aiecc] Keep the merged module's alignment when downgrading for Peano

### DIFF
--- a/test/aiecc/Inputs/peano_merge_intrinsics_kernel.ll
+++ b/test/aiecc/Inputs/peano_merge_intrinsics_kernel.ll
@@ -14,6 +14,9 @@
 ;     becomes llvm.fabs, a multiply-add llvm.fmuladd, a clamp smax/smin.
 ;   * llvm.lifetime.start/end carrying the size operand Peano requires and a
 ;     newer LLVM drops.
+;   * an over-aligned alloca and over-aligned accesses to it, whose alignment
+;     the post-link downgrade must not strip -- opt cannot re-derive it, and the
+;     core misbehaves without it.
 ;
 ; The (ptr, ptr) signature is aiecc's bare-pointer memref calling convention.
 
@@ -21,7 +24,7 @@ target triple = "aie2"
 
 define linkonce_odr void @merge_kernel(ptr %in, ptr %out) #0 {
 entry:
-  %scratch = alloca [4 x float], align 4
+  %scratch = alloca [4 x float], align 64
   call void @llvm.lifetime.start.p0(i64 16, ptr %scratch)
   br label %body
 
@@ -35,9 +38,11 @@ body:
   ; |v| * v + v staged through the local buffer: llvm.fabs / llvm.fmuladd.
   %v = sitofp i32 %clamped to float
   %mag = call float @llvm.fabs.f32(float %v)
+  ; Over-aligned, matching the alloca. ABI alignment for float is 4, so a
+  ; downgrade that strips these is observable: they come back as `align 4`.
   %slot = getelementptr inbounds [4 x float], ptr %scratch, i32 0, i32 0
-  store float %mag, ptr %slot, align 4
-  %mag.reloaded = load float, ptr %slot, align 4
+  store float %mag, ptr %slot, align 64
+  %mag.reloaded = load float, ptr %slot, align 64
   %acc = call float @llvm.fmuladd.f32(float %mag.reloaded, float %v, float %v)
   %res = fptosi float %acc to i32
   %out.ptr = getelementptr inbounds i32, ptr %out, i32 %i

--- a/test/aiecc/peano_compat_merge_link.mlir
+++ b/test/aiecc/peano_compat_merge_link.mlir
@@ -20,7 +20,7 @@
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: aiecc --tmpdir %t %s
-// RUN: FileCheck %s --check-prefix=LINKED --input-file %t/peano-linked_main_core_0_2.ll --implicit-check-not=nocreateundeforpoison --implicit-check-not=", align "
+// RUN: FileCheck %s --check-prefix=LINKED --input-file %t/peano-linked_main_core_0_2.ll --implicit-check-not=nocreateundeforpoison
 // RUN: FileCheck %s --check-prefix=OPTED --input-file %t/opted_main_core_0_2.ll --implicit-check-not=@merge_kernel
 
 // The kernel arrived, and the merged text is back in a dialect Peano parses: no
@@ -32,6 +32,16 @@
 // LINKED-DAG: call void @llvm.lifetime.end.p0(i64 -1,
 // LINKED-DAG: declare void @llvm.lifetime.start.p0(i64 immarg,
 // LINKED-DAG: declare void @llvm.lifetime.end.p0(i64 immarg,
+
+// The merged module keeps its `align`, unlike the pre-link downgrade (see
+// peano_compat_align_strip.mlir). Stripping it here demotes the kernel's
+// over-aligned scratch buffer to the type's ABI alignment (64 -> 4) and drops
+// the load/store alignment the kernel was compiled against, which miscompiles
+// the core: an inline attention kernel built that way hangs its tile. Both
+// halves are pinned -- exempting only the alloca still miscompiles it.
+// LINKED-DAG: alloca [4 x float], align 64
+// LINKED-DAG: store float %{{.*}}, ptr %{{.*}}, align 64
+// LINKED-DAG: load float, ptr %{{.*}}, align 64
 
 // Peano's opt then folds the alwaysinline kernel in and dead-strips the
 // linkonce_odr definition: no `@merge_kernel` survives (--implicit-check-not

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -256,7 +256,8 @@ patchCoreElfFiles(mlir::ModuleOp src,
 //===----------------------------------------------------------------------===//
 
 // Strip LLVM-23-only features Peano's older opt/llc can't parse.
-inline std::string downgradeIRForPeano(llvm::StringRef ir) {
+inline std::string downgradeIRForPeano(llvm::StringRef ir,
+                                       bool stripAlign = true) {
   std::string result = ir.str();
   auto erasePattern = [&](llvm::StringRef pat, auto trail) {
     for (size_t p = 0; (p = result.find(pat.str(), p)) != std::string::npos;) {
@@ -373,10 +374,12 @@ inline std::string downgradeIRForPeano(llvm::StringRef ir) {
   // program memory and overflowing AIE core memory. Do not remove without
   // confirming the i8 matmul still fits program memory.
   //
-  // Applies after the merge too: llvm-link reprints the module and reintroduces
-  // `align` (with ABI defaults) on the very instructions this stripped before
-  // linking, so a merged core would otherwise reach opt fully annotated.
-  {
+  // Pre-link only. The merged module keeps its `align`: the kernel arrives
+  // already annotated by its own clang, and re-stripping demotes an
+  // over-aligned alloca to the type's ABI alignment (an `aie::linear_approx`
+  // LUT falls from 64 to 4) and drops the load/store alignment the kernel was
+  // compiled against, which miscompiles the core.
+  if (stripAlign) {
     const std::string alignPat = ", align ";
     size_t pos = 0;
     while ((pos = result.find(alignPat, pos)) != std::string::npos) {

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -181,7 +181,9 @@ buildObjectSubgraph(EdgeWithTypedOutput<ModRef> &lowered,
       .input()
       .output("-o");
   auto &peanoCompat =
-      llvmIR.map<std::string>("peano-compat_{0}.ll", downgradeIRForPeano);
+      llvmIR.map<std::string>("peano-compat_{0}.ll", [](llvm::StringRef ir) {
+        return downgradeIRForPeano(ir);
+      });
   // Merge the core's merge-mode link artifacts (`link_merge_files`) into the
   // downgraded core IR before opt; with the kernel marked alwaysinline that
   // inlines its body into the core, leaving no func.call and no separate kernel
@@ -262,7 +264,7 @@ buildObjectSubgraph(EdgeWithTypedOutput<ModRef> &lowered,
                                << out.filePath << "': " << ec.message() << "\n";
                   return mlir::failure();
                 }
-                os << downgradeIRForPeano(merged);
+                os << downgradeIRForPeano(merged, /*stripAlign=*/false);
                 out.value = File{};
                 return mlir::success();
               })


### PR DESCRIPTION
## Problem

`downgradeIRForPeano` strips `, align N`. That was introduced pre-link, where the rationale still holds (retaining `align` made Peano's capped-O1 opt skip vectorizing the matmul K-loop). #3493 moved the kernel merge in-process and ran the same downgrade **again on the merged module** — and there the strip is destructive.

An `alloca`'s alignment is not an annotation opt can re-derive. Once the text is gone, re-parsing gives the type's ABI alignment, so an over-aligned stack object is silently demoted:

```llvm
-  %lin_aprox = alloca %"struct.aie::linear_approx", align 64
+  %lin_aprox = alloca %"struct.aie::linear_approx", align 4
```

`aie::linear_approx` is the LUT helper behind the softmax `exp` in an inline attention kernel. At 4-byte alignment the core misbehaves and the tile hangs — an NPU decode wedged with `ERT_CMD_STATE_TIMEOUT` after a handful of tokens. Before #3493 the kernel was merged by an external `llvm-link` and never re-downgraded, so its alignment survived.

## Fix

Strip pre-link only. The merged module keeps its `align`: the kernel arrives already annotated by its own clang, and the core module was stripped before the merge, so the vectorization rationale is unaffected.

I first tried the narrower fix of exempting only `alloca` and continuing to strip loads/stores. It is **not** sufficient — the model still failed its numerical gate (1 of 2 prompts), because the merged kernel also depends on the load/store alignment it was compiled against. Hence the whole post-link strip goes.

## Validation

Two AMD NPU2 LLM decode models that hung with this defect now pass their top-k-vs-HF-bf16 gate (`topk_passed: 2, topk_failed: 0` each) on the pinned toolchain:

| model | before | after |
|---|---|---|
| `llama32_1b_q4nx` | `decode dispatch pos7 ERT_CMD_STATE_TIMEOUT` | PASS |
| `llama32_3b_q4nx` | same | PASS |

Localized by A/B against the pre-#3493 toolchain: identical `input_physical.mlir`, identical instruction histograms, and of 27 cores only the 8 merge-mode ones differed in their object/ELF — with this single alignment line as the only semantic difference. Swapping just the pre-#3493 xclbin into an otherwise post-bump run also passes, confirming the defect is in the core code and not the instruction stream.

Keeping the alignment also produces **smaller** code here: the attention core ELF drops from 11512 to 9444 bytes (176KB vs 193KB across all cores).

## Tests

`peano_compat_merge_link.mlir` asserted `--implicit-check-not=", align "` on the merged module — precisely the behaviour that has to go — so it now pins the alignment instead, and its kernel's scratch buffer and the accesses to it are over-aligned to make a demotion observable (at the ABI-default `align 4` a strip would be invisible, since the reprint restores it).

Both wrong implementations are rejected, not just the absent one:
- unpatched `aiecc` → all three stripped (`alloca [4 x float]`, `store float %mag, ptr %slot`), assertions fail;
- the alloca-only variant → alloca keeps 64 but the accesses are stripped, and the test fails on `store ... align 64`.

All `peano_compat_*` tests pass, including `peano_compat_align_strip.mlir`, which covers the pre-link strip that is retained.

One residual risk worth a reviewer's eye: the merged module now reaches opt with the ABI-default `align` that the reprint adds back to *core* instructions. That did not regress program memory in my workload (it shrank), but the i8 matmul the original note names is the case to sanity-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)