### PR TITLE
ci: move GitHub-hosted runners off the soon-to-be deprecated ubuntu-22.04 image

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Install cross-compilation toolchain
       shell: bash
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' && inputs.MATRIX_ARCH == 'aarch64' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-24.04' && inputs.MATRIX_ARCH == 'aarch64' }}
       run: |
         
         sudo apt-get update
@@ -89,7 +89,7 @@ runs:
       run: pip install --require-hashes -r python/requirements_dev.lock
 
     - name: install rename
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-24.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
       shell: bash
       run: |
         
@@ -110,7 +110,7 @@ runs:
       shell: pwsh
 
     - run: echo "TEMP=/tmp" >> $GITHUB_ENV
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-24.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
       shell: bash
 
     - name: Set workspace root

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -48,7 +48,7 @@ jobs:
       # Run the tests on the Cartesian product of the following
       matrix:
 
-        OS: [ ubuntu-22.04, ubuntu-24.04 ]
+        OS: [ ubuntu-24.04 ]
         COMPILER: [ llvm, gcc ]
         ENABLE_ASSERTIONS: [ ON, OFF ]
         ENABLE_RTTI: [ ON, OFF ]

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -44,7 +44,7 @@ jobs:
       # Run the tests on the Cartesian product of the following
       matrix:
         build_type: [ Assert, Release ]
-        ubuntu_version: [ 22.04, 24.04 ]
+        ubuntu_version: [ 24.04 ]
         python_version: [ "3.11", "3.12", "3.13", "3.14" ]
 
     steps:

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -27,7 +27,7 @@ jobs:
 
     name: Python and C/C++ Lint
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
@@ -119,11 +119,11 @@ jobs:
 
 # disabled because openssl dep isn't being compiled from source
 # (and hence system openssl can't be linked against during cross-compile)
-#          - OS: ubuntu-22.04
+#          - OS: ubuntu-24.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
@@ -142,7 +142,7 @@ jobs:
 
 # disabled because openssl dep isn't being compiled from source
 # (and hence system openssl can't be linked against during cross-compile)
-#          - OS: ubuntu-22.04
+#          - OS: ubuntu-24.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: OFF
 
@@ -291,7 +291,7 @@ jobs:
     # build
 
     - name: build distro wheels
-      if: ${{ matrix.OS != 'ubuntu-22.04' || matrix.ARCH != 'aarch64' }}
+      if: ${{ matrix.OS != 'ubuntu-24.04' || matrix.ARCH != 'aarch64' }}
       shell: bash
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       run: |
@@ -333,7 +333,7 @@ jobs:
         Remove-Item wheelhouse\repaired_wheel -Recurse -Force
 
     - name: build aarch ubuntu wheel
