### PR TITLE
[AIEX] set_lock takes a runtime_sequence ancestor, not a parent

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1554,8 +1554,10 @@ def AIEX_SetLockOp: AIEX_Op<"set_lock", [HasAncestor<"AIE::RuntimeSequenceOp">, 
   let summary = "Set the value of a lock";
   let description = [{
     This operation sets the value of `lock` inside of a RuntimeSequenceOp.
-    Ancestor rather than parent: it lowers to a single write32, so a rolled
-    runtime-bound loop can hold one the same way it holds a DMA configure.
+    Ancestor rather than parent: `aie-lower-set-lock` rewrites this into a
+    single `aiex.npu.write32`, which is legal anywhere inside the sequence, so
+    a runtime-bound `scf.for` may hold one just as it holds an
+    `aiex.dma_configure_task`.
     The operation is non blocking and does not offer any synchronization guarantees.
     Should be used in combination with blocking operations.
 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1550,7 +1550,8 @@ def AIE_DMAStartBdChainForOp: AIEX_Op<"dma_start_bd_chain_for", [HasParent<"AIE:
   }];
 }
 
-def AIEX_SetLockOp: AIEX_Op<"set_lock", [HasAncestor<"AIE::RuntimeSequenceOp">, SkipAccessibilityCheckTrait]> {
+def AIEX_SetLockOp : AIEX_Op<"set_lock", [HasAncestor<"AIE::RuntimeSequenceOp">,
+                                          SkipAccessibilityCheckTrait]> {
   let summary = "Set the value of a lock";
   let description = [{
     This operation sets the value of `lock` inside of a RuntimeSequenceOp.

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1550,10 +1550,12 @@ def AIE_DMAStartBdChainForOp: AIEX_Op<"dma_start_bd_chain_for", [HasParent<"AIE:
   }];
 }
 
-def AIEX_SetLockOp: AIEX_Op<"set_lock", [HasParent<"AIE::RuntimeSequenceOp">, SkipAccessibilityCheckTrait]> {
+def AIEX_SetLockOp: AIEX_Op<"set_lock", [HasAncestor<"AIE::RuntimeSequenceOp">, SkipAccessibilityCheckTrait]> {
   let summary = "Set the value of a lock";
   let description = [{
     This operation sets the value of `lock` inside of a RuntimeSequenceOp.
+    Ancestor rather than parent: it lowers to a single write32, so a rolled
+    runtime-bound loop can hold one the same way it holds a DMA configure.
     The operation is non blocking and does not offer any synchronization guarantees.
     Should be used in combination with blocking operations.
 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1555,10 +1555,6 @@ def AIEX_SetLockOp : AIEX_Op<"set_lock", [HasAncestor<"AIE::RuntimeSequenceOp">,
   let summary = "Set the value of a lock";
   let description = [{
     This operation sets the value of `lock` inside of a RuntimeSequenceOp.
-    Ancestor rather than parent: `aie-lower-set-lock` rewrites this into a
-    single `aiex.npu.write32`, which is legal anywhere inside the sequence, so
-    a runtime-bound `scf.for` may hold one just as it holds an
-    `aiex.dma_configure_task`.
     The operation is non blocking and does not offer any synchronization guarantees.
     Should be used in combination with blocking operations.
 

--- a/test/Passes/lower-set-lock/lower_set_lock_in_loop.mlir
+++ b/test/Passes/lower-set-lock/lower_set_lock_in_loop.mlir
@@ -1,0 +1,67 @@
+//===- lower_set_lock_in_loop.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-lower-set-lock %s | FileCheck %s
+
+// aiex.set_lock lowers to a single write32, so it is valid anywhere a write is
+// valid inside a runtime sequence -- including inside a rolled loop or a
+// select arm, not only as a direct child of the sequence. A control program
+// that keeps its loop rolled (a runtime-bound trip count, which is the point
+// of the dynamic BD pool path) has to release a lock once per iteration.
+
+// CHECK-LABEL: @lock_in_runtime_bound_loop
+// CHECK:         scf.for
+// 126976 = 0x0001F000, lock 0 in a compute tile's local address space.
+// CHECK-DAG:       %[[V0:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[A0:.*]] = arith.constant 126976 : i32
+// CHECK:           aiex.npu.write32(%[[A0]], %[[V0]]) {column = 2 : i32, row = 2 : i32} : i32, i32
+module @lock_in_runtime_bound_loop {
+  aie.device(npu2) {
+    %tile22 = aie.tile(2, 2)
+    %lock22_0 = aie.lock(%tile22, 0) {init = 0 : i32}
+    aie.runtime_sequence(%n: index) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %i = %c0 to %n step %c1 {
+        aiex.set_lock(%lock22_0, 1)
+      }
+    }
+  }
+}
+
+// -----
+
+// Two levels down: a select arm inside a loop, which is where a rolled
+// per-iteration mode select puts its arming.
+
+// CHECK-LABEL: @lock_in_select_arm
+// CHECK:         scf.for
+// CHECK:           scf.index_switch
+// 786480 = 0x000C0030, lock 3 in a memtile's local address space.
+// CHECK-DAG:         %[[V1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:         %[[A1:.*]] = arith.constant 786480 : i32
+// CHECK:             aiex.npu.write32(%[[A1]], %[[V1]]) {column = 1 : i32, row = 1 : i32} : i32, i32
+module @lock_in_select_arm {
+  aie.device(npu2) {
+    %memtile11 = aie.tile(1, 1)
+    %lock11_3 = aie.lock(%memtile11, 3) {init = 0 : i32}
+    aie.runtime_sequence(%n: index, %sel: index) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %i = %c0 to %n step %c1 {
+        scf.index_switch %sel
+        case 0 {
+          aiex.set_lock(%lock11_3, 1)
+          scf.yield
+        }
+        default {
+          scf.yield
+        }
+      }
+    }
+  }
+}

--- a/test/dialect/AIEX/invalid.mlir
+++ b/test/dialect/AIEX/invalid.mlir
@@ -13,3 +13,16 @@ aie.device(npu1) {
     aiex.npu.dma_wait {symbol = @out0}
   }
 }
+
+// -----
+
+// set_lock takes a runtime_sequence ANCESTOR, not necessarily a parent -- a
+// rolled loop or a select arm may hold one. It still has to be under a
+// sequence somewhere, though: this one is under a plain func.
+func.func @set_lock_outside_sequence() {
+  %tile22 = aie.tile(2, 2)
+  %lock22_0 = aie.lock(%tile22, 0) {init = 0 : i32}
+  // expected-error@+1 {{'aiex.set_lock' op expects ancestor op 'aie.runtime_sequence'}}
+  aiex.set_lock(%lock22_0, 1)
+  return
+}


### PR DESCRIPTION
`aiex.set_lock` is `HasParent<RuntimeSequenceOp>`, so it can only ever be a direct child of the sequence. It lowers to a single `npu.write32`, which is valid anywhere a write is valid — including inside a loop or a select arm.

The restriction blocks the rolled control program that the dynamic BD pool path exists for. `aie-lower-dynamic-bd-pool` keeps a runtime-bound `scf.for` rolled and draws BD ids from a runtime free list, and the DMA ops it handles (`dma_configure_task`, `dma_start_task`, …) already use `HasAncestor`. A sequence that releases a herd lock once per iteration cannot express that today: the `set_lock` has to sit outside the loop it belongs to.

This relaxes it to `HasAncestor`, matching the DMA ops.

**No lowering change.** `AIELowerSetLock` rewrites the op in place, so it already handles nesting — the two positive tests below pass with only the trait changed.

### Tests

`test/Passes/lower-set-lock/lower_set_lock_in_loop.mlir` (new)
- `set_lock` inside a **runtime-bound** `scf.for` (the form the static BD-id allocator rejects and the pool path handles) → checks the `write32` lands inside the loop with the right address and column/row.
- `set_lock` two levels down, in a select arm inside a loop — where a rolled per-iteration mode select puts its arming.

`test/dialect/AIEX/invalid.mlir`
- Negative case: a `set_lock` under a plain `func.func`, with no sequence anywhere above it, is still rejected. This pins that the relaxation is ancestor-not-anywhere; there was no test asserting the old rejection.

### Context

Found while making mlir-air's `airrt-to-npu` stop unrolling its runtime sequence, so that aiecc's `aie-unroll-runtime-sequence-loops` is the single unroller in the stack. With this trait relaxed, all four of our q4nx/q4 LLM decoders build with the loop rolled and produce a **word-for-word identical** instruction stream to the unrolled build (llama-3.2-1B, llama-3.2-3B, gemma-3-4B, qwen-2.5-3B; verified at several context lengths), and pass their end-to-end gates on NPU2.

Five other AIEX ops carry the same `HasParent` restriction (`dma_start_bd_chain`, `dma_start_bd_chain_for`, `dma_channel_reset`, `dma_channel_reset_for`, `core_reset`). Only `set_lock` is on this path today, so I have left those alone rather than relax them untested.