### PR TITLE
[AIE] Let a non-core peer's known column decide the centroid

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1145,15 +1145,9 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
   if (ltoIt == flowIndex.ltoFlows.end())
     return 0;
 
-  // The column of a peer, when it is already known. A core is known by
-  // construction (physical, or placed in an earlier phase). A non-core peer --
-  // a memtile or shim -- is known only if it carries an explicit col or was
-  // already placed; when it is, that peer IS this flow's destination and the
-  // core indirection below must not run. Resolving past a known memtile
-  // over-collects: a memtile typically serves several unrelated flows, so
-  // walking to its cores returns the union of every column it touches. A shim
-  // feeding a memtile pinned to col 1 was pulled to col 3 that way, because
-  // that memtile also carried packet flows reaching cols 0, 2, 5, 6 and 7.
+  // A peer's column when already known. A known non-core peer IS the
+  // destination; resolving past it over-collects, since a memtile usually
+  // serves several unrelated flows.
   auto resolvePeerCol = [&](Value v) -> std::optional<int> {
     Operation *defOp = v.getDefiningOp();
     if (!defOp)

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1145,9 +1145,9 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
   if (ltoIt == flowIndex.ltoFlows.end())
     return 0;
 
-  // A peer's column when already known. A known non-core peer IS the
-  // destination; resolving past it over-collects, since a memtile usually
-  // serves several unrelated flows.
+  // Column of a flow endpoint, or nullopt if not yet fixed. A memtile that
+  // already knows its column answers here; looking past it to its cores
+  // would pick up the other flows it carries.
   auto resolvePeerCol = [&](Value v) -> std::optional<int> {
     Operation *defOp = v.getDefiningOp();
     if (!defOp)

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1145,7 +1145,16 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
   if (ltoIt == flowIndex.ltoFlows.end())
     return 0;
 
-  auto resolveCoreCol = [&](Value v) -> std::optional<int> {
+  // The column of a peer, when it is already known. A core is known by
+  // construction (physical, or placed in an earlier phase). A non-core peer --
+  // a memtile or shim -- is known only if it carries an explicit col or was
+  // already placed; when it is, that peer IS this flow's destination and the
+  // core indirection below must not run. Resolving past a known memtile
+  // over-collects: a memtile typically serves several unrelated flows, so
+  // walking to its cores returns the union of every column it touches. A shim
+  // feeding a memtile pinned to col 1 was pulled to col 3 that way, because
+  // that memtile also carried packet flows reaching cols 0, 2, 5, 6 and 7.
+  auto resolvePeerCol = [&](Value v) -> std::optional<int> {
     Operation *defOp = v.getDefiningOp();
     if (!defOp)
       return std::nullopt;
@@ -1155,17 +1164,26 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
         return tileOp.getCol();
       return std::nullopt;
     }
-    if (auto lto = dyn_cast<LogicalTileOp>(defOp);
-        lto && lto.getTileType() == AIETileType::CoreTile) {
+    auto lto = dyn_cast<LogicalTileOp>(defOp);
+    if (!lto)
+      return std::nullopt;
+    if (lto.getTileType() == AIETileType::CoreTile) {
       auto it = result.find(defOp);
       if (it != result.end())
         return it->second.col;
+      return std::nullopt;
     }
+    if (auto c = lto.tryGetCol())
+      return *c;
+    auto it = result.find(defOp);
+    if (it != result.end())
+      return it->second.col;
     return std::nullopt;
   };
 
-  // One level of indirection for shim->memtile->core. Multi-level memtile
-  // chains aren't currently produced by mlir-aie.
+  // One level of indirection for shim->memtile->core, used only when the
+  // memtile's own column is still unknown. Multi-level memtile chains aren't
+  // currently produced by mlir-aie.
   auto resolveLtoCoreCols = [&](Value v) {
     SmallVector<int> out;
     auto it = flowIndex.ltoFlows.find(v);
@@ -1173,7 +1191,7 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
       return out;
     for (auto &peerList : it->second)
       for (Value p : peerList)
-        if (auto col = resolveCoreCol(p))
+        if (auto col = resolvePeerCol(p))
           out.push_back(*col);
     return out;
   };
@@ -1182,7 +1200,7 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
   for (auto &peers : ltoIt->second) {
     SmallVector<int> dests;
     for (Value p : peers) {
-      if (auto col = resolveCoreCol(p)) {
+      if (auto col = resolvePeerCol(p)) {
         dests.push_back(*col);
         continue;
       }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1152,23 +1152,14 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
     Operation *defOp = v.getDefiningOp();
     if (!defOp)
       return std::nullopt;
-    if (auto tileOp = dyn_cast<TileOp>(defOp)) {
-      if (targetModel->getTileType(tileOp.getCol(), tileOp.getRow()) ==
-          AIETileType::CoreTile)
-        return tileOp.getCol();
-      return std::nullopt;
-    }
+    // A physical tile's column is fixed by construction, whatever its type.
+    if (auto tileOp = dyn_cast<TileOp>(defOp))
+      return tileOp.getCol();
     auto lto = dyn_cast<LogicalTileOp>(defOp);
     if (!lto)
       return std::nullopt;
-    if (lto.getTileType() == AIETileType::CoreTile) {
-      auto it = result.find(defOp);
-      if (it != result.end())
-        return it->second.col;
-      return std::nullopt;
-    }
     if (auto c = lto.tryGetCol())
-      return *c;
+      return c;
     auto it = result.find(defOp);
     if (it != result.end())
       return it->second.col;
@@ -1370,8 +1361,6 @@ void TileAvailability::removeTile(TileID tile, AIETileType type) {
   case AIETileType::ShimNOCTile:
   case AIETileType::ShimPLTile:
     removeFromVector(nonCompTiles);
-    break;
-  default:
     break;
   }
 }

--- a/test/place-tiles/test_shim_follows_pinned_memtile.mlir
+++ b/test/place-tiles/test_shim_follows_pinned_memtile.mlir
@@ -1,0 +1,47 @@
+//===- test_shim_follows_pinned_memtile.mlir -------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// An unpinned shim feeding a MemTile that is pinned to a column, where that
+// same MemTile also carries unrelated traffic to cores in far-away columns.
+// The shim's destination is the memtile, and the memtile's column is known,
+// so the shim belongs in that column.
+//
+// The centroid used to resolve only CoreTile peers, so a memtile peer with a
+// known column was discarded and the search fell through to the memtile's
+// downstream cores. That returns the union of every column the memtile
+// touches -- here {0, 6, 7} -- placing the shim near their mean instead of
+// next to the memtile it actually feeds.
+//
+// Reduced from the weight feed of the fused LLM decode designs in mlir-air,
+// where a shim feeding a col-1 memtile was placed on col 3.
+
+// RUN: aie-opt --aie-place-tiles %s | FileCheck %s
+
+// CHECK-LABEL: aie.device(npu2)
+// The shim follows the memtile it feeds, not the memtile's other consumers.
+// CHECK-DAG: aie.tile(1, 0)
+// CHECK-NOT: aie.tile(3, 0)
+// CHECK-NOT: aie.tile(4, 0)
+
+module {
+  aie.device(npu2) {
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+    %mem = aie.logical_tile<MemTile>(1, ?)
+    %core0 = aie.tile(0, 2)
+    %core6 = aie.tile(6, 2)
+    %core7 = aie.tile(7, 2)
+
+    // The flow under test: host -> the pinned memtile.
+    aie.flow(%shim, DMA : 0, %mem, DMA : 0)
+
+    // The memtile's other traffic, spread across the array. These are what
+    // the core-only resolution used to collect for the shim.
+    aie.flow(%mem, DMA : 0, %core0, DMA : 0)
+    aie.flow(%mem, DMA : 1, %core6, DMA : 0)
+    aie.flow(%mem, DMA : 2, %core7, DMA : 0)
+  }
+}

--- a/test/place-tiles/test_shim_follows_pinned_memtile.mlir
+++ b/test/place-tiles/test_shim_follows_pinned_memtile.mlir
@@ -5,19 +5,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// An unpinned shim feeding a MemTile that is pinned to a column, where that
-// same MemTile also carries unrelated traffic to cores in far-away columns.
-// The shim's destination is the memtile, and the memtile's column is known,
-// so the shim belongs in that column.
-//
-// The centroid used to resolve only CoreTile peers, so a memtile peer with a
-// known column was discarded and the search fell through to the memtile's
-// downstream cores. That returns the union of every column the memtile
-// touches -- here {0, 6, 7} -- placing the shim near their mean instead of
-// next to the memtile it actually feeds.
-//
-// Reduced from the weight feed of the fused LLM decode designs in mlir-air,
-// where a shim feeding a col-1 memtile was placed on col 3.
+// An unpinned shim feeding a col-pinned MemTile that also carries unrelated
+// traffic to distant cores. Resolving past the memtile to those cores collects
+// {0, 6, 7} and places the shim near their mean; the memtile's own column is
+// the answer. Reduced from an mlir-air LLM decode weight feed.
 
 // RUN: aie-opt --aie-place-tiles %s | FileCheck %s
 


### PR DESCRIPTION
A shim feeding a memtile can be placed in the wrong column, producing a cross-column flow, even when the memtile's own column is already fixed.

### The case

Added as `test/place-tiles/test_shim_follows_pinned_memtile.mlir`:

```mlir
%shim  = aie.logical_tile<ShimNOCTile>(?, ?)   // column not yet decided
%mem   = aie.logical_tile<MemTile>(1, ?)       // column 1
%core0 = aie.tile(0, 2)
%core6 = aie.tile(6, 2)
%core7 = aie.tile(7, 2)

aie.flow(%shim, DMA:0, %mem,   DMA:0)   // the flow being placed
aie.flow(%mem,  DMA:0, %core0, DMA:0)   // unrelated traffic the memtile
aie.flow(%mem,  DMA:1, %core6, DMA:0)   // also carries
aie.flow(%mem,  DMA:2, %core7, DMA:0)
```

`%shim` sends to exactly one thing, `%mem`, and `%mem` is in column 1. The placer puts `%shim` in **column 4** before this change and **column 1** after.

### Why

To place a tile, `computeCentroidColumn` collects the columns of the tiles its flows reach and picks a column near them. It asks each endpoint for its column through a helper that only answered for core tiles, so a memtile returned "unknown" even with an explicit column written on it. On "unknown" the caller falls back to looking *past* that endpoint, at the cores behind it.

That fallback is right for a memtile whose position isn't decided yet, and wrong for one whose position is — a memtile is shared, so the cores behind it belong to other flows. Above, looking past `%mem` yields columns {0, 6, 7}; their mean, 4.33, is why the shim lands on column 4.

### Change

Answer with a non-core endpoint's column when it is already known — an explicit `col`, or a placement made earlier in the run — and fall back to the core walk only when it isn't. `resolveCoreCol` is renamed `resolvePeerCol`, since it no longer resolves cores exclusively.

### Limits

Memtiles and shims are placed from one demand-sorted list, so a memtile placed *after* the shim that feeds it is still unknown at that moment and takes the old path. Placing memtiles before the shims that feed them would close that gap; not attempted here.

### Testing

**lit:** no test fails with this change that does not also fail without it. (96 failures with, 97 without — the extra failure without it is the new test, behaving as designed. The 96 are pre-existing in my local configuration, which has no Peano, xrt or chess.)

**On NPU2 hardware**, through mlir-air's four Q4NX LLM decode designs. Those designs hand-pin 50 shim columns via an `air.shim_col` attribute specifically to work around this bug, which makes them a direct test of it:

- With the pins left in place, placement is **identical** before and after this change — existing pinned designs are undisturbed.
- With **38 of the 50 pins removed**, placement is **still identical**: 0 shim-placement diffs and 0 hardware-op diffs across all four designs. Those 38 pins existed only because of this bug.
- All 7 production decode `insts.bin` are **byte-identical** to the pre-change builds, so no performance change.
- Correctness: llama-3.2-1b PASS, llama-3.2-3b PASS, gemma3-4b 16.97 tok/s, qwen2.5-3b 12.19 tok/s, all with correct output.
- mlir-air regression net on the patched toolchain: `check-air-mlir` 487/487, `conv2d_14x14` PASS, `xrt/48` PASS, `xrt/50` 4/4 PASS at its stock 218 buffers / 292 locks.

The other 12 pins are genuine hand placement (spreading readback flows across columns) and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
