### PR TITLE
Add AIECC_PATH environment variable override to config.aiecc_path()

### DIFF
--- a/programming_guide/iron_configuration.md
+++ b/programming_guide/iron_configuration.md
@@ -93,6 +93,18 @@ ever editing the source.
 
 The IRON jit feature caches compiled objects in a directory defined by ```NPU_CACHE_HOME```. By default this value is the user's home directory.
 
+## aiecc Executable Override (`AIECC_PATH`)
+
+`aie.utils.config.aiecc_path()` resolves the `aiecc` executable used by JIT
+compilation: the `AIECC_PATH` environment variable first (an explicit full
+path to the `aiecc` executable), then the MLIR-AIE bin directory, then
+`PATH`. Set `AIECC_PATH` when a consumer needs to pin a specific `aiecc`
+without relying on `PATH` search order.
+
+```bash
+AIECC_PATH=/path/to/aiecc python my_script.py
+```
+
 ## IRON XRT Runtime Cache Size
 
 The `CachedXRTRuntime` caches XRT contexts to improve performance. The size of this cache can be configured using the `XRT_CONTEXT_CACHE_SIZE` environment variable. This is particularly useful in CI environments where multiple tests run in parallel and might exhaust the available NPU contexts.

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -73,8 +73,8 @@ def aiecc_path():
         return path_aiecc
 
     raise RuntimeError(
-        "Could not find aiecc. Expected it under the MLIR-AIE bin directory, "
-        "on PATH, or set via the AIECC_PATH environment variable."
+        "Could not find aiecc. Resolves in the order of the AIECC_PATH "
+        "environment variable, MLIR-AIE bin directory, then PATH."
     )
 
 

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -50,7 +50,20 @@ def root_path():
 
 
 def aiecc_path():
-    """Return the aiecc executable used by JIT compilation."""
+    """Return the aiecc executable used by JIT compilation.
+
+    Resolution order: the AIECC_PATH environment variable (for consumers,
+    e.g. IRON, that need to point at a specific aiecc without relying on
+    PATH search order), then the MLIR-AIE bin directory, then PATH.
+    """
+    env_aiecc = os.environ.get("AIECC_PATH")
+    if env_aiecc:
+        if not os.path.isfile(env_aiecc):
+            raise RuntimeError(
+                f"AIECC_PATH is set to {env_aiecc}, but no such file exists."
+            )
+        return env_aiecc
+
     bundled_aiecc = os.path.join(root_path(), "bin", _executable_name("aiecc"))
     if os.path.isfile(bundled_aiecc):
         return bundled_aiecc
@@ -60,8 +73,8 @@ def aiecc_path():
         return path_aiecc
 
     raise RuntimeError(
-        "Could not find aiecc. Expected it under the MLIR-AIE bin directory "
-        "or on PATH."
+        "Could not find aiecc. Expected it under the MLIR-AIE bin directory, "
+        "on PATH, or set via the AIECC_PATH environment variable."
     )
 
 

--- a/test/python/test_config.py
+++ b/test/python/test_config.py
@@ -1,0 +1,26 @@
+# test_config.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# RUN: %pytest %s
+
+"""Unit tests for aie.utils.config's AIECC_PATH override."""
+
+import pytest
+
+import aie.utils.config as config
+
+
+def test_aiecc_path_env_override(tmp_path, monkeypatch):
+    fake_aiecc = tmp_path / "aiecc"
+    fake_aiecc.touch()
+    monkeypatch.setenv("AIECC_PATH", str(fake_aiecc))
+    assert config.aiecc_path() == str(fake_aiecc)
+
+
+def test_aiecc_path_env_override_missing_file_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIECC_PATH", str(tmp_path / "does-not-exist"))
+    with pytest.raises(RuntimeError, match="AIECC_PATH"):
+        config.aiecc_path()


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

- `aie.utils.config.aiecc_path()` previously only checked the bundled MLIR-AIE `bin/` directory, then `PATH` — there was no way to point at a specific `aiecc` explicitly. This came up while unifying IRON's compilation paths, where a consumer needs to pin `aiecc` without relying on `PATH` search order.
- Adds an `AIECC_PATH` env var override, checked first, mirroring the existing `PEANO_INSTALL_DIR` precedent in `configure.py`. An `AIECC_PATH` pointing at a nonexistent file is a hard error rather than a silent fallback.
- Documents the new variable in `programming_guide/iron_configuration.md` alongside the other IRON env vars (`NPU_CACHE_HOME`, `NPU_RUNTIME`, etc.) and in the `aiecc_path()` docstring.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
