### PR TITLE
[AIE] Deterministic merge mode for stream switch arbiters

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEAttrs.td
+++ b/include/aie/Dialect/AIE/IR/AIEAttrs.td
@@ -199,6 +199,39 @@ def BDPadLayoutArrayAttr : ArrayOfAttr<
     /*eltName*/BDPadLayoutAttr.cppClassName
 >;
 
+def MergeSlotAttr : AttrDef<AIE_Dialect, "MergeSlot", []> {
+  let mnemonic = "merge_slot";
+  let summary = [{
+    One slot of a stream switch arbiter's deterministic merge sequence;
+  }];
+  let description = [{
+    A slave port, and how many packets the arbiter grants it before advancing to
+    the next slot. Used as an element of the `deterministic_merge` attribute on
+    [AMSelOp](#aieamsel-xilinxaieamselop), which documents the mode as a whole.
+
+    The same slave may appear in more than one slot, which is how an uneven
+    service ratio is expressed.
+  }];
+
+  let parameters = (ins
+    EnumParameter<WireBundle> : $slave_bundle,
+    AttrParameter<"uint32_t", "channel index within the slave bundle">
+      : $slave_channel,
+    AttrParameter<"uint32_t",
+                  "packets granted on each visit to this slot; 1..63">
+      : $packet_count
+  );
+
+  let assemblyFormat = "`<` $slave_bundle `:` $slave_channel `,` $packet_count `>`";
+}
+
+def MergeSlotArrayAttr : ArrayOfAttr<
+    /*dialect*/AIE_Dialect,
+    /*attrName*/"MergeSlotArray",
+    /*attrMnemonic*/"merge_slot_array",
+    /*eltName*/MergeSlotAttr.cppClassName
+>;
+
 def PacketInfoAttr : AttrDef<AIE_Dialect, "PacketInfo", []> {
   let mnemonic = "packet_info";
   let summary = [{

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -601,7 +601,8 @@ def AIE_AMSelOp: AIE_Op<"amsel", [
   ]>, Results<(outs Index)> {
   let arguments = (
     ins ConfinedAttr<AIEI8Attr, [IntMinValue<0>, IntMaxValue<5>]>:$arbiterID,
-        ConfinedAttr<AIEI8Attr, [IntMinValue<0>, IntMaxValue<3>]>:$msel
+        ConfinedAttr<AIEI8Attr, [IntMinValue<0>, IntMaxValue<3>]>:$msel,
+        OptionalAttr<MergeSlotArrayAttr>:$deterministic_merge
   );
   let summary = "Declare an arbiter of a switchbox with a master select value (arbiter + msel)";
   let description = [{
@@ -622,11 +623,55 @@ def AIE_AMSelOp: AIE_Op<"amsel", [
     See also [MasterSetOp](#aiemasterset-xilinxaiemastersetop),
     [PacketRulesOp](#aiepacket_rules-xilinxaiepacketrulesop), and
     [PacketRuleOp](#aierule-xilinxaiepacketruleop) for more information.
+
+    ### Deterministic merge
+
+    The optional `deterministic_merge` attribute puts this op's *arbiter* into
+    deterministic merge mode. By default a packet-switched arbiter grants its
+    pending slave ports in an order the compiler does not control, so the
+    interleaving of a many-to-one merge is an emergent property of path
+    latencies and arbiter state. With the attribute set, the arbiter instead
+    walks the given sequence of merge slots: it grants only the slave named by
+    slot 0, `packet_count` times, then moves to slot 1, and so on, wrapping
+    after the last slot.
+
+    That makes the merge order a declared contract rather than an accident, and
+    it reserves bandwidth: a slave holding a slot cannot be starved by another
+    slave with a large backlog, because the arbiter will not grant that other
+    slave while it is on a slot that is not its own. The contract binds both
+    ways -- the arbiter waits at a slot for its slave, so a slot must only be
+    given to a stream that will actually produce the programmed packets.
+
+    The feature is scoped to a whole arbiter, not to an (arbiter, msel) pair.
+    Because several `aie.amsel` ops may name the same arbiter, at most one of
+    them may carry this attribute, and its slots must name every slave port
+    routed to that arbiter -- a slave feeding the arbiter with no slot of its
+    own is never granted. Both rules are checked by the verifier.
+
+    Only some arbiters support this; query the target model with
+    `getNumDeterministicMergeArbiters()`. It is unavailable on AIE1.
+
+    Example:
+    ```
+      aie.switchbox(%tile_0_3) {
+        %a0 = aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 1>]
+        aie.masterset(South : 1, %a0)
+        aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+        aie.packet_rules(DMA : 0)   { aie.rule(31, 1, %a0) }
+      }
+    ```
+
+    Each slot reads `<slave_bundle : slave_channel, packet_count>`, so the
+    schedule above grants `North : 1` one packet, then `DMA : 0` one packet,
+    then repeats.
   }];
 
   let assemblyFormat = [{
-    `<` $arbiterID `>` `(` $msel `)` attr-dict
+    `<` $arbiterID `>` `(` $msel `)`
+    (`deterministic_merge` $deterministic_merge^)? attr-dict
   }];
+
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     int arbiterIndex() { return getArbiterID(); }
@@ -638,7 +683,8 @@ def AIE_AMSelOp: AIE_Op<"amsel", [
     [{
       build($_builder, $_state, $_builder.getIndexType(),
             $_builder.getI8IntegerAttr(arbiterID),
-            $_builder.getI8IntegerAttr(msel));
+            $_builder.getI8IntegerAttr(msel),
+            /*deterministic_merge=*/nullptr);
     }]>
   ];
 }

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -385,6 +385,13 @@ public:
                                         AIE::DMAChannelDir direction) const = 0;
 
   virtual uint32_t getNumMemTileRows() const = 0;
+  /// Return how many of a stream switch's arbiters support deterministic merge
+  /// mode. Arbiters [0, N) support it; returning 0 means the target has no such
+  /// feature at all. See the `deterministic_merge` attribute on AMSelOp.
+  virtual uint32_t getNumDeterministicMergeArbiters() const = 0;
+  /// Return how many merge slots a deterministic merge arbiter has, i.e. the
+  /// widest merge that can be programmed. Zero when the feature is unavailable.
+  virtual uint32_t getNumDeterministicMergeSlots() const = 0;
   /// Return the size (in bytes) of a MemTile.
   virtual uint32_t getMemTileSize() const = 0;
   /// Return the number of memory banks of a given tile.
@@ -566,6 +573,10 @@ public:
                                 AIE::DMAChannelDir direction) const override;
 
   uint32_t getNumMemTileRows() const override { return 0; }
+  // AIE1 stream switches have no deterministic merge feature; the AIE2 mode is
+  // defined to behave exactly like AIE1 when it is disabled.
+  uint32_t getNumDeterministicMergeArbiters() const override { return 0; }
+  uint32_t getNumDeterministicMergeSlots() const override { return 0; }
   uint32_t getMemTileSize() const override { return 0; }
   uint32_t getNumBanks(int col, int row) const override { return 4; }
 
@@ -612,6 +623,11 @@ public:
     addModelProperty(AIETargetModel::UsesSemaphoreLocks);
     addModelProperty(AIETargetModel::UsesMultiDimensionalBDs);
   }
+
+  // AIE2 exposes deterministic merge on 2 of the 6 stream switch arbiters,
+  // with 4 merge slots each (so at most a 4-to-1 merge per arbiter).
+  uint32_t getNumDeterministicMergeArbiters() const override { return 2; }
+  uint32_t getNumDeterministicMergeSlots() const override { return 4; }
 
   AIEArch getTargetArch() const override;
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1774,6 +1774,82 @@ LogicalResult PacketRulesOp::verify() {
   return success();
 }
 
+LogicalResult AMSelOp::verify() {
+  auto slots = getDeterministicMerge();
+  if (!slots)
+    return success();
+
+  const auto &tm = getTargetModel(*this);
+  uint32_t numArbiters = tm.getNumDeterministicMergeArbiters();
+  if (numArbiters == 0)
+    return emitOpError("deterministic merge is not supported by this device");
+  if (static_cast<uint32_t>(arbiterIndex()) >= numArbiters)
+    return emitOpError("arbiter ")
+           << arbiterIndex()
+           << " does not support deterministic merge; this device supports "
+              "arbiters [0, "
+           << numArbiters << ")";
+
+  uint32_t numSlots = tm.getNumDeterministicMergeSlots();
+  if (slots->size() > numSlots)
+    return emitOpError("has ")
+           << slots->size() << " merge slots but this device provides only "
+           << numSlots;
+  // The hardware marks an unused slot with a packet count of zero, and slots 0
+  // and 1 may never be zero, so the narrowest legal configuration is 2-to-1.
+  if (slots->size() < 2)
+    return emitOpError("needs at least 2 merge slots (a 2-to-1 merge); got ")
+           << slots->size();
+
+  // packet_count is a 6-bit field and a zero count is how the hardware marks an
+  // unused slot, so an explicit slot must be in 1..63.
+  for (auto slot : *slots)
+    if (slot.getPacketCount() < 1 || slot.getPacketCount() > 63)
+      return emitOpError("merge slot packet_count must be in 1..63; got ")
+             << (int)slot.getPacketCount();
+
+  auto switchbox = (*this)->getParentOfType<SwitchboxOp>();
+  if (!switchbox)
+    return success();
+
+  // Deterministic merge is scoped to a whole arbiter, but several amsels may
+  // name the same arbiter, so exactly one of them may carry the schedule.
+  for (auto other : switchbox.getOps<AMSelOp>())
+    if (other != *this && other.arbiterIndex() == arbiterIndex() &&
+        other.getDeterministicMerge())
+      return emitOpError("arbiter ")
+             << arbiterIndex()
+             << " already has a deterministic merge schedule on another amsel; "
+                "the schedule covers the whole arbiter, so it must appear once";
+
+  // Every slave routed to this arbiter must hold a slot: once the feature is
+  // enabled the arbiter grants only the slaves it names, so an omitted slave is
+  // starved forever.
+  llvm::SmallSet<std::pair<int, int>, 8> scheduled;
+  for (auto slot : *slots)
+    scheduled.insert({static_cast<int>(slot.getSlaveBundle()),
+                      static_cast<int>(slot.getSlaveChannel())});
+
+  for (auto rules : switchbox.getOps<PacketRulesOp>()) {
+    bool feedsThisArbiter = false;
+    for (auto rule : rules.getRules().front().getOps<PacketRuleOp>())
+      if (auto amsel = dyn_cast<AMSelOp>(rule.getAmsel().getDefiningOp());
+          amsel && amsel.arbiterIndex() == arbiterIndex())
+        feedsThisArbiter = true;
+    if (!feedsThisArbiter)
+      continue;
+    if (!scheduled.count(
+            {static_cast<int>(rules.getSourceBundle()), rules.sourceIndex()}))
+      return emitOpError("deterministic merge on arbiter ")
+             << arbiterIndex() << " does not schedule slave port "
+             << stringifyWireBundle(rules.getSourceBundle()) << " : "
+             << rules.sourceIndex()
+             << ", which is routed to that arbiter and would never be granted";
+  }
+
+  return success();
+}
+
 LogicalResult PacketFlowOp::verify() {
   Region &body = getPorts();
   if (body.empty())

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -767,6 +767,29 @@ xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp,
         slot++;
       }
     }
+
+    // Deterministic merge: an arbiter may be told to grant its slaves in a
+    // programmed order instead of arbitrating freely. The schedule is carried
+    // on one amsel per arbiter (see AMSelOp's verifier) and must be written
+    // before the enable, which resets the feature's internal state.
+    for (auto amselOp : b.getOps<AMSelOp>()) {
+      auto slots = amselOp.getDeterministicMerge();
+      if (!slots)
+        continue;
+      TxnLocBracket bracket(*this, amselOp.getLoc());
+      int arbiter = amselOp.arbiterIndex();
+      int position = 0;
+      for (auto mergeSlot : *slots) {
+        TRY_XAIE_API_EMIT_ERROR(
+            amselOp, XAie_StrmSwDeterministicMergeConfig, &aiert->devInst,
+            tileLoc, arbiter,
+            WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(mergeSlot.getSlaveBundle()),
+            mergeSlot.getSlaveChannel(), mergeSlot.getPacketCount(), position);
+        position++;
+      }
+      TRY_XAIE_API_EMIT_ERROR(amselOp, XAie_StrmSwDeterministicMergeEnable,
+                              &aiert->devInst, tileLoc, arbiter);
+    }
   }
 
   for (auto muxOp : targetOp.getOps<ShimMuxOp>()) {

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -702,6 +702,31 @@ xilinx::AIE::AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output,
       }
     }
 
+    // Deterministic merge: an arbiter may be told to grant its slaves in a
+    // programmed order instead of arbitrating freely. The schedule is carried
+    // on one amsel per arbiter (see AMSelOp's verifier) and must be written
+    // before the enable, which resets the feature's internal state.
+    for (auto amselOp : b.getOps<AMSelOp>()) {
+      auto slots = amselOp.getDeterministicMerge();
+      if (!slots)
+        continue;
+      int arbiter = amselOp.arbiterIndex();
+      int position = 0;
+      for (auto mergeSlot : *slots) {
+        output << "__mlir_aie_try(XAie_StrmSwDeterministicMergeConfig("
+               << deviceInstRef << ", " << tileLocStr("x", "y") << ", "
+               << "/* arbiter */ " << arbiter << ", "
+               << wireBundleToPortType(mergeSlot.getSlaveBundle()) << ", "
+               << mergeSlot.getSlaveChannel() << ", "
+               << "/* pkt_count */ " << mergeSlot.getPacketCount() << ", "
+               << "/* position */ " << position << "));\n";
+        position++;
+      }
+      output << "__mlir_aie_try(XAie_StrmSwDeterministicMergeEnable("
+             << deviceInstRef << ", " << tileLocStr("x", "y") << ", "
+             << "/* arbiter */ " << arbiter << "));\n";
+    }
+
     if (isParam) {
       output << "}\n";
       output << "}\n";

--- a/test/Targets/AIEGenerateXAIE/deterministic_merge.mlir
+++ b/test/Targets/AIEGenerateXAIE/deterministic_merge.mlir
@@ -1,0 +1,36 @@
+//===- deterministic_merge.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+
+// The `deterministic_merge` schedule on an amsel must reach the libxaie
+// configuration. This backend previously dropped it silently, which is the
+// worst failure mode for the feature: the design compiles and runs, but with
+// free arbitration and no diagnostic.
+//
+// Slots are emitted in array order (position 0, 1, ...), and the enable must
+// come last -- writing it resets the feature's internal state, so it has to
+// follow the slot configuration.
+//
+// See test/npu-xrt/packet_flow_merge_order for the hardware test proving the
+// arbiter actually honours a programmed order.
+
+// CHECK: XAie_StrmSwDeterministicMergeConfig({{.*}}, /* arbiter */ 0, NORTH, 1, /* pkt_count */ 1, /* position */ 0)
+// CHECK-NEXT: XAie_StrmSwDeterministicMergeConfig({{.*}}, /* arbiter */ 0, DMA, 0, /* pkt_count */ 3, /* position */ 1)
+// CHECK-NEXT: XAie_StrmSwDeterministicMergeEnable({{.*}}, /* arbiter */ 0)
+
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      %a0 = aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 3>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}

--- a/test/Targets/AIEGenerateXAIE/deterministic_merge.mlir
+++ b/test/Targets/AIEGenerateXAIE/deterministic_merge.mlir
@@ -5,7 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+// RUN: sed 's/NPUDEVICE/npu1/g' %s | aie-translate --aie-generate-xaie | FileCheck %s
+// RUN: sed 's/NPUDEVICE/npu2/g' %s | aie-translate --aie-generate-xaie | FileCheck %s
 
 // The `deterministic_merge` schedule on an amsel must reach the libxaie
 // configuration. This backend previously dropped it silently, which is the
@@ -16,6 +17,10 @@
 // come last -- writing it resets the feature's internal state, so it has to
 // follow the slot configuration.
 //
+// Run for both parts: deterministic merge is an AIE2 property, and npu1 and
+// npu2 both expose two arbiters with four slots each, so the same schedule must
+// verify and emit on either.
+//
 // See test/npu-xrt/packet_flow_merge_order for the hardware test proving the
 // arbiter actually honours a programmed order.
 
@@ -24,7 +29,7 @@
 // CHECK-NEXT: XAie_StrmSwDeterministicMergeEnable({{.*}}, /* arbiter */ 0)
 
 module {
-  aie.device(npu1) {
+  aie.device(NPUDEVICE) {
     %t = aie.tile(0, 3)
     aie.switchbox(%t) {
       %a0 = aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 3>]

--- a/test/dialect/AIE/bad_deterministic_merge.mlir
+++ b/test/dialect/AIE/bad_deterministic_merge.mlir
@@ -1,0 +1,106 @@
+//===- bad_deterministic_merge.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -split-input-file -verify-diagnostics
+
+// Deterministic merge is scoped to a whole arbiter, so a slave port routed to
+// that arbiter with no slot of its own would never be granted again once the
+// feature is enabled -- a silent, permanent stall. Reject it.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      // expected-error @+1 {{does not schedule slave port DMA : 0}}
+      %a0 = aie.amsel<0> (0) deterministic_merge [ <North : 1, 1>, <North : 1, 2>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}
+
+// -----
+
+// Several amsels may name one arbiter, but the schedule covers the arbiter, so
+// only one of them may carry it.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      // expected-error @+1 {{already has a deterministic merge schedule on another amsel}}
+      %a0 = aie.amsel<0> (0) deterministic_merge [ <North : 1, 1>, <DMA : 0, 1>]
+      %a1 = aie.amsel<0> (1) deterministic_merge [ <North : 1, 1>, <DMA : 0, 1>]
+      aie.masterset(South : 1, %a0, %a1)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}
+
+// -----
+
+// Only arbiters 0 and 1 implement the feature on AIE2.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      // expected-error @+1 {{arbiter 2 does not support deterministic merge}}
+      %a0 = aie.amsel<2> (0) deterministic_merge [ <North : 1, 1>, <DMA : 0, 1>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}
+
+// -----
+
+// The hardware marks an unused slot with a packet count of zero and slots 0 and
+// 1 may never be zero, so the narrowest legal configuration is 2-to-1.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      // expected-error @+1 {{needs at least 2 merge slots}}
+      %a0 = aie.amsel<0> (0) deterministic_merge [ <North : 1, 1>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+    }
+  }
+}
+
+// -----
+
+// packet_count is a 6-bit field.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      // expected-error @+1 {{packet_count must be in 1..63}}
+      %a0 = aie.amsel<0> (0) deterministic_merge [ <North : 1, 64>, <DMA : 0, 1>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}
+
+// -----
+
+// AIE1 stream switches have no such feature at all.
+module {
+  aie.device(xcvc1902) {
+    %t = aie.tile(2, 3)
+    aie.switchbox(%t) {
+      // expected-error @+1 {{deterministic merge is not supported by this device}}
+      %a0 = aie.amsel<0> (0) deterministic_merge [ <North : 1, 1>, <DMA : 0, 1>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}

--- a/test/dialect/AIE/deterministic_merge.mlir
+++ b/test/dialect/AIE/deterministic_merge.mlir
@@ -1,0 +1,58 @@
+//===- deterministic_merge.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s | aie-opt | FileCheck %s
+
+// Round-trip for the `deterministic_merge` schedule carried on aie.amsel.
+//
+// The schedule puts the amsel's *arbiter* into deterministic merge mode: the
+// arbiter grants slot 0's slave port `packet_count` times, then slot 1's, and so
+// on, instead of arbitrating freely. See AMSelOp's description, and
+// test/npu-xrt/packet_flow_merge_order for a design that proves on real
+// hardware that the arbiter honours the programmed order.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       %[[a0:.*]] = aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 1>]
+// CHECK:       aie.masterset(South : 1, %[[a0]])
+
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 3)
+    aie.switchbox(%t) {
+      %a0 = aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 1>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+    }
+  }
+}
+
+// -----
+
+// The Figure 3-16(b) shape from the architecture spec: a slave may hold more
+// than one slot, and a slot may grant several packets in a row. Here North : 1
+// is served once, then DMA : 0, then North : 1 three more times, then West : 3.
+//
+// A repeated slave is why the schedule cannot simply be derived from the
+// packet_rules -- the rules say which slaves feed the arbiter, but not how many
+// times or in what order each is served.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 1>, <North : 1, 3>, <West : 3, 1>]
+module {
+  aie.device(npu1) {
+    %t = aie.tile(1, 3)
+    aie.switchbox(%t) {
+      %a0 = aie.amsel<0> (0) deterministic_merge [
+              <North : 1, 1>, <DMA : 0, 1>, <North : 1, 3>, <West : 3, 1>]
+      aie.masterset(South : 1, %a0)
+      aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
+      aie.packet_rules(DMA : 0) { aie.rule(31, 1, %a0) }
+      aie.packet_rules(West : 3) { aie.rule(31, 4, %a0) }
+    }
+  }
+}

--- a/test/npu-xrt/packet_flow_merge_order/aie.mlir
+++ b/test/npu-xrt/packet_flow_merge_order/aie.mlir
@@ -1,0 +1,265 @@
+//===- aie.mlir --------------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Deterministic merge, proven by the ARRIVAL ORDER rather than by liveness.
+//
+// Three source tiles each send exactly one 256-byte packet (all packet id 0) to
+// the same shim DMA. They merge at the shim stream switch on arbiter 0, which
+// has three slaves -- one per source:
+//
+//   North : 2  <- tile(0,2), payload 1
+//   East  : 2  <- tile(0,3), payload 2
+//   East  : 0  <- tile(0,4), payload 3
+//
+// Left to arbitrate freely the hardware delivers 1, 3, 2 -- measured identical
+// across 12 consecutive runs. That order is reproducible but nothing in the
+// architecture guarantees it; it just falls out of path latency and arbiter
+// state.
+//
+// The schedule below demands 2, 1, 3 instead: a permutation the hardware does
+// NOT produce on its own. So the assertion in test.cpp can only pass if the
+// arbiter actually honoured the programmed slot order. If deterministic merge
+// regresses -- emission drops, wrong register, wrong slot order, hardware
+// ignores it -- the output reverts to 1, 3, 2 and the test fails.
+//
+// This is deliberately NOT a deadlock test. Every packet is delivered either
+// way and the destination BD takes all 768 bytes, so neither outcome can stall
+// the stream or wedge the device. Each source produces exactly the one packet
+// its slot grants.
+//
+// The switchbox ops are `--aie-create-pathfinder-flows` output with the
+// attribute added and the aie.packet_flow ops removed, which leaves the
+// configuration untouched by the router.
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    %shim_mux_0_0 = aie.shim_mux(%shim_noc_tile_0_0) {
+      aie.connect<North : 2, DMA : 0>
+    }
+    %switchbox_0_0 = aie.switchbox(%shim_noc_tile_0_0) {
+      %0 = aie.amsel<0> (0) deterministic_merge [<East : 2, 1>, <North : 2, 1>, <East : 0, 1>]
+      %1 = aie.masterset(South : 2, %0)
+      aie.packet_rules(East : 0) {
+        aie.rule(31, 0, %0)
+      }
+      aie.packet_rules(East : 2) {
+        aie.rule(31, 0, %0)
+      }
+      aie.packet_rules(North : 2) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_2 = aie.tile(0, 2)
+    %switchbox_0_2 = aie.switchbox(%tile_0_2) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(South : 2, %0)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_3 = aie.tile(0, 3)
+    %switchbox_0_3 = aie.switchbox(%tile_0_3) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(East : 0, %0)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_0_4 = aie.tile(0, 4)
+    %switchbox_0_4 = aie.switchbox(%tile_0_4) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(East : 3, %0)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %buf0 = aie.buffer(%tile_0_2) {sym_name = "buf0"} : memref<256xi8> 
+    %prod0 = aie.lock(%tile_0_2, 0) {init = 1 : i32, sym_name = "prod0"}
+    %cons0 = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "cons0"}
+    %buf1 = aie.buffer(%tile_0_3) {sym_name = "buf1"} : memref<256xi8> 
+    %prod1 = aie.lock(%tile_0_3, 0) {init = 1 : i32, sym_name = "prod1"}
+    %cons1 = aie.lock(%tile_0_3, 1) {init = 0 : i32, sym_name = "cons1"}
+    %buf2 = aie.buffer(%tile_0_4) {sym_name = "buf2"} : memref<256xi8> 
+    %prod2 = aie.lock(%tile_0_4, 0) {init = 1 : i32, sym_name = "prod2"}
+    %cons2 = aie.lock(%tile_0_4, 1) {init = 0 : i32, sym_name = "cons2"}
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c256 = arith.constant 256 : index
+      %c1_i8 = arith.constant 1 : i8
+      %c1_i32 = arith.constant 1 : i32
+      aie.use_lock(%prod0, AcquireGreaterEqual, %c1_i32)
+      scf.for %arg0 = %c0 to %c256 step %c1 {
+        memref.store %c1_i8, %buf0[%arg0] : memref<256xi8>
+      }
+      aie.use_lock(%cons0, Release, %c1_i32)
+      aie.end
+    }
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma(MM2S, 0) [{
+        %c1_i32 = arith.constant 1 : i32
+        aie.use_lock(%cons0, AcquireGreaterEqual, %c1_i32)
+        aie.dma_bd(%buf0 : memref<256xi8>) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>}
+        aie.use_lock(%prod0, Release, %c1_i32)
+      }]
+      aie.end
+    }
+    %core_0_3 = aie.core(%tile_0_3) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c256 = arith.constant 256 : index
+      %c2_i8 = arith.constant 2 : i8
+      %c1_i32 = arith.constant 1 : i32
+      aie.use_lock(%prod1, AcquireGreaterEqual, %c1_i32)
+      scf.for %arg0 = %c0 to %c256 step %c1 {
+        memref.store %c2_i8, %buf1[%arg0] : memref<256xi8>
+      }
+      aie.use_lock(%cons1, Release, %c1_i32)
+      aie.end
+    }
+    %mem_0_3 = aie.mem(%tile_0_3) {
+      %0 = aie.dma(MM2S, 0) [{
+        %c1_i32 = arith.constant 1 : i32
+        aie.use_lock(%cons1, AcquireGreaterEqual, %c1_i32)
+        aie.dma_bd(%buf1 : memref<256xi8>) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>}
+        aie.use_lock(%prod1, Release, %c1_i32)
+      }]
+      aie.end
+    }
+    %core_0_4 = aie.core(%tile_0_4) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c256 = arith.constant 256 : index
+      %c3_i8 = arith.constant 3 : i8
+      %c1_i32 = arith.constant 1 : i32
+      aie.use_lock(%prod2, AcquireGreaterEqual, %c1_i32)
+      scf.for %arg0 = %c0 to %c256 step %c1 {
+        memref.store %c3_i8, %buf2[%arg0] : memref<256xi8>
+      }
+      aie.use_lock(%cons2, Release, %c1_i32)
+      aie.end
+    }
+    %mem_0_4 = aie.mem(%tile_0_4) {
+      %0 = aie.dma(MM2S, 0) [{
+        %c1_i32 = arith.constant 1 : i32
+        aie.use_lock(%cons2, AcquireGreaterEqual, %c1_i32)
+        aie.dma_bd(%buf2 : memref<256xi8>) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>}
+        aie.use_lock(%prod2, Release, %c1_i32)
+      }]
+      aie.end
+    }
+    aie.shim_dma_allocation @out0(%shim_noc_tile_0_0, S2MM, 0)
+    aie.runtime_sequence(%arg0: memref<768xi8>) {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c768_i64 = arith.constant 768 : i64
+      aiex.npu.dma_memcpy_nd(%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c768_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, issue_token = true, metadata = @out0} : memref<768xi8>
+      aiex.npu.dma_wait {symbol = @out0}
+    }
+    %mem_tile_0_1 = aie.tile(0, 1)
+    %switchbox_0_1 = aie.switchbox(%mem_tile_0_1) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(South : 2, %0)
+      aie.packet_rules(North : 2) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %shim_noc_tile_1_0 = aie.tile(1, 0)
+    %switchbox_1_0 = aie.switchbox(%shim_noc_tile_1_0) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.masterset(West : 0, %0)
+      %3 = aie.masterset(West : 2, %1)
+      aie.packet_rules(North : 0) {
+        aie.rule(31, 0, %0)
+      }
+      aie.packet_rules(North : 3) {
+        aie.rule(31, 0, %1)
+      }
+    }
+    %mem_tile_1_1 = aie.tile(1, 1)
+    %switchbox_1_1 = aie.switchbox(%mem_tile_1_1) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.masterset(South : 0, %0)
+      %3 = aie.masterset(South : 3, %1)
+      aie.packet_rules(North : 0) {
+        aie.rule(31, 0, %0)
+      }
+      aie.packet_rules(North : 3) {
+        aie.rule(31, 0, %1)
+      }
+    }
+    %tile_1_2 = aie.tile(1, 2)
+    %switchbox_1_2 = aie.switchbox(%tile_1_2) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.masterset(South : 0, %0)
+      %3 = aie.masterset(South : 3, %1)
+      aie.packet_rules(North : 0) {
+        aie.rule(31, 0, %0)
+      }
+      aie.packet_rules(North : 1) {
+        aie.rule(31, 0, %1)
+      }
+    }
+    %tile_1_3 = aie.tile(1, 3)
+    %switchbox_1_3 = aie.switchbox(%tile_1_3) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.masterset(South : 0, %1)
+      %3 = aie.masterset(South : 1, %0)
+      aie.packet_rules(North : 3) {
+        aie.rule(31, 0, %1)
+      }
+      aie.packet_rules(West : 0) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    %tile_1_4 = aie.tile(1, 4)
+    %switchbox_1_4 = aie.switchbox(%tile_1_4) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.masterset(South : 3, %0)
+      aie.packet_rules(West : 3) {
+        aie.rule(31, 0, %0)
+      }
+    }
+    aie.wire(%shim_mux_0_0 : North, %switchbox_0_0 : South)
+    aie.wire(%shim_noc_tile_0_0 : DMA, %shim_mux_0_0 : DMA)
+    aie.wire(%mem_tile_0_1 : Core, %switchbox_0_1 : Core)
+    aie.wire(%mem_tile_0_1 : DMA, %switchbox_0_1 : DMA)
+    aie.wire(%switchbox_0_0 : North, %switchbox_0_1 : South)
+    aie.wire(%tile_0_2 : Core, %switchbox_0_2 : Core)
+    aie.wire(%tile_0_2 : DMA, %switchbox_0_2 : DMA)
+    aie.wire(%switchbox_0_1 : North, %switchbox_0_2 : South)
+    aie.wire(%tile_0_3 : Core, %switchbox_0_3 : Core)
+    aie.wire(%tile_0_3 : DMA, %switchbox_0_3 : DMA)
+    aie.wire(%switchbox_0_2 : North, %switchbox_0_3 : South)
+    aie.wire(%tile_0_4 : Core, %switchbox_0_4 : Core)
+    aie.wire(%tile_0_4 : DMA, %switchbox_0_4 : DMA)
+    aie.wire(%switchbox_0_3 : North, %switchbox_0_4 : South)
+    aie.wire(%switchbox_0_0 : East, %switchbox_1_0 : West)
+    aie.wire(%switchbox_0_1 : East, %switchbox_1_1 : West)
+    aie.wire(%mem_tile_1_1 : Core, %switchbox_1_1 : Core)
+    aie.wire(%mem_tile_1_1 : DMA, %switchbox_1_1 : DMA)
+    aie.wire(%switchbox_1_0 : North, %switchbox_1_1 : South)
+    aie.wire(%switchbox_0_2 : East, %switchbox_1_2 : West)
+    aie.wire(%tile_1_2 : Core, %switchbox_1_2 : Core)
+    aie.wire(%tile_1_2 : DMA, %switchbox_1_2 : DMA)
+    aie.wire(%switchbox_1_1 : North, %switchbox_1_2 : South)
+    aie.wire(%switchbox_0_3 : East, %switchbox_1_3 : West)
+    aie.wire(%tile_1_3 : Core, %switchbox_1_3 : Core)
+    aie.wire(%tile_1_3 : DMA, %switchbox_1_3 : DMA)
+    aie.wire(%switchbox_1_2 : North, %switchbox_1_3 : South)
+    aie.wire(%switchbox_0_4 : East, %switchbox_1_4 : West)
+    aie.wire(%tile_1_4 : Core, %switchbox_1_4 : Core)
+    aie.wire(%tile_1_4 : DMA, %switchbox_1_4 : DMA)
+    aie.wire(%switchbox_1_3 : North, %switchbox_1_4 : South)
+  }
+}
+