-      if: ${{ matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'aarch64' }}
+      if: ${{ matrix.OS == 'ubuntu-24.04' && matrix.ARCH == 'aarch64' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -398,7 +398,7 @@ jobs:
         echo "MLIR_AIE_WHEEL_VERSION=$(python -c "import pkginfo; w = pkginfo.Wheel('$WHL'); print(w.version.split('+')[0] + '+' + w.version.split('+')[1].rsplit('.', 1)[-1])")" | tee -a $GITHUB_OUTPUT
 
     - name: Download cache from container ubuntu
-      if: (matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'x86_64') && (success() || failure())
+      if: (matrix.OS == 'ubuntu-24.04' && matrix.ARCH == 'x86_64') && (success() || failure())
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -434,14 +434,14 @@ jobs:
     # python version. With py3-none you can pip install them in any python venv. Unfortunately though this does
     # mean that the python bindings themselves will confusingly not work in other envs (!=3.12)
     - name: rename non-windows
-      if: ${{ matrix.OS == 'ubuntu-22.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
+      if: ${{ matrix.OS == 'ubuntu-24.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
 
         rename 's/cp312-cp312/py3-none/' wheelhouse/mlir_aie*whl
 
-        if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
+        if [ x"${{ matrix.OS }}" == x"ubuntu-24.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
           rename 's/x86_64/aarch64/' wheelhouse/mlir_aie*whl
         fi
 
@@ -468,7 +468,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
@@ -476,7 +476,7 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
@@ -533,11 +533,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-#          - OS: ubuntu-22.04
+#          - OS: ubuntu-24.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: ON
 
@@ -545,11 +545,11 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-#          - OS: ubuntu-22.04
+#          - OS: ubuntu-24.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: OFF
 

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -139,11 +139,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: aarch64
             ENABLE_RTTI: ON
 
@@ -151,11 +151,11 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: aarch64
             ENABLE_RTTI: OFF
 
@@ -246,7 +246,7 @@ jobs:
     # build
 
     - name: cibuildwheel
-      if: ${{ matrix.OS != 'ubuntu-22.04' || matrix.ARCH != 'aarch64' }}
+      if: ${{ matrix.OS != 'ubuntu-24.04' || matrix.ARCH != 'aarch64' }}
       shell: bash
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       run: |
@@ -262,7 +262,7 @@ jobs:
         cibuildwheel --output-dir wheelhouse
 
     - name: build aarch ubuntu wheel
-      if: ${{ matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'aarch64' }}
+      if: ${{ matrix.OS == 'ubuntu-24.04' && matrix.ARCH == 'aarch64' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -306,7 +306,7 @@ jobs:
         echo "MLIR_WHEEL_VERSION=$(python -c "import pkginfo; w = pkginfo.Wheel('$WHL'); print(w.version.split('+')[0] + '+' + w.version.split('+')[1].rsplit('.', 1)[-1])")" | tee -a $GITHUB_OUTPUT
 
     - name: Download cache from container ubuntu
-      if: (matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'x86_64') && (success() || failure())
+      if: (matrix.OS == 'ubuntu-24.04' && matrix.ARCH == 'x86_64') && (success() || failure())
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -358,7 +358,7 @@ jobs:
           unzip -j wheelhouse/mlir*whl "mlir/bin/$TOOL" -d native_tools/
         done
 
-        if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ]; then
+        if [ x"${{ matrix.OS }}" == x"ubuntu-24.04" ]; then
           PLAT="linux"
         elif [ x"${{ matrix.OS }}" == x"windows-2022" ]; then
           PLAT="win"
@@ -408,7 +408,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
@@ -416,7 +416,7 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
@@ -462,11 +462,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: aarch64
             ENABLE_RTTI: ON
 
@@ -474,11 +474,11 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-          - OS: ubuntu-22.04
+          - OS: ubuntu-24.04
             ARCH: aarch64
             ENABLE_RTTI: OFF
 

--- a/docs/buildHostLin.md
+++ b/docs/buildHostLin.md
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 # Linux Setup and Build Instructions
 
-These instructions will guide you through everything required for building and executing a program on the Ryzen™ AI NPU, starting from a fresh bare-bones **Ubuntu 22.04 LTS** install. Ubuntu 22.04 LTS, Ubuntu 24.04 LTS and Ubuntu 24.10 are supported by this toolchain.
+These instructions will guide you through everything required for building and executing a program on the Ryzen™ AI NPU, starting from a fresh bare-bones **Ubuntu 24.04 LTS** install. Ubuntu 22.04 LTS, Ubuntu 24.04 LTS and Ubuntu 24.10 are supported by this toolchain.
 
 > On a **non-Ubuntu distro** (Arch, Void, Fedora-from-source, …) or a kernel that already ships the **in-tree `amdxdna` driver** (Linux ≥ 6.14), see [Building on a non-Ubuntu distro](buildHostLinNonUbuntu.md), which covers building only the XRT userspace SHIM and installing dependencies without `apt`.
 


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

GitHub begins deprecating the ubuntu-22.04 runner image on 2026-09-17, runs failing brownouts through March/April 2027, and removes it entirely on 2027-04-17 (actions/runner-images#14254). Move the affected jobs to ubuntu-24.04.

Targets 24.04 rather than 26.04 because 26.04 is still a preview image; restoring matrix breadth with a 26.04 leg is left to a follow-up once it goes GA.

The distro wheel jobs are unaffected in terms of ABI: cibuildwheel builds them inside manylinux_2_28 containers, so the runner is only a Docker host. Likewise the ghcr.io ubuntu22-ryzenai / ubuntu24-ryzenai container jobs are untouched, since those pin a tested target OS rather than a GitHub runner image; Ubuntu 22.04 remains covered there.

Note that setup_base and the two distro workflows gate steps on exact string equality against MATRIX_OS, so those guards move with the matrix. Missing one would silently skip a step rather than fail.

buildAndTestMulti and buildAndTestPythons drop their 22.04 leg instead of gaining a duplicate 24.04 one, halving both matrices for now.

The lint job picks up clang-tidy 14 -> 18 as a side effect: the 22.04 and 24.04 images share no clang-tidy version (13/14/15 vs 16/17/18), so the jump cannot be staged separately without adding apt.llvm.org.

buildHostLin.md now leads with 24.04 to match README.md, Building.md and getting-started.md. All three Ubuntu versions remain listed as supported.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
