### PR TITLE
[aievec] Don't vectorize scalar arith inside runtime_sequence (#3549)

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEVec/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_dialect_library(MLIRAIEVecTransforms
   MLIRAIEVecAnalysisPassIncGen
 
   LINK_LIBS PUBLIC
+  AIE
   MLIRIR
   MLIRPass
   MLIRAIEVecUtils)

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -9,6 +9,7 @@
 // to ops that can be translated to a sequence of valid AIEVec ops.
 //===----------------------------------------------------------------------===//
 
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEVec/AIE1/IR/AIEVecAIE1Ops.h"
 #include "aie/Dialect/AIEVec/AIEVecUtils.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecOps.h"
@@ -6102,7 +6103,7 @@ struct LowerVectorToAIEVec : PassWrapper<LowerVectorToAIEVec, OperationPass<>> {
         .insert<affine::AffineDialect, xilinx::aievec::aie1::AIEVecAIE1Dialect,
                 xilinx::aievec::AIEVecDialect, arith::ArithDialect,
                 memref::MemRefDialect, scf::SCFDialect, vector::VectorDialect,
-                emitc::EmitCDialect>();
+                emitc::EmitCDialect, xilinx::AIE::AIEDialect>();
   }
 
   Option<std::string> aieTarget{
@@ -6117,6 +6118,15 @@ struct LowerVectorToAIEVec : PassWrapper<LowerVectorToAIEVec, OperationPass<>> {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     ConversionTarget target(*context);
+
+    // `aie.runtime_sequence` bodies are host-side control code (either NPU
+    // instruction streams or C++ TXN builders), not AIE-core compute. Vector
+    // and AIEVec ops are meaningless there, so leave anything nested inside a
+    // runtime sequence untouched regardless of the legalizations configured
+    // below.
+    target.addLegalOp<xilinx::AIE::RuntimeSequenceOp>();
+    target.markOpRecursivelyLegal<xilinx::AIE::RuntimeSequenceOp>();
+
     auto aieVersion = AIEArch::AIE;
     if (!aieTarget.empty()) {
       std::string targetStr = aieTarget;

--- a/test/Conversion/VectorToAIEVec/test-scalar-promotion-runtime-sequence.mlir
+++ b/test/Conversion/VectorToAIEVec/test-scalar-promotion-runtime-sequence.mlir
@@ -1,0 +1,56 @@
+//===- test-scalar-promotion-runtime-sequence.mlir ----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Regression for https://github.com/Xilinx/mlir-aie/issues/3549.
+//
+// LowerVectorToAIEVec promotes scalar arith.minsi/maxsi/shrsi to vector
+// aievec ops (see test-scalar-promotion.mlir) to work around an AIE2 backend
+// crash when lowering aie.core kernel bodies. `aie.runtime_sequence` bodies
+// are host-side control code (an NPU instruction stream or a C++ TXN
+// builder), not aie.core compute: they never go through that backend, and
+// aievec ops there are rejected outright ("'aievec.broadcast_scalar' op is
+// not supported by the C++ TXN target"). The pass must leave scalar arith
+// inside a runtime sequence untouched, regardless of AIE target.
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p" | FileCheck %s
+
+// CHECK-LABEL: aie.runtime_sequence @clamp_in_runtime_sequence
+// CHECK-NOT: aievec.
+// CHECK: arith.maxsi
+// CHECK: arith.minsi
+// CHECK: arith.shrsi
+// CHECK-NOT: aievec.
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence @clamp_in_runtime_sequence(%arg0 : i32, %arg1 : i32, %out : memref<i32>) {
+      %0 = arith.maxsi %arg0, %arg1 : i32
+      memref.store %0, %out[] : memref<i32>
+      %1 = arith.minsi %0, %arg1 : i32
+      memref.store %1, %out[] : memref<i32>
+      %2 = arith.shrsi %1, %arg1 : i32
+      memref.store %2, %out[] : memref<i32>
+    }
+  }
+}
+
+// -----
+
+// Companion control: the same scalar ops in an aie.core body (real AIE2
+// compute) must still be promoted. The fix for #3549 must not disable the
+// optimization outside of runtime sequences.
+
+// CHECK-LABEL: func.func @scalar_ops_in_core
+// CHECK: aievec.broadcast_scalar
+// CHECK: aievec.broadcast_scalar
+// CHECK: aievec.max
+// CHECK: aievec.ext_elem
+// CHECK-NOT: arith.maxsi
+func.func @scalar_ops_in_core(%a: i32, %b: i32) -> i32 {
+  %0 = arith.maxsi %a, %b : i32
+  return %0 : i32
+}


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Fixes #3549 

LowerVectorToAIEVec runs on the whole module and promotes scalar arith.minsi/maxsi/shrsi to vector aievec ops as an AIE2/AIE2P backend workaround for aie.core kernel bodies. Since it has no awareness of aie.runtime_sequence boundaries, it was also promoting the same scalar ops when they appeared in a runtime sequence, producing aievec ops (e.g. aievec.broadcast_scalar) that the C++ TXN target rejects outright -- runtime sequences are host-side control code, not AIE-core compute.

Mark aie.runtime_sequence recursively legal in the conversion target so its body is left untouched regardless of AIE target, while aie.core (and other) bodies keep the existing promotion behavior.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