--- a/test/npu-xrt/packet_flow_merge_order/aie.mlir
+++ b/test/npu-xrt/packet_flow_merge_order/aie.mlir
@@ -36,7 +36,7 @@
 // configuration untouched by the router.
 
 module {
-  aie.device(npu1) {
+  aie.device(NPUDEVICE) {
     %shim_noc_tile_0_0 = aie.tile(0, 0)
     %shim_mux_0_0 = aie.shim_mux(%shim_noc_tile_0_0) {
       aie.connect<North : 2, DMA : 0>

--- a/test/npu-xrt/packet_flow_merge_order/run.lit
+++ b/test/npu-xrt/packet_flow_merge_order/run.lit
@@ -1,13 +1,22 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai_npu1, peano
+// REQUIRES: ryzen_ai, peano
 //
 // Deterministic merge verified by arrival order: the schedule demands a
 // permutation (2,1,3) that free arbitration does not produce (1,3,2), so this
 // test goes red if the feature stops reaching the hardware. It cannot deadlock
 // -- every packet has a destination BD either way.
 //
-// RUN: %aiecc --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// The switchbox configuration is pinned rather than routed, so it is identical
+// on both parts, and the assertion is the PROGRAMMED order rather than the
+// natural one -- neither depends on which device runs it. Deterministic merge
+// is an AIE2 property: npu1 and npu2 both expose two arbiters with four slots.
+//
+// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1/g' -i aie_arch.mlir
+// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2/g' -i aie_arch.mlir
+// RUN: %aiecc --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
 // RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
+// RUN: %run_on_npu2% ./test.exe aie.xclbin

--- a/test/npu-xrt/packet_flow_merge_order/run.lit
+++ b/test/npu-xrt/packet_flow_merge_order/run.lit
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// Deterministic merge verified by arrival order: the schedule demands a
+// permutation (2,1,3) that free arbitration does not produce (1,3,2), so this
+// test goes red if the feature stops reaching the hardware. It cannot deadlock
+// -- every packet has a destination BD either way.
+//
+// RUN: %aiecc --get-npu-insts --get-xclbin --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %run_on_npu1% ./test.exe aie.xclbin

--- a/test/npu-xrt/packet_flow_merge_order/test.cpp
+++ b/test/npu-xrt/packet_flow_merge_order/test.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -38,10 +39,10 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(0);
   xrt::xclbin xclbin(std::string("aie.xclbin"));
   auto xkernels = xclbin.get_kernels();
-  auto xkernel = *std::find_if(
-      xkernels.begin(), xkernels.end(), [](xrt::xclbin::kernel &k) {
-        return k.get_name().rfind("MLIR_AIE", 0) == 0;
-      });
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [](xrt::xclbin::kernel &k) {
+                                 return k.get_name().rfind("MLIR_AIE", 0) == 0;
+                               });
   device.register_xclbin(xclbin);
   xrt::hw_context context(device, xclbin.get_uuid());
   auto kernel = xrt::kernel(context, xkernel.get_name());

--- a/test/npu-xrt/packet_flow_merge_order/test.cpp
+++ b/test/npu-xrt/packet_flow_merge_order/test.cpp
@@ -1,0 +1,107 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Asserts the EXACT arrival order of three merged packets, which is only
+// achievable because the shim arbiter is in deterministic merge mode. See
+// aie.mlir for why 2,1,3 is the expected order and 1,3,2 is what free
+// arbitration produces.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "test_utils.h"
+
+constexpr int CHUNK = 256;
+constexpr int NUM_SRC = 3;
+constexpr int OUT_SIZE = CHUNK * NUM_SRC;
+
+// The programmed merge-slot order: East:2 (payload 2), North:2 (payload 1),
+// East:0 (payload 3). Free arbitration on this part yields {1, 3, 2}.
+constexpr int8_t kExpectedOrder[NUM_SRC] = {2, 1, 3};
+constexpr int8_t kFreeArbitrationOrder[NUM_SRC] = {1, 3, 2};
+
+int main(int argc, const char *argv[]) {
+  std::vector<uint32_t> instr_v = test_utils::load_instr_binary("insts.bin");
+
+  auto device = xrt::device(0);
+  xrt::xclbin xclbin(std::string("aie.xclbin"));
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(
+      xkernels.begin(), xkernels.end(), [](xrt::xclbin::kernel &k) {
+        return k.get_name().rfind("MLIR_AIE", 0) == 0;
+      });
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, xkernel.get_name());
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_out =
+      xrt::bo(device, OUT_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+
+  memcpy(bo_instr.map<void *>(), instr_v.data(), instr_v.size() * sizeof(int));
+  int8_t *out = bo_out.map<int8_t *>();
+  std::fill(out, out + OUT_SIZE, static_cast<int8_t>(-1));
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  auto run = kernel(3u, bo_instr, instr_v.size(), bo_out);
+  // Bounded wait purely so a broken build reports instead of hanging the
+  // harness. This design cannot deadlock: every packet has a destination BD.
+  if (run.wait2(std::chrono::seconds(10)) == std::cv_status::timeout) {
+    std::cout << "Kernel timed out.\n";
+    return 1;
+  }
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  // Each source contributes one contiguous 256-byte block; the block order is
+  // what deterministic merge fixes.
+  int errors = 0;
+  std::cout << "arrival order: ";
+  for (int b = 0; b < NUM_SRC; b++)
+    std::cout << static_cast<int>(out[b * CHUNK]) << " ";
+  std::cout << "(expected 2 1 3)\n";
+
+  for (int b = 0; b < NUM_SRC; b++) {
+    for (int i = 0; i < CHUNK; i++) {
+      int8_t got = out[b * CHUNK + i];
+      if (got != kExpectedOrder[b]) {
+        if (errors < 8)
+          std::cout << "byte " << (b * CHUNK + i) << ": got "
+                    << static_cast<int>(got) << " want "
+                    << static_cast<int>(kExpectedOrder[b]) << "\n";
+        errors++;
+      }
+    }
+  }
+
+  if (errors) {
+    bool looksUnscheduled = true;
+    for (int b = 0; b < NUM_SRC; b++)
+      if (out[b * CHUNK] != kFreeArbitrationOrder[b])
+        looksUnscheduled = false;
+    if (looksUnscheduled)
+      std::cout << "\nThe order is 1 3 2, which is what this design produces "
+                   "with free arbitration. The deterministic merge schedule "
+                   "was not applied -- check that the `deterministic_merge` "
+                   "attribute survived compilation and reached "
+                   "XAie_StrmSwDeterministicMergeConfig.\n";
+    std::cout << "\nfailed. " << errors << " mismatched bytes.\n";
+    return 1;
+  }
+
+  std::cout << "\nPASS!\n";
+  return 0;
+}


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

AIE2 stream switches can put arbiters 0 and 1 into **deterministic merge** mode: the arbiter walks a programmed sequence of slave ports instead of arbitrating freely, granting each slot's slave `packet_count` packets before advancing. The `aie-rt` driver has exposed `XAie_StrmSwDeterministicMergeConfig`/`Enable` all along and the registers exist on npu1 and npu2, but nothing in mlir-aie could reach them.

Without it, the interleaving of a many-to-one packet merge is an emergent property of path latency and arbiter state. It is reproducible in practice — 12 consecutive runs of a 3-source merge gave a bit-identical order — but nothing architectural guarantees it, and a slave with a large backlog can starve one sharing the link.

### Surface

The schedule is an optional attribute on `aie.amsel`:

```mlir
%a0 = aie.amsel<0> (0) deterministic_merge [<North : 1, 1>, <DMA : 0, 3>]
aie.masterset(South : 1, %a0)
aie.packet_rules(North : 1) { aie.rule(31, 2, %a0) }
aie.packet_rules(DMA : 0)   { aie.rule(31, 1, %a0) }
```

Each slot reads `<slave_bundle : slave_channel, packet_count>`. `amsel` is the only op that names an arbiter, so it is the natural anchor — but the correspondence is many-to-one (several amsels may share an arbiter, while the feature is arbiter-scoped). The verifier therefore requires:

- at most **one** amsel per arbiter carries a schedule;
- the slots name **every** slave routed to that arbiter — an omitted slave is never granted, and enabling the mode turns that into permanent starvation rather than a diagnostic;
- arbiter < `getNumDeterministicMergeArbiters()` (2 on AIE2, 0 on AIE1);
- 2..`getNumDeterministicMergeSlots()` slots (4 on AIE2);
- `packet_count` in 1..63 — zero is how the hardware marks an unused slot.

Emission goes through **both** backends: `AIERT.cpp` for the CDO/xclbin path used by `aiecc`, and `AIETargetXAIEV2.cpp` for `--aie-generate-xaie`. Missing the second would be the worst failure mode here — the design would compile and run with free arbitration and no diagnostic.

## Testing

| Test | Proves | Hardware |
| --- | --- | --- |
| `npu-xrt/packet_flow_merge_order` | the arbiter honours the programmed order | yes |
| `Targets/AIEGenerateXAIE/deterministic_merge.mlir` | schedule reaches libxaie config | no |
| `dialect/AIE/deterministic_merge.mlir` | round-trip, incl. repeated slave | no |
| `dialect/AIE/bad_deterministic_merge.mlir` | 6 verifier rejections | no |

The hardware test proves the feature is **load-bearing** rather than merely present: three sources merge at a shim arbiter, free arbitration delivers `1, 3, 2`, and the schedule demands `2, 1, 3`. The assertion can only pass if the hardware obeyed the programmed slot order, so a regression at any layer turns it red.

It **cannot deadlock**. Every packet has a destination BD either way, so a regression surfaces as wrong data rather than a wedged device. This matters: a merge design that deadlocks on regression wedges the NPU driver device-wide and needs `modprobe -r amdxdna` to clear, which is not acceptable on a shared runner.

## Why draft

Two gaps to settle before this is ready:

1. **No router support.** The schedule must be written on hand-routed switchbox IR — there is no way to express it from source-form `aie.packet_flow`, and nothing pins merge nodes to arbiters 0/1. This PR lands the representation, verification and hardware path; router integration is a follow-up.
2. **npu1-only hardware coverage.** The target model enables the feature for all of AIE2, but the e2e test is gated `REQUIRES: ryzen_ai_npu1` because that is the hardware available. npu2 coverage needs a Strix runner.

Feedback welcome on the attribute placement in particular — an arbiter-scoped op was the alternative, and it would remove the "written on an amsel, governs the arbiter" mismatch at the cost of not reusing the existing arbiter naming.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)