### PR TITLE
ci: link aarch64 distro wheel binaries with lld to fix R_AARCH64_CALL26 overflow

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -82,7 +82,7 @@ runs:
         
         sudo apt-get update
         sudo apt-get install -y binutils-aarch64-linux-gnu \
-          g++-aarch64-linux-gnu gcc-aarch64-linux-gnu openssl libssl-dev
+          g++-aarch64-linux-gnu gcc-aarch64-linux-gnu openssl libssl-dev lld
 
     - name: pip install standard tools
       shell: bash

--- a/utils/mlir_wheels/setup.py
+++ b/utils/mlir_wheels/setup.py
@@ -85,6 +85,13 @@ def get_cross_cmake_args():
             cmake_args["CMAKE_C_COMPILER"] = "aarch64-linux-gnu-gcc"
             cmake_args["CMAKE_CXX_COMPILER"] = "aarch64-linux-gnu-g++"
             cmake_args["CMAKE_CXX_FLAGS"] = "-static-libgcc -static-libstdc++"
+            # GNU ld fails to insert AArch64 long-branch veneers for the fully
+            # static mlir-opt/mlir-translate binaries, causing "relocation
+            # truncated to fit: R_AARCH64_CALL26" inside libstdc++.a itself.
+            # lld handles arbitrarily large binaries correctly.
+            cmake_args["CMAKE_EXE_LINKER_FLAGS_INIT"] = "-fuse-ld=lld"
+            cmake_args["CMAKE_MODULE_LINKER_FLAGS_INIT"] = "-fuse-ld=lld"
+            cmake_args["CMAKE_SHARED_LINKER_FLAGS_INIT"] = "-fuse-ld=lld"
             native_tools()
         elif ARCH == "X86":
             cmake_args["LLVM_DEFAULT_TARGET_TRIPLE"] = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

The `ubuntu-22.04 aarch64` legs of the MLIR Distro wheel build (mlirDistro.yml) have been consistently failing on `main` for at least the last couple days — masked from view because `upload_distro_wheels`/`smoke_test_wheels` are skipped on the `schedule`-triggered runs that normally exercise this workflow, and the `build` job itself is `continue-on-error: true`.           
                                                                                                                                     
The actual failure is a link error,:
```                                
  /usr/lib/gcc-cross/aarch64-linux-gnu/11/libstdc++.a(locale_init.o): in function __gnu_cxx::__throw_concurrence_lock_error()': 
  relocation truncated to fit: R_AARCH64_CALL26 against symbol __cxa_allocate_exception'
  collect2: error: ld returned 1 exit status                       
```

The aarch64 leg cross-links `mlir-opt`/`mlir-translate` as fully static binaries (`-static-libgcc -static-libstdc++`, `BUILD_SHARED_LIBS=OFF`). The resulting binaries are large enough that GNU `ld` fails to insert AArch64 long-branch veneers, so even calls *within* `libstdc++.a` (e.g. `__cxa_throw`) overflow the ±128MB range of the `R_AARCH64_CALL26` relocation.

Fix: link with `lld` instead, via `CMAKE_EXE_LINKER_FLAGS_INIT`/`CMAKE_MODULE_LINKER_FLAGS_INIT`/`CMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=lld` in `utils/mlir_wheels/setup.py`, and install the `lld` apt package alongside the existing aarch64 cross-toolchain in `setup_base`. This is the same workaround already used elsewhere in this repo's CMake configs (buildAndTestPythons.yml, lintAndFormat.yml, buildAndTestVitis.yml, buildAndTestRyzenAISw.yml) for large LLVM/MLIR link units.
                                                                   
Note: `mlirDistro.yml` only runs on `pull_request` when the PR touches that exact file, so this PR won't self-validate on the aarch64 legs unless a no-op change to `.github/workflows/mlirDistro.yml` is included, or the workflow is triggered manually via `workflow_dispatch`.   

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
