### PR TITLE
[AIEVec] Lower aievec.neg to LLVM for AIE2 and AIE2p

### DIFF
--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -231,6 +231,18 @@ def SubACC2048AccFloatAIE2pIntrOp :
                    VectorOfLengthAndType<[64], [F32]>:$rhs,
                    I32:$conf)>;
 
+// ----- NEG -----
+
+def NegACC512AccFloatAIE2IntrOp
+    : AIEVec2_IntrOp<"ACC512.accfloat.neg.conf",
+                     [TypeIs<"res", VectorOfLengthAndType<[8], [I64]>>]>,
+      Arguments<(ins VectorOfLengthAndType<[8], [I64]>:$source, I32:$conf)>;
+
+def NegACC2048AccFloatAIE2pIntrOp
+    : AIEVec2p_IntrOp<"ACC2048.accfloat.neg.conf",
+                      [TypeIs<"res", VectorOfLengthAndType<[64], [F32]>>]>,
+      Arguments<(ins VectorOfLengthAndType<[64], [F32]>:$source, I32:$conf)>;
+
 // ----- SET -----
 
 def VectorSetI512I128IntrOp :

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -732,6 +732,106 @@ public:
   }
 };
 
+// AIE2 version of NegOp conversion.
+//
+// aievec.neg operates on an accumulator. For floats the accumulator is
+// v16accfloat, which is carried as vector<16xf32> in AIEVec and as <8 x i64>
+// at the intrinsic boundary, so this maps directly onto the ACC512 accfloat
+// negate.
+class NegOpAIE2Conversion : public mlir::ConvertOpToLLVMPattern<aievec::NegOp> {
+public:
+  using ConvertOpToLLVMPattern<aievec::NegOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(aievec::NegOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto srcVecTy = cast<VectorType>(adaptor.getSource().getType());
+    auto srcScaTy = srcVecTy.getElementType();
+
+    // Only the float accumulator (v16accfloat) is wired up. Integer
+    // accumulators would need the ACC1024 acc32/acc64 negates instead.
+    if (!isa<FloatType>(srcScaTy) || srcScaTy.getIntOrFloatBitWidth() != 32 ||
+        srcVecTy.getNumElements() != 16) {
+      op.emitWarning() << "aievec.neg conversion is not supported.\n";
+      return failure();
+    }
+
+    auto v8i64Ty = VectorType::get({8}, rewriter.getI64Type());
+    // conf selects the fp32 accumulator datapath. Matches the AIE API's
+    // neg(v16accfloat): aiev2_compute_control(0, 0, /*amode=*/2, /*bmode=*/3,
+    // 0, 0, 0, 0, 0, 0, 0) == (2 << 1) | (3 << 3) == 28.
+    auto confCst = LLVM::ConstantOp::create(
+        rewriter, loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(28));
+    SmallVector<Value> operands({adaptor.getSource(), confCst});
+
+    auto negOp = xllvm::NegACC512AccFloatAIE2IntrOp::create(
+        rewriter, loc, v8i64Ty,
+        forceCastOperandsToSignature(rewriter, loc, operands,
+                                     {v8i64Ty, rewriter.getI32Type()}));
+
+    auto resultVal =
+        forceCastValueToType(rewriter, loc, negOp, op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
+    return success();
+  }
+};
+
+// AIE2p version of NegOp conversion.
+//
+// AIE2p only exposes the negate on the 2048-bit accumulator, so a
+// v16accfloat operand is widened to <64 x float>, negated, and the low 16
+// lanes extracted back out. This mirrors AddElemOpAIE2pConversion.
+class NegOpAIE2pConversion
+    : public mlir::ConvertOpToLLVMPattern<aievec::NegOp> {
+public:
+  using ConvertOpToLLVMPattern<aievec::NegOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(aievec::NegOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto srcVecTy = cast<VectorType>(adaptor.getSource().getType());
+    auto srcScaTy = srcVecTy.getElementType();
+    unsigned laneSize = srcVecTy.getNumElements();
+
+    if (!isa<FloatType>(srcScaTy) || srcScaTy.getIntOrFloatBitWidth() != 32 ||
+        (laneSize != 16 && laneSize != 32)) {
+      op.emitWarning() << "aievec.neg conversion is not supported.\n";
+      return failure();
+    }
+
+    auto v64f32Ty = VectorType::get({64}, rewriter.getF32Type());
+
+    // Widen the accumulator to ACC2048, filling the unused lanes with poison.
+    SmallVector<int64_t> expandMask;
+    for (unsigned i = 0; i < laneSize; ++i)
+      expandMask.push_back(i);
+    for (unsigned i = laneSize; i < 64; ++i)
+      expandMask.push_back(-1);
+    auto srcExpanded = vector::ShuffleOp::create(
+        rewriter, loc, adaptor.getSource(), adaptor.getSource(), expandMask);
+
+    // conf selects the fp32 accumulator datapath, matching the ACC2048
+    // accfloat add/sub lowerings and the AIE API's neg(v64accfloat):
+    // aie2p_compute_control(0, 0, /*amode=*/2, /*bmode=*/3, /*variant=*/1,
+    // 0, 0, 0, 0, 0, 0) == (2 << 1) | (3 << 3) | (1 << 5) == 60.
+    auto confCst = LLVM::ConstantOp::create(
+        rewriter, loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(60));
+    auto negResult = xllvm::NegACC2048AccFloatAIE2pIntrOp::create(
+        rewriter, loc, v64f32Ty, srcExpanded, confCst);
+
+    SmallVector<int64_t> extractMask;
+    for (unsigned i = 0; i < laneSize; ++i)
+      extractMask.push_back(i);
+    auto finalResult = vector::ShuffleOp::create(rewriter, loc, negResult,
+                                                 negResult, extractMask);
+
+    rewriter.replaceOp(op, finalResult);
+    return success();
+  }
+};
+
 class SubOpConversion
     : public mlir::ConvertOpToLLVMPattern<aievec::aie1::SubOp> {
 public:
@@ -5647,6 +5747,7 @@ static void populateAIEVecToLLVMAIE2ConversionPatterns(
     Aie2Fp32Emulation aie2Fp32EmulationOption) {
   // Patterns specific to AIE2 backend
   patterns.add<AddElemOpAIE2Conversion, SubElemOpAIE2Conversion>(converter);
+  patterns.add<NegOpAIE2Conversion>(converter);
   patterns.add<MulElemOpConversion>(converter, aie2Fp32EmulationOption);
   patterns.add<UPSOpAIE2Conversion, SRSOpAIE2Conversion>(converter);
   patterns.add<ShiftOpConversion>(converter);
@@ -5746,6 +5847,7 @@ void populateAIEVecToLLVMAIE2pConversionPatterns(
     mlir::LLVMTypeConverter &converter, mlir::RewritePatternSet &patterns) {
   // Patterns specific to AIE2p backend
   patterns.add<AddElemOpAIE2pConversion, SubElemOpAIE2pConversion>(converter);
+  patterns.add<NegOpAIE2pConversion>(converter);
   patterns.add<MulElemOpAIE2pConversion>(converter);
   patterns.add<FMAElemOpAIE2pConversion>(converter);
   patterns.add<UPSOpAIE2pConversion, SRSOpAIE2pConversion>(converter);

--- a/test/Conversion/AIEVecToLLVM/test-neg-aie2p.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-neg-aie2p.mlir
@@ -1,0 +1,32 @@
+//===- test-neg-aie2p.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-aievec-to-llvm="aie-target=aie2p" | FileCheck %s
+
+// CHECK-LABEL: neg_v16f32
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: vector<16xf32>
+func.func @neg_v16f32(%src : vector<16xf32>) -> vector<16xf32> {
+  // CHECK: %[[SHUF0:.*]] = vector.shuffle %[[ARG0]], %[[ARG0]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1] : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[CONF:.*]] = llvm.mlir.constant(60 : i32) : i32
+  // CHECK: %[[NEG:.*]] = "xllvm.intr.aie2p.ACC2048.accfloat.neg.conf"(%[[SHUF0]], %[[CONF]]) : (vector<64xf32>, i32) -> vector<64xf32>
+  // CHECK: %[[SHUF1:.*]] = vector.shuffle %[[NEG]], %[[NEG]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<64xf32>, vector<64xf32>
+  // CHECK: return %[[SHUF1]] : vector<16xf32>
+  %0 = aievec.neg %src : vector<16xf32>
+  return %0 : vector<16xf32>
+}
+
+// CHECK-LABEL: neg_v32f32
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: vector<32xf32>
+func.func @neg_v32f32(%src : vector<32xf32>) -> vector<32xf32> {
+  // CHECK: %[[SHUF0:.*]] = vector.shuffle %[[ARG0]], %[[ARG0]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1] : vector<32xf32>, vector<32xf32>
+  // CHECK: %[[CONF:.*]] = llvm.mlir.constant(60 : i32) : i32
+  // CHECK: %[[NEG:.*]] = "xllvm.intr.aie2p.ACC2048.accfloat.neg.conf"(%[[SHUF0]], %[[CONF]]) : (vector<64xf32>, i32) -> vector<64xf32>
+  // CHECK: %[[SHUF1:.*]] = vector.shuffle %[[NEG]], %[[NEG]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<64xf32>, vector<64xf32>
+  // CHECK: return %[[SHUF1]] : vector<32xf32>
+  %0 = aievec.neg %src : vector<32xf32>
+  return %0 : vector<32xf32>
+}

--- a/test/Conversion/AIEVecToLLVM/test-neg.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-neg.mlir
@@ -1,0 +1,20 @@
+//===- test-neg.mlir -------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-aievec-to-llvm="aie-target=aie2" | FileCheck %s
+
+// CHECK-LABEL: neg_v16f32
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: vector<16xf32>
+func.func @neg_v16f32(%src : vector<16xf32>) -> vector<16xf32> {
+  // CHECK: %[[CONF:.*]] = llvm.mlir.constant(28 : i32) : i32
+  // CHECK: %[[BC0:.*]] = llvm.bitcast %[[ARG0]] : vector<16xf32> to vector<8xi64>
+  // CHECK: %[[NEG:.*]] = "xllvm.intr.aie2.ACC512.accfloat.neg.conf"(%[[BC0]], %[[CONF]]) : (vector<8xi64>, i32) -> vector<8xi64>
+  // CHECK: %[[BC1:.*]] = llvm.bitcast %[[NEG]] : vector<8xi64> to vector<16xf32>
+  // CHECK: return %[[BC1]] : vector<16xf32>
+  %0 = aievec.neg %src : vector<16xf32>
+  return %0 : vector<16xf32>
+}


### PR DESCRIPTION
## Description

`ComputeNegOpPattern` in `VectorToAIEVecConversions.cpp` rewrites a 16-lane `arith.negf` into `aievec.ups` / `aievec.neg` / `aievec.srs`, but `--convert-aievec-to-llvm` marks the whole AIEVec dialect illegal and has never registered a pattern for `aievec.neg` (the string `NegOp` does not appear in `AIEVecToLLVM.cpp`). The op is therefore unconditionally unlowerable — any float negate on a 16-lane vector that reaches this pipeline dies with:

```
error: failed to legalize operation 'aievec.neg' that was explicitly marked illegal
```

Both targets are affected, since `ComputeNegOpPattern` is registered in `populateAIEVecCommonConversionPatterns`. Minimal repro on current `main`:

```mlir
func.func @t(%in: memref<256xbf16>, %out: memref<256xbf16>) {
  %c0 = arith.constant 0 : index
  %cs = arith.constant 16 : index
  %c256 = arith.constant 256 : index
  %pad = arith.constant 0.0 : bf16
  scf.for %i = %c0 to %c256 step %cs {
    %a = vector.transfer_read %in[%i], %pad {in_bounds = [true]} : memref<256xbf16>, vector<16xbf16>
    %b = arith.negf %a : vector<16xbf16>
    vector.transfer_write %b, %out[%i] {in_bounds = [true]} : vector<16xbf16>, memref<256xbf16>
  }
  return
}
```

```
aie-opt --canonicalize-vector-for-aievec="aie-target=$T" \
        --convert-vector-to-aievec="aie-target=$T" \
        --convert-aievec-to-llvm="aie-target=$T" repro.mlir
```

| input | result before this PR |
| --- | --- |
| `negf vector<16xbf16>` | fails to legalize `aievec.neg` |
| `negf vector<16xf32>` | fails to legalize `aievec.neg` |
| `negf vector<32xbf16>` | OK |
| `negf vector<32xf32>` | OK |

32-lane negates survive only incidentally: `ComputeNegOpPattern` bails on `laneSize != 16` and leaves a legal `arith.negf` behind.

This surfaced downstream in Triton-XDNA. Triton recently changed float unary minus to emit `arith.negf` instead of `sub(0, x)` (`create_fneg` in `semantic.minus`), so kernels that previously lowered through `aievec.sub_elem` now hit this path. It is not Triton-specific — any frontend emitting a 16-lane float negate hits it.

## What this changes

- **`XLLVMAIE2IntrOps.td`**: adds `NegACC512AccFloatAIE2IntrOp` (`llvm.aie2.ACC512.accfloat.neg.conf`) and `NegACC2048AccFloatAIE2pIntrOp` (`llvm.aie2p.ACC2048.accfloat.neg.conf`), alongside the existing add/sub accfloat ops.
- **`AIEVecToLLVM.cpp`**: adds `NegOpAIE2Conversion` and `NegOpAIE2pConversion`. AIE2 maps directly onto the ACC512 negate. AIE2p has no 512-bit form, so it widens to `<64 x float>` with poison, negates, and extracts the low lanes back out — mirroring `AddElemOpAIE2pConversion`. Unsupported element types / lane counts return `failure()` with a warning rather than producing a dead-end op.
- **Tests**: `test-neg.mlir` (AIE2) and `test-neg-aie2p.mlir` (AIE2p, 16- and 32-lane).

### A note on the `conf` operand

The `conf` word selects the fp32 accumulator datapath. Rather than copying `conf=0` from the neighbouring `AddElemOpAIE2Conversion`, it is taken from the AIE API headers in llvm-aie:

```c
INTRINSIC(v16accfloat) neg(v16accfloat acc) {
  int conf = aiev2_compute_control(0, 0, /*amode=*/2, /*bmode=*/3, 0, ...);   // == 28
INTRINSIC(v64accfloat) neg(v64accfloat acc) {
  int conf = aie2p_compute_control(0, 0, /*amode=*/2, /*bmode=*/3, /*variant=*/1, ...);  // == 60
```

So this PR uses **28** for AIE2 and **60** for AIE2p. The AIE2p value already matches what the existing ACC2048 add/sub lowerings use. Worth flagging separately: the **AIE2** `add.accfloat` / `sub.accfloat` lowerings pass `conf=0`, which does not match the header value of 28. Those appear to work in practice, so I have left them untouched here — but someone with the hardware spec may want to confirm whether that is benign or a latent bug.

## Validation

Lowering, per target:

| stage | aie2 | aie2p |
| --- | --- | --- |
| `--convert-aievec-to-llvm` | ok | ok |
| LLVM IR | `@llvm.aie2.ACC512.accfloat.neg.conf` | `@llvm.aie2p.ACC2048.accfloat.neg.conf` |
| Peano `llc` | `vneg.f bmh0, bmh0, r16` | `vneg.f dm0, dm0, r2` |

On **npu1 hardware** (Phoenix, XRT 2.23.0):

- A bf16 kernel computing `y = -x` over 1024 values is **bitwise equal** to the torch reference (`torch.equal`). Reverting to a stock `aiecc` makes the same kernel fail with `failed to legalize operation 'aievec.neg'`, confirming the path is exercised.
- Three previously failing end-to-end tests (sigmoid, silu, swiglu) now pass; the surrounding suite is unchanged at 13/18, matching its pre-existing baseline.

`lit test/Conversion/AIEVecToLLVM` and `test/Dialect/AIEVec`: 45/45 pass.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing (n/a)
- [x] Code is formatted (`clang-format` on the touched C++; the `.td` hunk follows surrounding style)
- [x] `ruff check` and `pyright` pass locally for any touched Python file (n/a — no Python touched)