### PR TITLE
[cert] Add deterministic multi-uC runtime sequencing and verification

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -139,7 +139,11 @@ public:
   virtual uint32_t getNumControllersPerColumn() const { return 0; }
 
   /// Total number of aie2ps/aie4 microcontrollers (uC) in the device.
-  uint32_t getNumControllers() const {
+  /// Defaults to one uC per column (see getNumControllersPerColumn());
+  /// architectures with a single device-level uC (e.g. AIE2/AIE2P NPUs)
+  /// override this directly instead, since their controller count doesn't
+  /// scale with column count.
+  virtual uint32_t getNumControllers() const {
     return static_cast<uint32_t>(columns()) * getNumControllersPerColumn();
   }
 
@@ -1037,6 +1041,9 @@ public:
 
   uint32_t getNumMemTileRows() const override { return 1; }
 
+  // AIE2 NPU1 has a single device-level uC, not one per column.
+  uint32_t getNumControllers() const override { return 1; }
+
   static bool classof(const AIETargetModel *model) {
     return model->getKind() >= TK_AIE2_NPU1_1Col &&
            model->getKind() < TK_AIE2_NPU1_Last;
@@ -1106,6 +1113,9 @@ public:
   bool isSupportedBlockFormat(std::string const &format) const override;
 
   bool isMemTilePadValueSupported() const override { return true; }
+
+  // AIE2P NPU2 has a single device-level uC, not one per column.
+  uint32_t getNumControllers() const override { return 1; }
 
   static bool classof(const AIETargetModel *model) {
     return model->getKind() >= TK_AIE2_NPU2 &&

--- a/include/aie/Dialect/AIEX/IR/CERTOps.td
+++ b/include/aie/Dialect/AIEX/IR/CERTOps.td
@@ -71,10 +71,18 @@ def AIE_CertPageOp: AIEX_Op<"cert.page",
   let summary = "A control code page";
   let description = [{
     This operation represents a page of control code. Pages are the basic unit
-    of control code organization, with a maximum size of 8192 bytes. Each page
-    typically contains one job along with its associated data.
+    of control code organization, with a maximum size of 8192 bytes. A page may
+    contain one or more jobs along with their associated data; jobs within a
+    page are cooperatively scheduled (see `cert.job`), while pages of a given
+    microcontroller execute strictly in order.
 
     Corresponds to the `.eop` (end of page) directive in assembly.
+
+    The optional `placement` attribute selects the microcontroller (CERT group /
+    uC id) that runs this page. It is a resolved group id — use the target
+    model's `getUcGroupId(col, half)` to compute it rather than deriving it by
+    hand. When absent, the page defaults to group 0 (col0/uC0). A later pass lowers
+    `placement` to an enclosing `cert.attach_to_group`.
 
     Example:
     ```
@@ -83,12 +91,26 @@ def AIE_CertPageOp: AIEX_Op<"cert.page",
           cert.write32(0x1000, 42)
         }
       }
+
+      // placed on microcontroller (group) 2:
+      cert.page {
+        cert.job(1) {
+          cert.write32(0x2000, 43)
+        }
+      } {placement = 2 : i32}
     ```
   }];
+  let arguments = (ins OptionalAttr<I32Attr>:$placement);
   let regions = (region
     AnyRegion:$body
   );
   let assemblyFormat = [{ $body attr-dict }];
+  let builders = [
+      // Convenience builder for an unplaced page (defaults to group 0), keeping
+      // the previous no-argument call sites valid.
+      OpBuilder<(ins), [{
+      build($_builder, $_state, /*placement=*/nullptr);
+    }]>];
 }
 
 def AIE_CertJobOp: AIEX_Op<"cert.job", [ParentOneOf<["AIE::DeviceOp", "CertAttachToGroupOp",
@@ -96,8 +118,16 @@ def AIE_CertJobOp: AIEX_Op<"cert.job", [ParentOneOf<["AIE::DeviceOp", "CertAttac
                                         SingleBlockImplicitTerminator<"AIE::EndOp">]> {
   let summary = "Start a job with a given job ID";
   let description = [{
-    This operation starts a job identified by the given job ID. The job ID is an
-    integer that uniquely identifies the job to be started.
+    This operation starts a job identified by the given job ID.
+
+    The job ID is a *label*, not an execution or emission order: it must be
+    unique among jobs on the same page, and the CERT firmware uses it as a
+    job-table key (and as the handle referenced by deferred/launch jobs). It is
+    NOT a priority. Emission order and execution order are both determined by
+    textual (IR) order: within a page the firmware starts jobs in textual order
+    (running each until it blocks or ends), and between pages on one uC
+    execution is strictly sequential. Emitters must therefore preserve IR order
+    and must not sort jobs by job_id.
 
     Example:
     ```

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -30,6 +30,7 @@ std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIEDecomposeLargeDmaBdPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createAIENpuToCertPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECertPagesPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECertVerifyPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createAIEXToStandardPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createAIESCFToControlFlowPass();

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -239,6 +239,24 @@ def AIECertPages : Pass<"cert-legalize-pages", "AIE::DeviceOp"> {
   ];
 }
 
+def AIECertVerify : Pass<"aie-cert-verify", "AIE::DeviceOp"> {
+  let summary = "Verify CERT ordering/placement legality invariants";
+  let description = [{
+    This pass checks the firmware-imposed legality invariants on cert
+    operations (see the CERT runtime-sequence report). It performs no IR
+    mutation; it only emits diagnostics for illegal cert programs.
+
+    The uC (microcontroller / CERT group) of a cert op is the `group_id` of
+    its nearest enclosing `cert.attach_to_group`, or 0 if the op is at device
+    level (not inside any `cert.attach_to_group`).
+  }];
+
+  let constructor = "xilinx::AIEX::createAIECertVerifyPass()";
+  let dependentDialects = ["xilinx::AIE::AIEDialect",
+                           "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 def AIEMaterializeBDChains : Pass<"aie-materialize-bd-chains", "AIE::DeviceOp"> {
   let summary = "Concretize aie.bd_chain ops at aiex.start_task use sites";
   let description = [{

--- a/lib/Dialect/AIEX/Transforms/AIECertVerify.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECertVerify.cpp
@@ -1,0 +1,353 @@
+//===- AIECertVerify.cpp ---------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <map>
+#include <set>
+#include <tuple>
+#include <utility>
+
+namespace xilinx::AIEX {
+#define GEN_PASS_DEF_AIECERTVERIFY
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+} // namespace xilinx::AIEX
+
+using namespace mlir;
+using namespace xilinx;
+
+#define DEBUG_TYPE "cert-verify"
+
+namespace {
+
+// The uC (CERT group) id of a cert op is the group_id of its nearest enclosing
+// cert.attach_to_group, or 0 if it is at device level.
+static int getUcGroupId(Operation *op) {
+  auto group = op->getParentOfType<AIEX::CertAttachToGroupOp>();
+  return group ? group.getGroupID() : 0;
+}
+
+// G-localbar: within each uC scope, all cert.local_barrier ops that share a
+// local_barrier_id must reside in the same cert.page (their participants must
+// be co-resident on one page, else the firmware hangs).
+static LogicalResult checkLocalBarrierColocation(AIE::DeviceOp device) {
+  LogicalResult result = success();
+  // Key: (uC group id, local_barrier_id) -> the co-location scope the id was
+  // first seen in. Participants of a local barrier must share one page; a
+  // barrier in a standalone job (no page) uses its enclosing job as its scope,
+  // so barriers in *different* standalone jobs are correctly flagged as not
+  // co-located (and two in the same job are fine). local_barrier always has an
+  // enclosing job (HasParent<CertJobOp>), so the scope is never null.
+  std::map<std::pair<int, int>, Operation *> firstScope;
+  device.walk(
+      [&](AIEX::CertLocalBarrierOp barrier) {
+        int uc = getUcGroupId(barrier);
+        int id = barrier.getLocalBarrierId();
+        Operation *scope = barrier->getParentOfType<AIEX::CertPageOp>();
+        if (!scope)
+          scope = barrier->getParentOfType<AIEX::CertJobOp>();
+        auto key = std::make_pair(uc, id);
+        auto it = firstScope.find(key);
+        if (it == firstScope.end()) {
+          firstScope[key] = scope;
+          return;
+        }
+        if (it->second != scope) {
+          barrier.emitError()
+              << "cert.local_barrier with local_barrier_id " << id << " in uC "
+              << uc << " must be on the same page as its other participants";
+          result = failure();
+        }
+      });
+  return result;
+}
+
+// G-tct: within one page, at most one *job* may wait on a given (tile_id,
+// channel_id). The firmware tracks a single outstanding TCT count per actor, so
+// two jobs that are cooperatively scheduled on the same page and both wait on
+// the same actor over-wait and hang forever.
+//
+// The constraint is on concurrency, not on the whole uC program, so two cases
+// that look like duplicates are legal and must not be flagged:
+//   - two wait_tcts in the *same job*: a job is a single thread of control, so
+//     they execute in sequence and only one is ever outstanding;
+//   - two wait_tcts on *different pages* of one uC: pages execute strictly in
+//     order, so the earlier wait has retired before the later page starts.
+// A page belongs to exactly one uC, so keying on the page scope also keys on
+// the uC; a wait in a bare job (no enclosing page, e.g. before
+// cert-legalize-pages has run) uses that job as its scope.
+static LogicalResult checkWaitTctsUniqueness(AIE::DeviceOp device) {
+  LogicalResult result = success();
+  // (page scope, tile, channel) -> the job that already waits on that actor.
+  std::map<std::tuple<Operation *, int, int>, Operation *> seen;
+  device.walk([&](AIEX::CertWaitTCTSOp wait) {
+    int tile = wait.getTileId();
+    int channel = wait.getChannelId();
+    Operation *job = wait->getParentOfType<AIEX::CertJobOp>();
+    Operation *scope = wait->getParentOfType<AIEX::CertPageOp>();
+    if (!scope)
+      scope = job;
+    auto key = std::make_tuple(scope, tile, channel);
+    auto it = seen.find(key);
+    if (it == seen.end()) {
+      seen[key] = job;
+      return;
+    }
+    // Same job: sequential within one thread of control, so legal.
+    if (it->second == job)
+      return;
+    wait.emitError() << "more than one job on this cert.page waits on tile "
+                     << tile << " channel " << channel << " in uC "
+                     << getUcGroupId(wait)
+                     << "; at most one job per page may wait_tcts on a given "
+                        "(tile, channel)";
+    result = failure();
+  });
+  return result;
+}
+
+// The set of uCs (CERT groups) present in a design: every group_id declared by
+// a cert.attach_to_group, plus 0 when there is cert content at device level.
+static std::set<int> computePresentUcs(AIE::DeviceOp device) {
+  std::set<int> present;
+  device.walk([&](AIEX::CertAttachToGroupOp group) {
+    present.insert(group.getGroupID());
+  });
+  if (!device.getBody()->getOps<AIEX::CertPageOp>().empty() ||
+      !device.getBody()->getOps<AIEX::CertJobOp>().empty() ||
+      !device.getBody()->getOps<AIEX::CertSectionOp>().empty())
+    present.insert(0);
+  return present;
+}
+
+// G-preempt: every uC must expose the same multiset of cert.preempt ids. A uC
+// is the group_id of an enclosing cert.attach_to_group, or 0 for device-level
+// content. Compare each present uC's preempt-id multiset against the smallest
+// present uC (the reference); a mismatch means a preemption point is missing or
+// extra on some uC, which the firmware requires to be consistent.
+static LogicalResult checkPreemptConsistency(AIE::DeviceOp device) {
+  std::map<int, std::multiset<int>> preemptIds;
+  std::map<int, AIEX::CertAttachToGroupOp> repAttach;
+  std::set<int> present;
+
+  // Every attach_to_group establishes a present uC.
+  device.walk([&](AIEX::CertAttachToGroupOp group) {
+    int uc = group.getGroupID();
+    present.insert(uc);
+    if (!repAttach.count(uc))
+      repAttach[uc] = group;
+  });
+
+  // Device-level cert content lives on uC 0.
+  if (!device.getBody()->getOps<AIEX::CertPageOp>().empty() ||
+      !device.getBody()->getOps<AIEX::CertJobOp>().empty() ||
+      !device.getBody()->getOps<AIEX::CertSectionOp>().empty())
+    present.insert(0);
+
+  // Collect the preempt ids per uC.
+  device.walk([&](AIEX::CertPreemptOp preempt) {
+    int uc = getUcGroupId(preempt);
+    present.insert(uc);
+    preemptIds[uc].insert(preempt.getId());
+  });
+
+  if (present.size() < 2)
+    return success();
+
+  int ref = *present.begin();
+  const std::multiset<int> &refSet = preemptIds[ref];
+  LogicalResult result = success();
+  for (int uc : present) {
+    if (uc == ref)
+      continue;
+    if (preemptIds[uc] != refSet) {
+      Operation *loc = repAttach.count(uc) ? repAttach[uc].getOperation()
+                                           : device.getOperation();
+      loc->emitError()
+          << "cert.preempt ids on uC " << uc << " differ from uC " << ref
+          << "; all uCs must have the same preempt ids (G-preempt)";
+      result = failure();
+    }
+  }
+  return result;
+}
+
+// Group/placement ids must be valid microcontroller indices for the device:
+// nonnegative, less than the number of uCs, and (defensively) < 32 so they are
+// representable in a party mask. Rejecting invalid ids up front keeps later
+// checks (e.g. the remote-barrier mask shift) free of undefined behavior.
+static LogicalResult checkGroupIds(AIE::DeviceOp device) {
+  const AIE::AIETargetModel &tm = device.getTargetModel();
+  int64_t numUcs =
+      (int64_t)tm.columns() * (int64_t)tm.getNumMicrocontrollersPerColumn();
+  LogicalResult result = success();
+  auto checkId = [&](Operation *op, int64_t id, llvm::StringRef what) {
+    if (id < 0 || id >= numUcs || id >= 32) {
+      op->emitError() << what << " " << id << " is not a valid uC id [0, "
+                      << numUcs << ")";
+      result = failure();
+    }
+  };
+  device.walk([&](AIEX::CertAttachToGroupOp g) {
+    checkId(g, g.getGroupID(), "cert.attach_to_group group id");
+  });
+  // The verifier may run before placement lowering; check any leftover attrs.
+  device.walk([&](AIEX::CertPageOp p) {
+    if (auto pl = p.getPlacementAttr())
+      checkId(p, pl.getInt(), "cert.page placement");
+  });
+  return result;
+}
+
+// G-uC / rendezvous: cross-uC remote barriers must actually rendezvous. Group
+// occurrences by remote_barrier_id and require: all occurrences agree on
+// party_mask; every mask bit names a present uC that has a matching occurrence
+// (so nobody waits forever); each participating uC sets its own bit; and at
+// most one occurrence per uC per id (one participant per column). Assumes group
+// ids are already validated by checkGroupIds (shifts are still guarded).
+static LogicalResult checkRemoteBarrierParties(AIE::DeviceOp device) {
+  std::set<int> present = computePresentUcs(device);
+  LogicalResult result = success();
+
+  std::map<int, SmallVector<AIEX::CertRemoteBarrierOp, 4>> byId;
+  device.walk([&](AIEX::CertRemoteBarrierOp b) {
+    byId[b.getRemoteBarrierId()].push_back(b);
+  });
+
+  for (auto &entry : byId) {
+    int id = entry.first;
+    SmallVector<AIEX::CertRemoteBarrierOp, 4> &occs = entry.second;
+
+    // All occurrences of an id must describe the same rendezvous.
+    uint32_t mask = occs.front().getPartyMask();
+    bool masksAgree = llvm::all_of(occs, [&](AIEX::CertRemoteBarrierOp b) {
+      return b.getPartyMask() == mask;
+    });
+    if (!masksAgree) {
+      for (auto b : occs)
+        b.emitError() << "cert.remote_barrier id " << id
+                      << " occurrences disagree on party_mask";
+      result = failure();
+      continue;
+    }
+
+    // Participating uCs (from occurrences); own-bit + one-per-uC checks.
+    std::map<int, int> occPerUc;
+    for (auto b : occs) {
+      int own = getUcGroupId(b);
+      occPerUc[own]++;
+      if (own >= 0 && own < 32 && !((mask >> own) & 1u)) {
+        b.emitError() << "cert.remote_barrier id " << id << " on uC " << own
+                      << " excludes its own uC from party_mask";
+        result = failure();
+      }
+    }
+    for (auto &[uc, count] : occPerUc)
+      if (count > 1) {
+        occs.front().emitError()
+            << "cert.remote_barrier id " << id << " has " << count
+            << " occurrences on uC " << uc
+            << " (at most one participant per uC per rendezvous)";
+        result = failure();
+      }
+
+    // Every mask bit must be a present uC that has a matching barrier.
+    for (int bit = 0; bit < 32; ++bit) {
+      if (!((mask >> bit) & 1u))
+        continue;
+      if (!present.count(bit)) {
+        occs.front().emitError()
+            << "cert.remote_barrier id " << id << " party_mask references uC "
+            << bit << " which is not present in the design";
+        result = failure();
+      } else if (!occPerUc.count(bit)) {
+        occs.front().emitError()
+            << "cert.remote_barrier id " << id << " party_mask includes uC "
+            << bit << " but that uC has no matching remote_barrier(" << id
+            << ") to rendezvous with";
+        result = failure();
+      }
+    }
+  }
+  return result;
+}
+
+// G-barlimits: local_barrier_id must be in [0, 15] and remote_barrier_id in
+// [1, 8]; a single uC may use at most 16 distinct local ids and 8 distinct
+// remote ids (the firmware barrier-id budget per microcontroller).
+static LogicalResult checkBarrierLimits(AIE::DeviceOp device) {
+  LogicalResult result = success();
+  std::map<int, std::set<int>> localIds;
+  std::map<int, std::set<int>> remoteIds;
+
+  device.walk([&](AIEX::CertLocalBarrierOp barrier) {
+    int id = barrier.getLocalBarrierId();
+    if (id < 0 || id > 15) {
+      barrier.emitError() << "cert.local_barrier local_barrier_id " << id
+                          << " out of range [0, 15]";
+      result = failure();
+    }
+    localIds[getUcGroupId(barrier)].insert(id);
+  });
+
+  device.walk([&](AIEX::CertRemoteBarrierOp barrier) {
+    int id = barrier.getRemoteBarrierId();
+    if (id < 1 || id > 8) {
+      barrier.emitError() << "cert.remote_barrier remote_barrier_id " << id
+                          << " out of range [1, 8]";
+      result = failure();
+    }
+    remoteIds[getUcGroupId(barrier)].insert(id);
+  });
+
+  for (auto &[uc, ids] : localIds)
+    if (ids.size() > 16) {
+      device.emitError() << "uC " << uc << " uses " << ids.size()
+                         << " distinct local_barrier ids (max 16)";
+      result = failure();
+    }
+  for (auto &[uc, ids] : remoteIds)
+    if (ids.size() > 8) {
+      device.emitError() << "uC " << uc << " uses " << ids.size()
+                         << " distinct remote_barrier ids (max 8)";
+      result = failure();
+    }
+  return result;
+}
+
+struct AIECertVerifyPass
+    : xilinx::AIEX::impl::AIECertVerifyBase<AIECertVerifyPass> {
+  void runOnOperation() override {
+    AIE::DeviceOp device = getOperation();
+    if (failed(checkGroupIds(device)))
+      signalPassFailure();
+    if (failed(checkLocalBarrierColocation(device)))
+      signalPassFailure();
+    if (failed(checkWaitTctsUniqueness(device)))
+      signalPassFailure();
+    if (failed(checkPreemptConsistency(device)))
+      signalPassFailure();
+    if (failed(checkRemoteBarrierParties(device)))
+      signalPassFailure();
+    if (failed(checkBarrierLimits(device)))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<AIE::DeviceOp>> AIEX::createAIECertVerifyPass() {
+  return std::make_unique<AIECertVerifyPass>();
+}

--- a/lib/Dialect/AIEX/Transforms/AIECertVerify.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECertVerify.cpp
@@ -190,8 +190,7 @@ static LogicalResult checkPreemptConsistency(AIE::DeviceOp device) {
 // checks (e.g. the remote-barrier mask shift) free of undefined behavior.
 static LogicalResult checkGroupIds(AIE::DeviceOp device) {
   const AIE::AIETargetModel &tm = device.getTargetModel();
-  int64_t numUcs =
-      (int64_t)tm.columns() * (int64_t)tm.getNumMicrocontrollersPerColumn();
+  int64_t numUcs = tm.getNumControllers();
   LogicalResult result = success();
   auto checkId = [&](Operation *op, int64_t id, llvm::StringRef what) {
     if (id < 0 || id >= numUcs || id >= 32) {

--- a/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
@@ -647,21 +647,18 @@ struct MergeConsecutiveCertUcDmaWriteDesSyncOps
 
     // Compute the size of the current and previous chains. If their combined
     // data size is greater than the cert page size, then we cannot merge them.
-    uint32_t prevChainSize = 0;
-    for (auto &o : prevChain.getBody().front().getOperations()) {
-      auto bdOp = dyn_cast<AIEX::CertUcDmaBdOp>(o);
-      if (!bdOp)
-        continue;
-      prevChainSize += bdOp.getLength() * sizeof(int);
-    }
-    uint32_t currChainSize = 0;
-    for (auto &o : chain.getBody().front().getOperations()) {
-      auto bdOp = dyn_cast<AIEX::CertUcDmaBdOp>(o);
-      if (!bdOp)
-        continue;
-      currChainSize += bdOp.getLength() * sizeof(int);
-    }
-    if ((currChainSize + prevChainSize) >= cert_page_size)
+    //
+    // A chain costs 16 bytes of descriptor per BD on top of the BD's payload --
+    // the same accounting updateCostForOp (the page splitter's authoritative
+    // cost model) uses. Charging payload only under-reports a chain by 16 bytes
+    // per BD, which for many small BDs is most of its real size.
+    auto chainSize = [](AIEX::CertUcDmaChainOp c) {
+      uint32_t size = 0;
+      for (auto bdOp : c.getBody().front().getOps<AIEX::CertUcDmaBdOp>())
+        size += bdOp.getLength() * sizeof(int) + 16; // payload + bd descriptor
+      return size;
+    };
+    if ((chainSize(chain) + chainSize(prevChain)) >= cert_page_size)
       return failure();
 
     IRMapping map;
@@ -1009,10 +1006,12 @@ struct AIENpuToCertPass
     if (failed(applyPartialConversion(currentDevice, target, std::move(p2))))
       return signalPassFailure();
 
-    // Add the merge pattern for CertUcDmaWriteDesSyncOps
-    RewritePatternSet p3(&getContext());
-    p3.insert<MergeConsecutiveCertUcDmaWriteDesSyncOps>(&getContext());
-    if (failed(applyPatternsGreedily(currentDevice, std::move(p3))))
+    // Run the greedy driver with no patterns, purely for its DCE: p2
+    // leaves each converted blockwrite's memref.get_global (and any constant
+    // feeding it) dead, since the new op references the global by symbol
+    // rather than by SSA value. CertJobOp's verifier rejects those ops
+    RewritePatternSet cleanup(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(cleanup))))
       return signalPassFailure();
 
     // Convert referenced devices to cert.sections

--- a/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include <map>
 #include <type_traits>
 #include <vector>
 
@@ -30,9 +31,27 @@ using namespace xilinx;
 
 namespace {
 
-// slightly smaller than the actual page size to account for overheads and
-// estimation errors
+// Two distinct thresholds, doing two different jobs.
+//
+// `cert_page_size` is the conservative trigger for *attempting* a split. It
+// sits below the real limit to absorb the imprecision in estimateCost (page
+// `.align 16` padding, `.eop`, and the data-vs-page layout it approximates).
+//
+// `cert_page_limit` is the hard architectural bound: a uC page buffer is 8 KB.
+// Anything at or under it is legal hardware.
+//
+// The distinction matters for diagnostics. A page between the two values trips
+// the trigger but is still perfectly loadable, so failing to split it is not an
+// error -- only a page whose estimate exceeds `cert_page_limit` is genuinely
+// unlowerable and worth rejecting at compile time.
 static constexpr uint32_t cert_page_size = 8000;
+static constexpr uint32_t cert_page_limit = 8192;
+
+// Per-job control-code overhead: START_JOB (ISA_OPSIZE_START_JOB = 0x08) plus
+// END_JOB (ISA_OPSIZE_END_JOB = 0x04), emitted around every job's body by
+// emitJob.
+static constexpr uint32_t cert_job_start_cost = 8;
+static constexpr uint32_t cert_job_end_cost = 4;
 
 // Returns the PDI id to use for a cert.load_pdi that references `deviceSymName`
 // within `parentDevice`. If a load_pdi for that symbol already exists, its id
@@ -73,15 +92,18 @@ struct RuntimeSequenceToCertJob : OpConversionPattern<AIE::RuntimeSequenceOp> {
       newJobId = maxJobId + 1;
     }
 
-    // Create page wrapper at the same location as the runtime sequence
+    // Create the job in place of the runtime sequence, WITHOUT a page wrapper.
+    // A later "form implicit pages" step (in cert-legalize-pages) groups
+    // contiguous top-level jobs into pages; explicit cert.page ops are the only
+    // delimiters. CertJobOp legally parents under DeviceOp, so a bare
+    // device-level job is valid between the two passes.
     rewriter.setInsertionPoint(op);
-    auto pageOp = AIEX::CertPageOp::create(rewriter, op.getLoc());
-    Block *pageBlock = new Block();
-    pageOp.getBody().push_back(pageBlock);
-    rewriter.setInsertionPointToStart(pageBlock);
-
-    // Create job inside page
     auto jobOp = AIEX::CertJobOp::create(rewriter, op.getLoc(), newJobId);
+
+    // Tag the implicit configuration job so a later step can force it to be the
+    // first page on uC0 and keep it out of user implicit pages.
+    if (symName == "configure")
+      jobOp->setAttr("cert.configure", rewriter.getUnitAttr());
 
     // Clone runtime sequence body into job
     // Note: This preserves block arguments from the runtime sequence, which
@@ -89,8 +111,6 @@ struct RuntimeSequenceToCertJob : OpConversionPattern<AIE::RuntimeSequenceOp> {
     IRMapping remap;
     op.getRegion().cloneInto(&jobOp.getBody(), remap);
     AIEX::CertJobOp::ensureTerminator(jobOp.getBody(), rewriter, op->getLoc());
-    AIEX::CertPageOp::ensureTerminator(pageOp.getBody(), rewriter,
-                                       op->getLoc());
 
     // Erase the original runtime sequence
     rewriter.eraseOp(op);
@@ -1075,26 +1095,38 @@ struct AIENpuToCertPass
 
 } // namespace
 
+// Instruction sizes are the authoritative ISA_OPSIZE_* values from
+// third_party/aiebu/specification/aie2ps/isa_stubs.h -- the same table the
+// assembler encodes against -- so the running total here matches the bytes
+// emitJob actually produces. Keep the two in sync when adding a cert op:
+// an op the emitter can emit but this function ignores is counted as free,
+// which makes the page look smaller than it is.
 static void updateCostForOp(Operation &o, AIE::DeviceOp deviceOp,
                             uint32_t &text_cost, uint32_t &data_cost) {
   // Several distinct op kinds share an encoded instruction size below --
   // an instruction-size table, not a copy-paste clone.
   // NOLINTBEGIN(bugprone-branch-clone)
   if (isa<AIEX::CertLocalBarrierOp>(o)) {
-    text_cost += 8; // local barrier
+    text_cost += 4; // ISA_OPSIZE_LOCAL_BARRIER
   } else if (isa<AIEX::CertRemoteBarrierOp>(o)) {
-    text_cost += 8; // remote barrier
+    text_cost += 8; // ISA_OPSIZE_REMOTE_BARRIER
   } else if (isa<AIEX::CertWaitTCTSOp>(o)) {
-    text_cost += 8; // wait tct
+    text_cost += 8; // ISA_OPSIZE_WAIT_TCTS
   } else if (isa<AIEX::CertMaskWrite32Op>(o)) {
-    text_cost += 16; // mask write
+    text_cost += 16; // ISA_OPSIZE_MASK_WRITE_32
   } else if (isa<AIEX::CertWrite32Op>(o)) {
-    text_cost += 12; // write
+    text_cost += 12; // ISA_OPSIZE_WRITE_32
   } else if (isa<AIEX::CertApplyOffset57Op>(o)) {
-    text_cost += 16; // apply offset
+    text_cost += 8; // ISA_OPSIZE_APPLY_OFFSET_57
+  } else if (isa<AIEX::CertNopOp>(o)) {
+    text_cost += 4; // ISA_OPSIZE_NOP
+  } else if (isa<AIEX::CertPreemptOp>(o)) {
+    text_cost += 8; // ISA_OPSIZE_PREEMPT
+  } else if (isa<AIEX::CertLoadPdiOp>(o)) {
+    text_cost += 12; // ISA_OPSIZE_LOAD_PDI
     // NOLINTEND(bugprone-branch-clone)
   } else if (auto syncOp = dyn_cast<AIEX::CertUcDmaWriteDesSyncOp>(o)) {
-    text_cost += 16; // write des sync
+    text_cost += 4; // ISA_OPSIZE_UC_DMA_WRITE_DES_SYNC
     // find the uc_dma_chain
     StringRef sym_name = syncOp.getSymbol();
     auto chain = dyn_cast_if_present<AIEX::CertUcDmaChainOp>(
@@ -1123,12 +1155,15 @@ static uint32_t estimateCost(AIEX::CertPageOp op, uint32_t split_target,
                              AIEX::CertJobOp &split_job,
                              Block::iterator &split_iter,
                              bool &found_split_point) {
-  uint32_t text_cost = 32; // page header
+  uint32_t text_cost = 32; // page header: `.align 16` padding plus `.eop`
   uint32_t data_cost = 0;
   found_split_point = false;
   AIE::DeviceOp deviceOp = op->getParentOfType<AIE::DeviceOp>();
 
   for (auto job : op.getBody().front().getOps<AIEX::CertJobOp>()) {
+    // START_JOB precedes the body, so it is already spent at every candidate
+    // split point inside this job; END_JOB is charged after the body below.
+    text_cost += cert_job_start_cost;
     for (auto &o : job.getBody().front().getOperations()) {
       Block::iterator current(&o);
       if (!found_split_point && !isa<AIE::EndOp>(o) &&
@@ -1151,33 +1186,106 @@ static uint32_t estimateCost(AIEX::CertPageOp op, uint32_t split_target,
         }
       }
     }
+    text_cost += cert_job_end_cost;
   }
   return text_cost + data_cost;
 }
 
-namespace {
+// local_barrier co-location across a page split (G-localbar).
+//
+// A page is a single uC scope, so all cert.local_barrier ops that share a
+// local_barrier_id are participants of one barrier and must stay together on a
+// single page (splitting them across an .eop hangs the firmware). We model a
+// candidate split as a "cut" in the page's flat textual op order: ops before
+// the cut land on the earlier page, ops at/after the cut land on the later
+// page. A barrier group is "separated" iff the cut falls strictly inside the
+// span of its participants' flat indices.
 
-struct WrapStandaloneCertJobOpPattern : OpRewritePattern<AIEX::CertJobOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(AIEX::CertJobOp jobOp,
-                                PatternRewriter &rewriter) const override {
-    if (jobOp->getParentOfType<AIEX::CertPageOp>())
-      return failure();
-
-    auto loc = jobOp.getLoc();
-    rewriter.setInsertionPoint(jobOp);
-
-    auto pageOp = AIEX::CertPageOp::create(rewriter, loc);
-    Block *pageBlock = new Block();
-    pageOp.getBody().push_back(pageBlock);
-
-    jobOp->moveBefore(pageBlock, pageBlock->begin());
-    AIEX::CertPageOp::ensureTerminator(pageOp.getBody(), rewriter, loc);
-
-    return success();
+// Assign each non-terminator op in `page` a flat textual index (jobs in order,
+// ops in order) and record, per local_barrier_id, the [min,max] flat-index span
+// of its participants.
+static void computeBarrierSpans(AIEX::CertPageOp page,
+                                std::map<Operation *, int> &flatIndex,
+                                std::map<int, std::pair<int, int>> &spans) {
+  int idx = 0;
+  for (auto job : page.getBody().front().getOps<AIEX::CertJobOp>()) {
+    for (auto &o : job.getBody().front().getOperations()) {
+      if (isa<AIE::EndOp>(o))
+        continue;
+      flatIndex[&o] = idx;
+      if (auto bar = dyn_cast<AIEX::CertLocalBarrierOp>(o)) {
+        int id = bar.getLocalBarrierId();
+        auto it = spans.find(id);
+        if (it == spans.end())
+          spans[id] = {idx, idx};
+        else {
+          it->second.first = std::min(it->second.first, idx);
+          it->second.second = std::max(it->second.second, idx);
+        }
+      }
+      ++idx;
+    }
   }
-};
+}
+
+// A cut before flat index `p` (ops with index < p -> earlier page) separates a
+// local_barrier group iff some participant is before and some at/after the cut.
+static bool cutSeparatesBarrier(const std::map<int, std::pair<int, int>> &spans,
+                                int p) {
+  return llvm::any_of(spans, [p](const auto &entry) {
+    auto [lo, hi] = entry.second;
+    return lo < p && hi >= p;
+  });
+}
+
+// Search for an interior split point (a position inside some job, with at least
+// one op before it in that job and a real op at/after it) whose cut keeps every
+// local_barrier group intact. Among the legal candidates pick the one whose
+// earlier-page cost is closest to `split_target`. Returns false if no legal
+// split point exists (the caller then leaves the page intact).
+static bool findLegalSplitPoint(AIEX::CertPageOp page, uint32_t split_target,
+                                const std::map<Operation *, int> &flatIndex,
+                                const std::map<int, std::pair<int, int>> &spans,
+                                AIEX::CertJobOp &split_job,
+                                Block::iterator &split_iter) {
+  AIE::DeviceOp deviceOp = page->getParentOfType<AIE::DeviceOp>();
+  uint32_t text_cost = 32; // page header, mirrors estimateCost
+  uint32_t data_cost = 0;
+  bool found = false;
+  uint32_t best_delta = 0;
+  for (auto job : page.getBody().front().getOps<AIEX::CertJobOp>()) {
+    text_cost += cert_job_start_cost; // mirrors estimateCost
+    bool sawOpInJob = false;
+    for (auto &o : job.getBody().front().getOperations()) {
+      if (isa<AIE::EndOp>(o))
+        continue;
+      Block::iterator current(&o);
+      // Candidate: cut before `o`. Only interior points are valid (at least one
+      // op precedes `o` in this job), matching what the splitter can execute.
+      if (sawOpInJob) {
+        auto fi = flatIndex.find(&o);
+        int p = fi == flatIndex.end() ? 0 : fi->second;
+        if (!cutSeparatesBarrier(spans, p)) {
+          uint32_t cost = text_cost + data_cost;
+          uint32_t delta =
+              cost > split_target ? cost - split_target : split_target - cost;
+          if (!found || delta < best_delta) {
+            found = true;
+            best_delta = delta;
+            split_job = job;
+            split_iter = current;
+          }
+        }
+      }
+      updateCostForOp(o, deviceOp, text_cost, data_cost);
+      sawOpInJob = true;
+    }
+    text_cost += cert_job_end_cost; // mirrors estimateCost
+  }
+  return found;
+}
+
+namespace {
 
 // Pattern to isolate load_pdi and preempt operations into their own job and
 // page According to CERT spec: "load_pdi and preempt should take one whole job
@@ -1351,7 +1459,13 @@ struct IsolateFullPageOpsPattern : OpRewritePattern<AIEX::CertJobOp> {
 };
 
 struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
-  using OpRewritePattern::OpRewritePattern;
+  // `hadError` is raised when the pattern emits an error diagnostic. A rewrite
+  // pattern returning failure() is ordinary control flow -- it does NOT fail
+  // the pass -- so without this the "cannot split" error below would print and
+  // the oversized page would still reach codegen. The pass checks the flag
+  // after applyPatternsGreedily and calls signalPassFailure().
+  SplitCertPageOpPattern(MLIRContext *context, bool *hadError)
+      : OpRewritePattern(context), hadError(hadError) {}
 
   LogicalResult matchAndRewrite(AIEX::CertPageOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1366,10 +1480,115 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
     LLVM_DEBUG(llvm::outs() << "Estimate cost for page: "
                             << " is " << cost << "\n");
 
-    if (cost < split_threshold || !found_split_point)
+    if (cost < split_threshold)
       return failure();
 
+    // Over the split trigger but with nowhere to cut. A split point must fall
+    // inside a job with at least one op ahead of it, so a page whose bulk sits
+    // in a single one-op job offers none. Leave the page alone -- but if it is
+    // also over the hard limit, it will not load, so say so instead of emitting
+    // a page the firmware will reject.
+    if (!found_split_point) {
+      if (cost > cert_page_limit) {
+        op.emitError() << "cert.page is an estimated " << cost
+                       << " bytes, over the " << cert_page_limit
+                       << "-byte microcontroller page limit, and offers no "
+                          "split point (a split must fall inside a job, after "
+                          "at least one of its ops); break the oversized job "
+                          "into smaller jobs";
+        *hadError = true;
+      }
+      return failure();
+    }
+
+    // never split a local_barrier participant set across an .eop
+    // (G-localbar). If the cost-chosen split point would separate a barrier
+    // group, retarget to a legal split point; if none exists the page cannot be
+    // made legal, so fail the compile rather than emit something broken.
+    // an implicit page (formed by formImplicitPages) groups jobs meant to
+    // be cooperatively scheduled together; an explicit page is a user-authored
+    // boundary. This governs the wording of the diagnostics below (the remedy
+    // differs), not whether they fire.
+    bool isImplicit = op->hasAttr("cert.implicit");
+
+    std::map<Operation *, int> flatIndex;
+    std::map<int, std::pair<int, int>> barrierSpans;
+    computeBarrierSpans(op, flatIndex, barrierSpans);
+    if (!barrierSpans.empty()) {
+      auto fi = flatIndex.find(&*split_iter);
+      int p = fi == flatIndex.end() ? 0 : fi->second;
+      if (cutSeparatesBarrier(barrierSpans, p)) {
+        if (!findLegalSplitPoint(op, cert_page_size / 2, flatIndex,
+                                 barrierSpans, split_job, split_iter)) {
+          // No split keeps every local_barrier group intact. Leave the
+          // page whole: severing a barrier hangs the firmware, so an oversized
+          // page is the better of the two. That is only survivable while the
+          // page still fits, though -- past cert_page_limit neither option
+          // works, and both fail silently at runtime, so diagnose and fail the
+          // compile. The remedy differs by page kind: an implicit page just
+          // needs a user-authored boundary in the right place, while an
+          // explicit page is already where the user put it and has to be made
+          // smaller or its participants regrouped. Raise `hadError` so the pass
+          // actually fails -- returning failure() alone only tells the greedy
+          // driver this pattern did not apply.
+          if (cost > cert_page_limit) {
+            if (isImplicit)
+              op.emitError()
+                  << "implicit cert.page is an estimated " << cost
+                  << " bytes, over the " << cert_page_limit
+                  << "-byte microcontroller page limit, and cannot be split "
+                     "without separating a local_barrier participant set "
+                     "across pages; insert an explicit cert.page boundary to "
+                     "co-locate the barrier participants";
+            else
+              op.emitError()
+                  << "cert.page is an estimated " << cost << " bytes, over the "
+                  << cert_page_limit
+                  << "-byte microcontroller page limit, and cannot be split "
+                     "without separating a local_barrier participant set "
+                     "across pages; reduce the page's contents or regroup its "
+                     "local_barrier participants so that a legal split point "
+                     "exists";
+            *hadError = true;
+          }
+          return failure();
+        }
+      }
+    }
+
+    // splitting an implicit page turns jobs that were meant to run
+    // cooperatively on one page into strictly sequential pages. Warn so the
+    // user can insert an explicit boundary if the serialization is unintended.
+    if (isImplicit)
+      op.emitRemark()
+          << "auto-split of implicit cert.page serializes cooperatively-"
+             "scheduled jobs into separate sequential pages; insert an "
+             "explicit "
+             "cert.page boundary to control where the split occurs";
+
     auto loc = op.getLoc();
+
+    // the split preserves IR (textual) order both within and across the
+    // two result pages. Jobs before split_job are cloned whole onto the earlier
+    // page; jobs after it onto the later page; split_job's own ops are
+    // partitioned at split_iter into [begin, split_iter) -> earlier page and
+    // [split_iter, end) -> later page, each cloned in order (see the
+    // distribution loop below). Because nothing is reordered, every producer
+    // stays before its consumer, so any dependency that survives across the new
+    // .eop is backward (earlier page -> later page), which is legal (G-fwd). In
+    // particular splitting a wait_tcts from its earlier uc_dma enqueues is
+    // allowed: the enqueues land on the earlier page and the wait on the later
+    // page (a backward dependency). split_iter is always interior to split_job
+    // (estimateCost / findLegalSplitPoint guarantee at least one op precedes
+    // it), so the earlier page is never empty.
+    assert(split_iter != split_job.getBody().front().begin() &&
+           "split_iter must be interior: at least one op stays on the earlier "
+           "page, preserving producer-before-consumer order");
+
+    // NOTE: the device-wide job-id shift below only keeps job ids unique per
+    // page; job_id is a label, not an order, so it does not affect
+    // emission/execution order, which is textual. A device-wide job-id renumber
+    // is left for a follow-up.
     op->getParentOfType<AIE::DeviceOp>().walk([&](AIEX::CertJobOp certJobOp) {
       if (certJobOp.getJobId() > split_job.getJobId())
         certJobOp.setJobId(certJobOp.getJobId() + 1);
@@ -1406,6 +1625,13 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
     Block *newPageBlock1 = new Block();
     newPageOp1.getBody().push_back(newPageBlock1);
 
+    // propagate the implicit tag so a later re-split of either fragment
+    // still knows it came from an implicit page and diagnoses consistently.
+    if (isImplicit) {
+      newPageOp0->setAttr("cert.implicit", rewriter.getUnitAttr());
+      newPageOp1->setAttr("cert.implicit", rewriter.getUnitAttr());
+    }
+
     for (auto job : op.getBody().front().getOps<AIEX::CertJobOp>()) {
       if (job == split_job) {
         rewriter.setInsertionPointToEnd(newPageBlock0);
@@ -1435,16 +1661,194 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
     rewriter.eraseOp(op);
     return success();
   }
+
+  bool *hadError;
 };
+
+// Form implicit pages: group maximal runs of contiguous top-level
+// cert.job ops into a single cert.page. Only an explicit cert.page delimits a
+// run; structural ops (tiles, buffers, locks, switchboxes, ...) do NOT. The
+// implicit configuration job (tagged {cert.configure}) is kept isolated in its
+// own page so it can be forced first on uC0 and never merged into a user
+// implicit page. CertJobOp legally parents under DeviceOp, so bare device-level
+// jobs are valid input here (produced by RuntimeSequenceToCertJob).
+// attach_to_group(0) names uC 0, which is exactly the default (unspecified)
+// group. It is therefore a placement no-op, not a page boundary: flatten it so
+// its content joins the device-level group-0 stream and participates in
+// implicit-page formation with adjacent default-group-0 content (rather than
+// being isolated on its own page). Move each group-0 op out before the
+// attach_to_group, preserving order, then erase the now-empty op.
+static void inlineDefaultGroup(AIE::DeviceOp dev) {
+  Block *body = dev.getBody();
+  SmallVector<AIEX::CertAttachToGroupOp> zeroGroups;
+  for (auto grp : body->getOps<AIEX::CertAttachToGroupOp>())
+    if (grp.getGroupId() == 0)
+      zeroGroups.push_back(grp);
+  for (auto grp : zeroGroups) {
+    SmallVector<Operation *> inner;
+    for (Operation &op : grp.getBody().front())
+      if (!isa<AIE::EndOp>(op))
+        inner.push_back(&op);
+    for (Operation *op : inner)
+      op->moveBefore(grp.getOperation());
+    grp.erase();
+  }
+}
+
+// Group a block's maximal runs of contiguous top-level cert.job ops into
+// implicit cert.page ops (only an explicit cert.page delimits; the
+// {cert.configure} job stays isolated in its own page). Applied per uC stream.
+static void formImplicitPagesInBlock(Block *body, OpBuilder &builder) {
+  // Snapshot top-level ops; the body is mutated while iterating.
+  SmallVector<Operation *> topOps;
+  for (Operation &op : *body)
+    topOps.push_back(&op);
+
+  // `cert.implicit` marks a page formed from a run of *user* jobs -- a
+  // boundary the author could have drawn but didn't. The splitter's diagnostics
+  // are keyed off it and all advise editing page boundaries, so it must not be
+  // set on a page the user cannot restructure. The compiler-synthesized
+  // @configure page is exactly that case, and it is isolated by construction,
+  // so the tag would buy nothing there anyway.
+  auto openPage = [&](Location loc, Operation *before,
+                      bool implicit) -> AIEX::CertPageOp {
+    builder.setInsertionPoint(before);
+    auto page = AIEX::CertPageOp::create(builder, loc);
+    if (implicit)
+      page->setAttr("cert.implicit", builder.getUnitAttr());
+    Block *b = new Block();
+    page.getBody().push_back(b);
+    AIEX::CertPageOp::ensureTerminator(page.getBody(), builder, loc);
+    return page;
+  };
+
+  AIEX::CertPageOp currentPage; // null => no open implicit page
+  for (Operation *op : topOps) {
+    if (auto job = dyn_cast<AIEX::CertJobOp>(op)) {
+      if (job->hasAttr("cert.configure")) {
+        // Keep the configuration job isolated in its own page. Not tagged
+        // implicit: the user did not author this job and cannot add a boundary
+        // inside it, so the auto-split remark would be noise on every compile
+        // whose
+        // config transaction is large enough to split (and it usually is).
+        auto page = openPage(job.getLoc(), job, /*implicit=*/false);
+        job->moveBefore(page.getBody().front().getTerminator());
+        currentPage = nullptr;
+        continue;
+      }
+      if (!currentPage)
+        currentPage = openPage(job.getLoc(), job, /*implicit=*/true);
+      job->moveBefore(currentPage.getBody().front().getTerminator());
+    } else if (isa<AIEX::CertPageOp>(op)) {
+      // An explicit page delimits the current implicit run.
+      currentPage = nullptr;
+    }
+    // All other ops (structural / control containers) do not delimit a run.
+  }
+}
+
+static void formImplicitPages(AIE::DeviceOp dev) {
+  OpBuilder builder(dev.getContext());
+  // uC 0 (device-level) stream. attach_to_group(0) has already been inlined
+  // here by inlineDefaultGroup.
+  formImplicitPagesInBlock(dev.getBody(), builder);
+  // Each other uC (attach_to_group) forms implicit pages within its own stream,
+  // so adjacent jobs on that uC are cooperatively co-located too.
+  SmallVector<AIEX::CertAttachToGroupOp> groups;
+  for (auto grp : dev.getBody()->getOps<AIEX::CertAttachToGroupOp>())
+    groups.push_back(grp);
+  for (auto grp : groups)
+    formImplicitPagesInBlock(&grp.getBody().front(), builder);
+}
+
+// Force the implicit configuration page to be the first page on uC0:
+// @configure sets up the device (DMA/lock/core config), so it must strictly
+// precede all other uC0 pages regardless of where it appeared textually. The
+// config job is already isolated in its own page by formImplicitPages; here we
+// just hoist that page to the front of the device body (structural ops are not
+// control code, so position relative to them does not matter).
+static void moveConfigPageFirst(AIE::DeviceOp dev) {
+  Block *body = dev.getBody();
+  AIEX::CertPageOp configPage;
+  for (auto page : body->getOps<AIEX::CertPageOp>()) {
+    for (auto job : page.getBody().front().getOps<AIEX::CertJobOp>()) {
+      if (job->hasAttr("cert.configure")) {
+        configPage = page;
+        break;
+      }
+    }
+    if (configPage)
+      break;
+  }
+  if (configPage && &body->front() != configPage.getOperation())
+    configPage->moveBefore(&body->front());
+}
+
+// Lower the `placement` attribute on top-level cert.page ops to enclosing
+// cert.attach_to_group ops. Placed pages (placement present and != 0)
+// are moved, preserving IR order, under one cert.attach_to_group per distinct
+// group id. Unplaced pages (and placement 0) stay at device level and are
+// emitted as the implicit group 0. Nesting stays attach_to_group -> page -> job
+// as the emitter expects.
+static void lowerPagePlacementToGroups(AIE::DeviceOp dev) {
+  Block *body = dev.getBody();
+
+  // Collect placed top-level pages by resolved group id, in first-seen order.
+  std::map<int32_t, SmallVector<AIEX::CertPageOp, 4>> byGroup;
+  for (auto page : body->getOps<AIEX::CertPageOp>()) {
+    if (auto placement = page.getPlacementAttr()) {
+      auto gid = static_cast<int32_t>(placement.getInt());
+      if (gid != 0)
+        byGroup[gid].push_back(page);
+    }
+  }
+
+  OpBuilder builder(dev.getContext());
+  for (auto &entry : byGroup) {
+    int32_t gid = entry.first;
+    SmallVector<AIEX::CertPageOp, 4> &pages = entry.second;
+
+    // Create the group op where the first placed page currently lives (avoids
+    // assuming anything about a device terminator).
+    builder.setInsertionPoint(pages.front());
+    auto grp = AIEX::CertAttachToGroupOp::create(builder, dev.getLoc(), gid);
+    Block *grpBlock = new Block();
+    grp.getBody().push_back(grpBlock);
+
+    // Move the placed pages into the group, in order, dropping the
+    // now-redundant placement attribute (the group encodes it).
+    for (AIEX::CertPageOp page : pages) {
+      page->removeAttr("placement");
+      page->moveBefore(grpBlock, grpBlock->end());
+    }
+    AIEX::CertAttachToGroupOp::ensureTerminator(grp.getBody(), builder,
+                                                dev.getLoc());
+  }
+}
 
 struct AIECertPagesPass
     : xilinx::AIEX::impl::AIECertPagesBase<AIECertPagesPass> {
   void runOnOperation() override {
-    // Normalize legacy standalone jobs to the page-based representation.
-    RewritePatternSet wrapPatterns(&getContext());
-    wrapPatterns.insert<WrapStandaloneCertJobOpPattern>(&getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(wrapPatterns))))
-      signalPassFailure();
+    // Flatten attach_to_group(0) into the device-level (default group-0) stream
+    // so it is a placement no-op, not a page boundary.
+    inlineDefaultGroup(getOperation());
+
+    // Form implicit pages: group contiguous top-level jobs into pages; only an
+    // explicit cert.page delimits. Replaces the old one-page-per-job
+    // wrapping.
+    formImplicitPages(getOperation());
+
+    // Force the @configure page to be first on uC0.
+    moveConfigPageFirst(getOperation());
+
+    // Lower cert.page placement to cert.attach_to_group BEFORE isolate
+    // and split. Those rewrites create replacement pages adjacent to the
+    // original (same parent block) with the no-placement builder; running the
+    // placement grouping first means placed pages already live inside their
+    // cert.attach_to_group, so any pages the later rewrites spawn stay in the
+    // same group by position. (Doing this last silently dropped placement from
+    // split/isolated pages, emitting them on group 0.)
+    lowerPagePlacementToGroups(getOperation());
 
     // First, isolate load_pdi and preempt operations into their own job/page
     RewritePatternSet isolatePatterns(&getContext());
@@ -1453,10 +1857,16 @@ struct AIECertPagesPass
             applyPatternsGreedily(getOperation(), std::move(isolatePatterns))))
       signalPassFailure();
 
-    // Then apply the page splitting pattern
+    // Then apply the page splitting pattern. `splitError` catches diagnostics
+    // the pattern emits while declining to split (see SplitCertPageOpPattern):
+    // applyPatternsGreedily reports only whether the rewrite converged, so an
+    // illegal-to-split page would otherwise print an error and still compile.
+    bool splitError = false;
     RewritePatternSet p1(&getContext());
-    p1.insert<SplitCertPageOpPattern>(&getContext());
+    p1.insert<SplitCertPageOpPattern>(&getContext(), &splitError);
     if (failed(applyPatternsGreedily(getOperation(), std::move(p1))))
+      signalPassFailure();
+    if (splitError)
       signalPassFailure();
 
     // Add the merge pattern for CertUcDmaWriteDesSyncOps

--- a/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
@@ -1182,6 +1182,19 @@ static uint32_t estimateCost(AIEX::CertPageOp op, uint32_t split_target,
           split_job = job;
           split_iter = next;
           found_split_point = true;
+        } else if (!isa<AIE::EndOp>(o) &&
+                   current != job.getBody().front().begin()) {
+          // The op that crossed the target is this job's last real op, so
+          // "cut after it" is not a split at all. Cut immediately before it
+          // instead: everything ahead of it was under the target and its own
+          // cost is what pushed the page over, so both halves are strictly
+          // smaller than the whole. NB the `!isa<AIE::EndOp>(o)` guard: this
+          // loop also visits the terminator, and cutting before *it* would put
+          // the whole job on the earlier page and an empty job on the later
+          // one -- a no-op "split" the greedy driver repeats forever.
+          split_job = job;
+          split_iter = current;
+          found_split_point = true;
         }
       }
     }
@@ -1237,9 +1250,16 @@ static bool cutSeparatesBarrier(const std::map<int, std::pair<int, int>> &spans,
   });
 }
 
-// Search for an interior split point (a position inside some job, with at least
-// one op before it in that job and a real op at/after it) whose cut keeps every
-// local_barrier group intact. Among the legal candidates pick the one whose
+// Search for a split point whose cut keeps every local_barrier group intact.
+// Two kinds of position qualify, and the splitter can execute either:
+//   - interior cut: at least one op of the same job precedes the position, so
+//     the job is partitioned into an earlier and a later half;
+//   - job-boundary cut: the position is a job's first op while an earlier job
+//     already carries content, so that job moves whole to the later page and no
+//     job is partitioned at all.
+// What is never legal is a cut ahead of everything on the page: it leaves the
+// earlier page empty, so the "split" makes no progress and the greedy driver
+// repeats it forever. Among the legal candidates pick the one whose
 // earlier-page cost is closest to `split_target`. Returns false if no legal
 // split point exists (the caller then leaves the page intact).
 static bool findLegalSplitPoint(AIEX::CertPageOp page, uint32_t split_target,
@@ -1252,6 +1272,9 @@ static bool findLegalSplitPoint(AIEX::CertPageOp page, uint32_t split_target,
   uint32_t data_cost = 0;
   bool found = false;
   uint32_t best_delta = 0;
+  // Whether some job already visited holds a real op, i.e. whether cutting at
+  // the current job's first op would leave content on the earlier page.
+  bool sawOpInEarlierJob = false;
   for (auto job : page.getBody().front().getOps<AIEX::CertJobOp>()) {
     text_cost += cert_job_start_cost; // mirrors estimateCost
     bool sawOpInJob = false;
@@ -1259,9 +1282,12 @@ static bool findLegalSplitPoint(AIEX::CertPageOp page, uint32_t split_target,
       if (isa<AIE::EndOp>(o))
         continue;
       Block::iterator current(&o);
-      // Candidate: cut before `o`. Only interior points are valid (at least one
-      // op precedes `o` in this job), matching what the splitter can execute.
-      if (sawOpInJob) {
+      // Candidate: cut before `o`, legal as an interior cut when an op of this
+      // job precedes it, or as a job-boundary cut when an earlier job does.
+      // Admitting the latter matters for a page built of small jobs whose sizes
+      // only sum over the limit: no job has an interior point worth cutting at,
+      // yet a cut between two whole jobs splits it perfectly well.
+      if (sawOpInJob || sawOpInEarlierJob) {
         auto fi = flatIndex.find(&o);
         int p = fi == flatIndex.end() ? 0 : fi->second;
         if (!cutSeparatesBarrier(spans, p)) {
@@ -1280,6 +1306,7 @@ static bool findLegalSplitPoint(AIEX::CertPageOp page, uint32_t split_target,
       sawOpInJob = true;
     }
     text_cost += cert_job_end_cost; // mirrors estimateCost
+    sawOpInEarlierJob |= sawOpInJob;
   }
   return found;
 }
@@ -1482,19 +1509,39 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
     if (cost < split_threshold)
       return failure();
 
-    // Over the split trigger but with nowhere to cut. A split point must fall
-    // inside a job with at least one op ahead of it, so a page whose bulk sits
-    // in a single one-op job offers none. Leave the page alone -- but if it is
-    // also over the hard limit, it will not load, so say so instead of emitting
-    // a page the firmware will reject.
+    bool isImplicit = op->hasAttr("cert.implicit");
+
+    std::map<Operation *, int> flatIndex;
+    std::map<int, std::pair<int, int>> barrierSpans;
+    computeBarrierSpans(op, flatIndex, barrierSpans);
+
+    // estimateCost's search is greedy: it retains only the first position at
+    // which the running cost crosses split_target and never backtracks, and it
+    // only ever considers positions interior to the one job the crossing
+    // happened in. So a page can be reported as offering no split point when a
+    // cut is plainly available -- the crossing op alone in its job while an
+    // earlier job has several ops, or a page of small jobs whose sizes merely
+    // sum over the limit, where the cut belongs on a job boundary. Fall back to
+    // the exhaustive search, which considers every position in the page and
+    // keeps the barrier-legal one closest to split_target, before giving up.
+    if (!found_split_point)
+      found_split_point =
+          findLegalSplitPoint(op, cert_page_size / 2, flatIndex, barrierSpans,
+                              split_job, split_iter);
+
+    // Over the split trigger but with nowhere to cut. Every cut has to leave at
+    // least one op on each side, so a page whose bulk sits in a single one-op
+    // job offers none. Leave the page alone -- but if it is also over the hard
+    // limit, it will not load, so say so instead of emitting a page the
+    // firmware will reject.
     if (!found_split_point) {
       if (cost > cert_page_limit) {
         op.emitError() << "cert.page is an estimated " << cost
                        << " bytes, over the " << cert_page_limit
                        << "-byte microcontroller page limit, and offers no "
-                          "split point (a split must fall inside a job, after "
-                          "at least one of its ops); break the oversized job "
-                          "into smaller jobs";
+                          "split point (a split must leave at least one op on "
+                          "each page); break the oversized job into smaller "
+                          "jobs";
         *hadError = true;
       }
       return failure();
@@ -1508,11 +1555,6 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
     // be cooperatively scheduled together; an explicit page is a user-authored
     // boundary. This governs the wording of the diagnostics below (the remedy
     // differs), not whether they fire.
-    bool isImplicit = op->hasAttr("cert.implicit");
-
-    std::map<Operation *, int> flatIndex;
-    std::map<int, std::pair<int, int>> barrierSpans;
-    computeBarrierSpans(op, flatIndex, barrierSpans);
     if (!barrierSpans.empty()) {
       auto fi = flatIndex.find(&*split_iter);
       int p = fi == flatIndex.end() ? 0 : fi->second;
@@ -1577,21 +1619,42 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
     // .eop is backward (earlier page -> later page), which is legal (G-fwd). In
     // particular splitting a wait_tcts from its earlier uc_dma enqueues is
     // allowed: the enqueues land on the earlier page and the wait on the later
-    // page (a backward dependency). split_iter is always interior to split_job
-    // (estimateCost / findLegalSplitPoint guarantee at least one op precedes
-    // it), so the earlier page is never empty.
-    assert(split_iter != split_job.getBody().front().begin() &&
-           "split_iter must be interior: at least one op stays on the earlier "
-           "page, preserving producer-before-consumer order");
+    // page (a backward dependency).
+    //
+    // split_iter at split_job's first op means the cut falls on a job boundary:
+    // split_job is not partitioned at all, it moves whole to the later page and
+    // the earlier page is made of the jobs ahead of it. That is a real split
+    // only because some earlier job carries content; the searches guarantee it,
+    // and cutting ahead of everything would leave an empty earlier page and no
+    // progress. Otherwise the cut is interior to split_job and, again by
+    // construction, at least one op stays behind on the earlier page. Either
+    // way the earlier page is non-empty and the split strictly makes progress.
+    bool jobBoundaryCut = split_iter == split_job.getBody().front().begin();
+    [[maybe_unused]] auto earlierJobHasRealOp = [&]() {
+      for (auto job : op.getBody().front().getOps<AIEX::CertJobOp>()) {
+        if (job == split_job)
+          break;
+        for (auto &o : job.getBody().front().getOperations())
+          if (!isa<AIE::EndOp>(o))
+            return true;
+      }
+      return false;
+    };
+    assert((!jobBoundaryCut || earlierJobHasRealOp()) &&
+           "a job-boundary cut needs a preceding job with content, else the "
+           "earlier page is empty and the split makes no progress");
 
     // NOTE: the device-wide job-id shift below only keeps job ids unique per
     // page; job_id is a label, not an order, so it does not affect
     // emission/execution order, which is textual. A device-wide job-id renumber
-    // is left for a follow-up.
-    op->getParentOfType<AIE::DeviceOp>().walk([&](AIEX::CertJobOp certJobOp) {
-      if (certJobOp.getJobId() > split_job.getJobId())
-        certJobOp.setJobId(certJobOp.getJobId() + 1);
-    });
+    // is left for a follow-up. A job-boundary cut creates no new job -- every
+    // job keeps its id, just on a different page -- so there is nothing to
+    // renumber and the walk is skipped.
+    if (!jobBoundaryCut)
+      op->getParentOfType<AIE::DeviceOp>().walk([&](AIEX::CertJobOp certJobOp) {
+        if (certJobOp.getJobId() > split_job.getJobId())
+          certJobOp.setJobId(certJobOp.getJobId() + 1);
+      });
 
     auto cloneJobRange = [&](AIEX::CertJobOp sourceJob, uint32_t jobId,
                              Block::iterator begin, Block::iterator end) {
@@ -1633,6 +1696,14 @@ struct SplitCertPageOpPattern : OpRewritePattern<AIEX::CertPageOp> {
 
     for (auto job : op.getBody().front().getOps<AIEX::CertJobOp>()) {
       if (job == split_job) {
+        if (jobBoundaryCut) {
+          // Whole job to the later page: partitioning it at its own first op
+          // would leave an empty half behind on the earlier page.
+          rewriter.setInsertionPointToEnd(newPageBlock1);
+          cloneJobRange(job, job.getJobId(), job.getBody().front().begin(),
+                        job.getBody().front().end());
+          continue;
+        }
         rewriter.setInsertionPointToEnd(newPageBlock0);
         cloneJobRange(job, job.getJobId(), job.getBody().front().begin(),
                       split_iter);

--- a/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
@@ -15,7 +15,9 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include <map>
+#include <set>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace xilinx::AIEX {
@@ -1319,6 +1321,18 @@ namespace {
 struct IsolateFullPageOpsPattern : OpRewritePattern<AIEX::CertJobOp> {
   using OpRewritePattern::OpRewritePattern;
 
+  // Create an empty, terminated cert.page directly after `after`, in the same
+  // block. Staying in `after`'s block is what keeps a page that was moved into
+  // a cert.attach_to_group by placement lowering on its uC.
+  static AIEX::CertPageOp makePageAfter(PatternRewriter &rewriter,
+                                        Operation *after, Location loc) {
+    rewriter.setInsertionPointAfter(after);
+    auto page = AIEX::CertPageOp::create(rewriter, loc);
+    page.getBody().push_back(new Block());
+    AIEX::CertPageOp::ensureTerminator(page.getBody(), rewriter, loc);
+    return page;
+  }
+
   LogicalResult matchAndRewrite(AIEX::CertJobOp jobOp,
                                 PatternRewriter &rewriter) const override {
 
@@ -1337,148 +1351,102 @@ struct IsolateFullPageOpsPattern : OpRewritePattern<AIEX::CertJobOp> {
     if (!fullPageOp)
       return failure(); // No full-page op in this job
 
-    // Check if this job ONLY contains the full-page op (and terminator)
+    auto parentPage = jobOp->getParentOfType<AIEX::CertPageOp>();
+    if (!parentPage)
+      return failure(); // No parent page (unusual but skip)
+
+    // Real ops in this job (the terminator does not count).
     size_t opCount = 0;
-    for (Operation &op : jobOp.getBody().front().getOperations()) {
+    for (Operation &op : jobOp.getBody().front().getOperations())
       if (!isa<AIE::EndOp>(op))
         opCount++;
+
+    // Pages execute in order, so the rewrite has to preserve this job's
+    // position among its *siblings*, not just relative to the parent page:
+    // anchoring every new page on the parent page's boundary hoists the jobs
+    // that surround this one across the isolated load_pdi/preempt. Nothing
+    // downstream checks op order, so that reordering is silent.
+    SmallVector<Operation *> leadingSiblings, trailingSiblings;
+    bool pastSelf = false;
+    for (Operation &op : parentPage.getBody().front()) {
+      if (isa<AIE::EndOp>(op))
+        continue;
+      if (&op == jobOp.getOperation()) {
+        pastSelf = true;
+        continue;
+      }
+      (pastSelf ? trailingSiblings : leadingSiblings).push_back(&op);
     }
+
+    // Already properly isolated: sole op of the sole job of its page.
+    if (opCount == 1 && leadingSiblings.empty() && trailingSiblings.empty())
+      return failure();
+
+    auto loc = jobOp.getLoc();
+
+    // The parent page stays where it is and keeps the leading siblings; every
+    // page created below is chained after it, in program order.
+    Operation *anchor = parentPage.getOperation();
 
     if (opCount == 1) {
-      // Job only contains full-page op - check if it's in its own page
-      auto parentPage = jobOp->getParentOfType<AIEX::CertPageOp>();
-      if (!parentPage)
-        return failure(); // No parent page (unusual but skip)
+      // The job is exactly the full-page op: it just needs a page of its own.
+      auto isolatedPage = makePageAfter(rewriter, anchor, loc);
+      jobOp->moveBefore(isolatedPage.getBody().front().getTerminator());
+      anchor = isolatedPage;
+    } else {
+      // Mixed job: split it into up to three jobs, each on its own page, in
+      // source order (ops before the full-page op, it, then the ops after).
+      auto parentDevice = jobOp->getParentOfType<AIE::DeviceOp>();
+      uint32_t maxJobId = 0;
+      parentDevice.walk([&](AIEX::CertJobOp certJobOp) {
+        maxJobId = std::max(maxJobId, certJobOp.getJobId());
+      });
+      uint32_t beforeJobId = jobOp.getJobId();
+      uint32_t fullPageJobId = maxJobId + 1;
+      uint32_t afterJobId = maxJobId + 2;
 
-      // Count jobs in parent page
-      size_t jobCount = 0;
-      for (Operation &op : parentPage.getBody().front().getOperations()) {
-        if (isa<AIEX::CertJobOp>(op))
-          jobCount++;
-      }
+      SmallVector<Operation *> beforeOps, afterOps;
+      for (Block::iterator it = jobOp.getBody().front().begin();
+           it != fullPageOpIter; ++it)
+        if (!isa<AIE::EndOp>(*it))
+          beforeOps.push_back(&*it);
+      Block::iterator afterStart = std::next(fullPageOpIter);
+      for (Block::iterator it = afterStart; it != jobOp.getBody().front().end();
+           ++it)
+        if (!isa<AIE::EndOp>(*it))
+          afterOps.push_back(&*it);
 
-      if (jobCount == 1)
-        return failure(); // Already properly isolated
+      auto emitJobPage = [&](uint32_t jobId, ArrayRef<Operation *> ops) {
+        auto page = makePageAfter(rewriter, anchor, loc);
+        rewriter.setInsertionPoint(page.getBody().front().getTerminator());
+        auto job = AIEX::CertJobOp::create(rewriter, loc, jobId);
+        job.getBody().push_back(new Block());
+        AIEX::CertJobOp::ensureTerminator(job.getBody(), rewriter, loc);
+        for (Operation *op : ops)
+          op->moveBefore(job.getBody().front().getTerminator());
+        anchor = page;
+      };
 
-      // Job is isolated but shares page - need to move to own page
-      auto loc = jobOp.getLoc();
-      rewriter.setInsertionPointAfter(parentPage);
+      if (!beforeOps.empty())
+        emitJobPage(beforeJobId, beforeOps);
+      emitJobPage(fullPageJobId, {fullPageOp});
+      if (!afterOps.empty())
+        emitJobPage(afterJobId, afterOps);
 
-      // Create new page for this job
-      auto newPageOp = AIEX::CertPageOp::create(rewriter, loc);
-      Block *newPageBlock = new Block();
-      newPageOp.getBody().push_back(newPageBlock);
-
-      // Move the job to the new page
-      rewriter.setInsertionPointToStart(newPageBlock);
-      jobOp->moveBefore(newPageBlock, newPageBlock->begin());
-
-      AIEX::CertPageOp::ensureTerminator(newPageOp.getBody(), rewriter, loc);
-
-      return success();
+      rewriter.eraseOp(jobOp);
     }
 
-    // Job contains full-page op mixed with other operations - need to split
-    auto loc = jobOp.getLoc();
-    auto parentDevice = jobOp->getParentOfType<AIE::DeviceOp>();
-
-    // Assign new job IDs
-    uint32_t maxJobId = 0;
-    parentDevice.walk([&](AIEX::CertJobOp certJobOp) {
-      maxJobId = std::max(maxJobId, certJobOp.getJobId());
-    });
-
-    uint32_t beforeJobId = jobOp.getJobId();
-    uint32_t fullPageJobId = maxJobId + 1;
-    uint32_t afterJobId = maxJobId + 2;
-
-    // Collect operations before full-page op
-    SmallVector<Operation *> beforeOps;
-    for (Block::iterator it = jobOp.getBody().front().begin();
-         it != fullPageOpIter; ++it) {
-      if (!isa<AIE::EndOp>(*it))
-        beforeOps.push_back(&*it);
+    // The trailing siblings cannot stay on the parent page, which now precedes
+    // the isolated page, so they move to a page of their own behind it.
+    if (!trailingSiblings.empty()) {
+      auto tailPage = makePageAfter(rewriter, anchor, loc);
+      for (Operation *op : trailingSiblings)
+        op->moveBefore(tailPage.getBody().front().getTerminator());
     }
 
-    // Collect operations after full-page op
-    SmallVector<Operation *> afterOps;
-    Block::iterator afterStart = fullPageOpIter;
-    ++afterStart; // Skip the full-page op itself
-    for (Block::iterator it = afterStart; it != jobOp.getBody().front().end();
-         ++it) {
-      if (!isa<AIE::EndOp>(*it))
-        afterOps.push_back(&*it);
-    }
-
-    // Get parent page to insert new pages after it
-    auto parentPage = jobOp->getParentOfType<AIEX::CertPageOp>();
-    rewriter.setInsertionPoint(parentPage);
-
-    // Create first page with operations before full-page op (if any)
-    if (!beforeOps.empty()) {
-      auto page1 = AIEX::CertPageOp::create(rewriter, loc);
-      Block *page1Block = new Block();
-      page1.getBody().push_back(page1Block);
-      rewriter.setInsertionPointToStart(page1Block);
-
-      auto job1 = AIEX::CertJobOp::create(rewriter, loc, beforeJobId);
-      Block *job1Block = new Block();
-      job1.getBody().push_back(job1Block);
-      rewriter.setInsertionPointToStart(job1Block);
-
-      for (Operation *op : beforeOps) {
-        op->moveBefore(job1Block, job1Block->end());
-      }
-
-      AIEX::CertJobOp::ensureTerminator(job1.getBody(), rewriter, loc);
-      AIEX::CertPageOp::ensureTerminator(page1.getBody(), rewriter, loc);
-    }
-
-    // Create page with full-page op in its own job
-    rewriter.setInsertionPointAfter(parentPage);
-    auto page2 = AIEX::CertPageOp::create(rewriter, loc);
-    Block *page2Block = new Block();
-    page2.getBody().push_back(page2Block);
-    rewriter.setInsertionPointToStart(page2Block);
-
-    auto job2 = AIEX::CertJobOp::create(rewriter, loc, fullPageJobId);
-    Block *job2Block = new Block();
-    job2.getBody().push_back(job2Block);
-    rewriter.setInsertionPointToStart(job2Block);
-
-    fullPageOp->moveBefore(job2Block, job2Block->end());
-
-    AIEX::CertJobOp::ensureTerminator(job2.getBody(), rewriter, loc);
-    AIEX::CertPageOp::ensureTerminator(page2.getBody(), rewriter, loc);
-
-    // Create third page with operations after full-page op (if any)
-    if (!afterOps.empty()) {
-      rewriter.setInsertionPointAfter(page2);
-      auto page3 = AIEX::CertPageOp::create(rewriter, loc);
-      Block *page3Block = new Block();
-      page3.getBody().push_back(page3Block);
-      rewriter.setInsertionPointToStart(page3Block);
-
-      auto job3 = AIEX::CertJobOp::create(rewriter, loc, afterJobId);
-      Block *job3Block = new Block();
-      job3.getBody().push_back(job3Block);
-      rewriter.setInsertionPointToStart(job3Block);
-
-      for (Operation *op : afterOps) {
-        op->moveBefore(job3Block, job3Block->end());
-      }
-
-      AIEX::CertJobOp::ensureTerminator(job3.getBody(), rewriter, loc);
-      AIEX::CertPageOp::ensureTerminator(page3.getBody(), rewriter, loc);
-    }
-
-    // Erase the original job and page
-    rewriter.eraseOp(jobOp);
-    if (parentPage.getBody().front().empty() ||
-        llvm::all_of(parentPage.getBody().front(),
-                     [](Operation &op) { return isa<AIE::EndOp>(op); })) {
+    if (llvm::all_of(parentPage.getBody().front(),
+                     [](Operation &op) { return isa<AIE::EndOp>(op); }))
       rewriter.eraseOp(parentPage);
-    }
 
     return success();
   }
@@ -1792,7 +1760,25 @@ static void formImplicitPagesInBlock(Block *body, OpBuilder &builder) {
     return page;
   };
 
+  // The (tile, channel) actors a job wait_tcts on, keyed exactly as
+  // AIECertVerify's G-tct check (checkWaitTctsUniqueness) keys them so the two
+  // stay consistent.
+  auto waitTctsActors = [](AIEX::CertJobOp job) {
+    std::set<std::pair<int, int>> actors;
+    job.walk([&](AIEX::CertWaitTCTSOp wait) {
+      actors.insert({wait.getTileId(), wait.getChannelId()});
+    });
+    return actors;
+  };
+
   AIEX::CertPageOp currentPage; // null => no open implicit page
+  // Actors already waited on by the jobs accumulated into `currentPage`.
+  std::set<std::pair<int, int>> pageActors;
+  auto closePage = [&]() {
+    currentPage = nullptr;
+    pageActors.clear();
+  };
+
   for (Operation *op : topOps) {
     if (auto job = dyn_cast<AIEX::CertJobOp>(op)) {
       if (job->hasAttr("cert.configure")) {
@@ -1803,15 +1789,28 @@ static void formImplicitPagesInBlock(Block *body, OpBuilder &builder) {
         // config transaction is large enough to split (and it usually is).
         auto page = openPage(job.getLoc(), job, /*implicit=*/false);
         job->moveBefore(page.getBody().front().getTerminator());
-        currentPage = nullptr;
+        closePage();
         continue;
       }
+      // G-tct: at most one job per page may wait on a given actor. Two jobs
+      // that each legally wait on the same (tile, channel) -- an ordinary shape
+      // for two runtime sequences sharing a shim channel -- are only legal
+      // while they sit on separate pages, so grouping them would manufacture a
+      // verifier error out of valid input. Cut a page boundary instead, exactly
+      // as an over-size job would.
+      auto actors = waitTctsActors(job);
+      if (currentPage &&
+          llvm::any_of(actors, [&](const std::pair<int, int> &actor) {
+            return pageActors.count(actor);
+          }))
+        closePage();
       if (!currentPage)
         currentPage = openPage(job.getLoc(), job, /*implicit=*/true);
       job->moveBefore(currentPage.getBody().front().getTerminator());
+      pageActors.insert(actors.begin(), actors.end());
     } else if (isa<AIEX::CertPageOp>(op)) {
       // An explicit page delimits the current implicit run.
-      currentPage = nullptr;
+      closePage();
     }
     // All other ops (structural / control containers) do not delimit a run.
   }

--- a/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIENpuToCert.cpp
@@ -622,16 +622,26 @@ struct MergeConsecutiveCertUcDmaWriteDesSyncOps
 
   LogicalResult matchAndRewrite(AIEX::CertUcDmaWriteDesSyncOp op,
                                 PatternRewriter &rewriter) const override {
+    // Fusing the two enqueues sinks the earlier one to the later one's position
+    // in the job, so every op scanned over is an op the earlier DMA is moved
+    // past. Only ops with no architectural effect at all may be crossed; this
+    // is an allowlist rather than a denylist so a cert op added to this dialect
+    // later blocks the merge by default instead of silently becoming
+    // reorderable with respect to a DMA enqueue. cert.nop is the only such op
+    // today: it emits padding and carries no ordering, sync or side effect.
+    auto isTransparentToMerge = [](Operation *o) {
+      return isa<AIEX::CertNopOp>(o);
+    };
+
     // Get the previous operation in the block
     Block::iterator it(op);
     AIEX::CertUcDmaWriteDesSyncOp prevWriteDesSync = nullptr;
     while (it != op->getBlock()->begin() && !prevWriteDesSync) {
       --it;
       Operation *prevOp = &*it;
-      if (isa<AIEX::CertWrite32Op, AIEX::CertMaskWrite32Op,
-              AIEX::CertApplyOffset57Op, AIEX::CertWaitTCTSOp>(prevOp))
-        return failure();
       prevWriteDesSync = dyn_cast<AIEX::CertUcDmaWriteDesSyncOp>(prevOp);
+      if (!prevWriteDesSync && !isTransparentToMerge(prevOp))
+        return failure();
     }
     if (!prevWriteDesSync)
       return failure();
@@ -645,6 +655,21 @@ struct MergeConsecutiveCertUcDmaWriteDesSyncOps
         prevWriteDesSync->getParentOfType<AIE::DeviceOp>().lookupSymbol(
             prev_sym_name));
     if (!chain || !prevChain)
+      return failure();
+
+    // The merge rewrites @chain's BD list in place and deletes @prevChain, so
+    // both symbols must be private to this pair of enqueues. Cert IR that is
+    // hand-authored rather than lowered from npu ops may enqueue one chain from
+    // several places: folding into a shared @chain would silently change those
+    // other enqueues, and erasing a shared @prevChain would leave a dangling
+    // symbol reference that neither the verifier nor the page cost model
+    // notices. Decline the merge instead.
+    auto deviceOp = op->getParentOfType<AIE::DeviceOp>();
+    auto isSingleUse = [&](AIEX::CertUcDmaChainOp c) {
+      auto uses = SymbolTable::getSymbolUses(c, deviceOp);
+      return uses && llvm::hasSingleElement(*uses);
+    };
+    if (!isSingleUse(chain) || !isSingleUse(prevChain))
       return failure();
 
     // Compute the size of the current and previous chains. If their combined

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIEDmaToNpu.cpp
   AIEDecomposeLargeDmaBd.cpp
   AIENpuToCert.cpp
+  AIECertVerify.cpp
   AIEMaterializeBDChains.cpp
   AIEMaterializeRuntimeSequences.cpp
   AIEAssignRuntimeSequenceBDIDs.cpp

--- a/lib/Targets/AIETargetUcCert.cpp
+++ b/lib/Targets/AIETargetUcCert.cpp
@@ -20,12 +20,20 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Path.h"
 
+#include <map>
 #include <vector>
 
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::AIE;
 using namespace xilinx::AIEX;
+
+// Emission ordering invariant: CERT jobs, pages, and the ops within a job are
+// emitted in IR/textual order. `job_id` is a per-page-unique label and a
+// firmware job-table key, NOT an execution/emission order (see CertJobOp docs).
+// Within a page the firmware starts jobs in textual order; between pages on a
+// uC execution is strictly sequential. Do not sort jobs/pages by job_id here.
+// (attach_to_group groups are sorted by group_id, which is the uC index.)
 
 namespace {
 
@@ -153,10 +161,9 @@ LogicalResult emitJobs(llvm::SmallVector<CertJobOp> &jobs, std::string &text,
                        std::string &data) {
   LogicalResult result = success();
 
-  llvm::sort(jobs, [](CertJobOp a, CertJobOp b) {
-    return a.getJobId() < b.getJobId();
-  });
-
+  // Emit jobs in IR/textual order. job_id is a per-page-unique label, not an
+  // execution/emission order (the firmware treats it as a job-table key and
+  // schedules jobs on a page cooperatively, starting them in textual order).
   for (auto job : jobs) {
     if (failed(emitJob(job, text, data)))
       result = failure();
@@ -173,14 +180,10 @@ LogicalResult emitPage(CertPageOp pageOp, std::string &text,
   LogicalResult result = success();
   text += ".align 16\n";
 
-  // Process jobs within the page
-  auto jobs =
-      llvm::to_vector_of<CertJobOp>(pageOp.getBody().getOps<CertJobOp>());
-  llvm::sort(jobs, [](CertJobOp a, CertJobOp b) {
-    return a.getJobId() < b.getJobId();
-  });
-
-  for (auto job : jobs) {
+  // Process jobs within the page in IR/textual order. Textual order is the
+  // execution order the firmware relies on within a page (jobs are started in
+  // textual order); do not reorder by job_id.
+  for (auto job : pageOp.getBody().getOps<CertJobOp>()) {
     if (failed(emitJob(job, text, data)))
       result = failure();
   }
@@ -388,60 +391,73 @@ LogicalResult xilinx::AIE::AIETranslateToUcDma(ModuleOp module,
 
   LogicalResult result = success();
 
-  // Process sections after attach_to_group so they're in the column
+  // Emit each microcontroller's (uC / group) content as its own ordered stream,
+  // keyed by the *actual* group id. Group 0 (device-level content plus any
+  // attach_to_group(0)) shares block 0; every other uC id gets its own
+  // code/data/EOF block (ops sharing a non-zero id share a block).
+  std::map<uint32_t, size_t> groupIdToBlock;
+  groupIdToBlock[0] = 0; // device-level content lives in block 0
+  auto blockFor = [&](uint32_t gid) -> size_t {
+    auto it = groupIdToBlock.find(gid);
+    if (it != groupIdToBlock.end())
+      return it->second;
+    text.emplace_back("\n;\n; Code\n;\n\n");
+    data.emplace_back("\n;\n; Data\n;\n\n");
+    chains.emplace_back("\n;\n; Data (chains)\n;\n\n");
+    size_t block = text.size() - 1;
+    groupIdToBlock[gid] = block;
+    return block;
+  };
+
+  // Sections are hoisted ahead of the executable stream: they are labeled
+  // `.include` blocks, not pages, and the code below them may reference them
+  // (e.g. `LOAD_PDI 1, @config_device`), so their labels must already be
+  // defined. `emitAttachToGroupOp` hoists a group's sections the same way.
   for (auto section : deviceOp.getBody()->getOps<CertSectionOp>()) {
     if (failed(emitSection(section, text[0], outputPath)))
       result = failure();
   }
 
-  // Process pages at device level (if any)
-  for (auto page : deviceOp.getBody()->getOps<CertPageOp>()) {
-    if (failed(emitPage(page, text[0], data[0])))
-      result = failure();
-  }
-
-  // Process standalone jobs at device level (for backwards compatibility)
-  auto jobs =
-      llvm::to_vector_of<CertJobOp>(deviceOp.getBody()->getOps<CertJobOp>());
-  if (failed(emitJobs(jobs, text[0], data[0])))
-    result = failure();
-
-  auto groups = llvm::to_vector_of<CertAttachToGroupOp>(
-      deviceOp.getBody()->getOps<CertAttachToGroupOp>());
-  llvm::sort(groups, [](CertAttachToGroupOp a, CertAttachToGroupOp b) {
-    return a.getGroupId() < b.getGroupId();
-  });
-
-  for (auto o : deviceOp.getBody()->getOps<CertUcDmaChainOp>())
-    emitUcDmaChain(o, chains[0], data[0], emittedGlobals);
-
-  int group_id = 0;
-  for (auto &groupOp : groups) {
-    if (group_id) {
-      text.emplace_back("\n;\n; Code\n;\n\n");
-      data.emplace_back("\n;\n; Data\n;\n\n");
-      chains.emplace_back("\n;\n; Data (chains)\n;\n\n");
+  // Single pass over the device body so each uC stream preserves the textual
+  // (encounter) order of its *executable* ops. In particular a device-level
+  // (group-0) page and an attach_to_group(0) job interleave in source order.
+  // The previous two-phase approach emitted ALL device-level pages before ANY
+  // attach_to_group content, which inverted source order on uC 0 -- e.g. a
+  // release job authored before the runtime sequence was emitted on a later
+  // page than the sequence's WAIT_TCTS, creating a forward-page dependency.
+  for (Operation &op : *deviceOp.getBody()) {
+    if (auto page = dyn_cast<CertPageOp>(&op)) {
+      if (failed(emitPage(page, text[0], data[0])))
+        result = failure();
+    } else if (auto job = dyn_cast<CertJobOp>(&op)) {
+      if (failed(emitJob(job, text[0], data[0])))
+        result = failure();
+    } else if (auto grp = dyn_cast<CertAttachToGroupOp>(&op)) {
+      size_t block = blockFor(grp.getGroupId());
+      if (failed(
+              emitAttachToGroupOp(grp, text[block], data[block], outputPath)))
+        result = failure();
+    } else if (auto chain = dyn_cast<CertUcDmaChainOp>(&op)) {
+      emitUcDmaChain(chain, chains[0], data[0], emittedGlobals);
     }
-    if (failed(emitAttachToGroupOp(groupOp, text[group_id], data[group_id],
-                                   outputPath)))
-      result = failure();
-    group_id++;
   }
 
   if (failed(result))
     return result;
 
-  for (auto const &[t, c, d] : llvm::zip(text, chains, data)) {
-    if (!t.empty()) {
-      assembly += t;
+  // Emit blocks in group-id order (block 0 = uC 0 first). Each block is a
+  // self-contained stream: code + EOF, then its chains and data.
+  for (auto const &entry : groupIdToBlock) {
+    size_t block = entry.second;
+    if (!text[block].empty()) {
+      assembly += text[block];
       // Add final EOF after all code (sections emit their own EOF before .endl)
       assembly += "EOF\n";
     }
-    if (!c.empty()) {
-      assembly += c;
-    }
-    if (!d.empty())
-      assembly += "\n" + d;
+    if (!chains[block].empty())
+      assembly += chains[block];
+    if (!data[block].empty())
+      assembly += "\n" + data[block];
   }
   return success();
 }

--- a/test/Conversion/NpuToCert/attach_group0_inline.mlir
+++ b/test/Conversion/NpuToCert/attach_group0_inline.mlir
@@ -1,0 +1,35 @@
+//===- attach_group0_inline.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// attach_to_group(0) names uC 0, which is exactly the default (unspecified)
+// group. It must be a placement no-op, not a page boundary: its content joins
+// the device-level group-0 stream and merges (implicit page) with an adjacent
+// device-level job. Previously it was isolated on its own page.
+
+// RUN: aie-opt -cert-legalize-pages %s | FileCheck %s --implicit-check-not=attach_to_group
+
+// The two jobs end up in ONE implicit page (no attach_to_group survives, no page
+// boundary between them), in textual order.
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(0)
+// CHECK: aiex.cert.write32(4096, 1)
+// CHECK-NOT: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.write32(8192, 2)
+
+module {
+  aie.device(npu2) {
+    aiex.cert.attach_to_group(0) {
+      aiex.cert.job(0) {
+        aiex.cert.write32(0x1000, 1)
+      }
+    }
+    aiex.cert.job(1) {
+      aiex.cert.write32(0x2000, 2)
+    }
+  }
+}

--- a/test/Conversion/NpuToCert/implicit_page_tct_boundary.mlir
+++ b/test/Conversion/NpuToCert/implicit_page_tct_boundary.mlir
@@ -1,0 +1,34 @@
+//===- implicit_page_tct_boundary.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Implicit page formation must respect G-tct (at most one job per page may
+// wait_tcts on a given (tile, channel)). Two top-level jobs waiting on the same
+// actor are legal on their own -- pages run in sequence -- but grouping them
+// into one implicit page makes them concurrent, which used to turn valid input
+// into a verifier error. The run is cut at the collision instead.
+
+// RUN: aie-opt -cert-legalize-pages --aie-cert-verify %s | FileCheck %s
+
+// Colliding jobs land on separate pages...
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.wait_tcts(0, 6, 1)
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.wait_tcts(0, 6, 1)
+// ...while a job waiting on a different actor still shares the page it follows.
+// CHECK: aiex.cert.job(3)
+// CHECK: aiex.cert.wait_tcts(0, 7, 1)
+// CHECK-NOT: aiex.cert.page
+
+module {
+  aie.device(npu2) {
+    aiex.cert.job(1) { aiex.cert.wait_tcts(0, 6, 1) }
+    aiex.cert.job(2) { aiex.cert.wait_tcts(0, 6, 1) }
+    aiex.cert.job(3) { aiex.cert.wait_tcts(0, 7, 1) }
+  }
+}

--- a/test/Conversion/NpuToCert/isolate_full_page_order.mlir
+++ b/test/Conversion/NpuToCert/isolate_full_page_order.mlir
@@ -1,0 +1,92 @@
+//===- isolate_full_page_order.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// load_pdi and preempt each need a page to themselves, but pages execute in
+// order, so pulling one out must not move it past the jobs that surround it.
+// The isolation rewrite used to anchor the pages it creates on the *parent
+// page* rather than on the job being isolated, which silently reordered the
+// program whenever that job was not the page's only job. Nothing downstream
+// checks op order, so these cases used to compile clean and run wrong.
+//
+// Every write32 address below is unique so the ordered CHECKs cannot be
+// satisfied by a match in a later input chunk.
+
+// RUN: aie-opt -cert-legalize-pages --split-input-file %s | FileCheck %s
+
+// A single-op load_pdi job that is NOT the last job on its page: the isolated
+// page used to land after the whole parent page, so the write32 ran before the
+// reconfiguration it was supposed to follow.
+// CHECK: aiex.cert.load_pdi(1, @cfg)
+// CHECK: aiex.cert.write32(4096, 1)
+aie.device(npu2) {
+  aiex.cert.section @cfg { }
+  aiex.cert.page {
+    aiex.cert.job(1) { aiex.cert.load_pdi(1, @cfg) }
+    aiex.cert.job(2) { aiex.cert.write32(4096, 1) }
+  }
+}
+
+// -----
+
+// Same shape with preempt.
+// CHECK: aiex.cert.preempt(1, @save, @restore)
+// CHECK: aiex.cert.write32(4104, 2)
+aie.device(npu2) {
+  aiex.cert.section @save { }
+  aiex.cert.section @restore { }
+  aiex.cert.page {
+    aiex.cert.job(1) { aiex.cert.preempt(1, @save, @restore) }
+    aiex.cert.job(2) { aiex.cert.write32(4104, 2) }
+  }
+}
+
+// -----
+
+// Mixed job (ops before and after the load_pdi) preceded by an unrelated job:
+// the "before ops" page used to be inserted ahead of the whole parent page,
+// hoisting write32(4116) over write32(4112).
+// CHECK: aiex.cert.write32(4112, 3)
+// CHECK: aiex.cert.write32(4116, 4)
+// CHECK: aiex.cert.load_pdi(1, @cfg)
+// CHECK: aiex.cert.write32(4120, 5)
+aie.device(npu2) {
+  aiex.cert.section @cfg { }
+  aiex.cert.page {
+    aiex.cert.job(1) { aiex.cert.write32(4112, 3) }
+    aiex.cert.job(2) {
+      aiex.cert.write32(4116, 4)
+      aiex.cert.load_pdi(1, @cfg)
+      aiex.cert.write32(4120, 5)
+    }
+  }
+}
+
+// -----
+
+// Leading and trailing siblings around a mixed job, plus a second full-page op
+// later on the same page: every fragment keeps its source position.
+// CHECK: aiex.cert.write32(4128, 6)
+// CHECK: aiex.cert.write32(4132, 7)
+// CHECK: aiex.cert.load_pdi(1, @cfg)
+// CHECK: aiex.cert.write32(4136, 8)
+// CHECK: aiex.cert.write32(4140, 9)
+// CHECK: aiex.cert.load_pdi(2, @cfg)
+// CHECK: aiex.cert.write32(4144, 10)
+aie.device(npu2) {
+  aiex.cert.section @cfg { }
+  aiex.cert.page {
+    aiex.cert.job(1) { aiex.cert.write32(4128, 6) }
+    aiex.cert.job(2) {
+      aiex.cert.write32(4132, 7)
+      aiex.cert.load_pdi(1, @cfg)
+      aiex.cert.write32(4136, 8)
+    }
+    aiex.cert.job(3) { aiex.cert.write32(4140, 9) }
+    aiex.cert.job(4) { aiex.cert.load_pdi(2, @cfg) }
+    aiex.cert.job(5) { aiex.cert.write32(4144, 10) }
+  }
+}

--- a/test/Conversion/NpuToCert/merge_dma_chains.mlir
+++ b/test/Conversion/NpuToCert/merge_dma_chains.mlir
@@ -1,0 +1,42 @@
+//===- merge_dma_chains.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// MergeConsecutiveCertUcDmaWriteDesSyncOps fuses adjacent
+// cert.uc_dma_write_des_sync ops (and their backing chains) into a single
+// enqueue, preserving BD order and clearing the "last BD" flag on every BD but
+// the final one.
+//
+// RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
+
+// CHECK:      aiex.cert.uc_dma_chain @[[SYM:[a-zA-Z0-9_]+]] {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @blockwrite_data0, 4321, 1, true
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @blockwrite_data1, 5432, 2, true
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @blockwrite_data2, 6543, 3, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@[[SYM]])
+// CHECK-NEXT: }
+
+aie.device(npu2) {
+  memref.global "private" constant @blockwrite_data0 : memref<1xi32> = dense<[1]>
+  memref.global "private" constant @blockwrite_data1 : memref<2xi32> = dense<[2, 3]>
+  memref.global "private" constant @blockwrite_data2 : memref<3xi32> = dense<[4, 5, 6]>
+  aiex.cert.uc_dma_chain @chain_0 {
+    aiex.cert.uc_dma_bd @blockwrite_data0, 4321, 1, false
+  }
+  aiex.cert.uc_dma_chain @chain_1 {
+    aiex.cert.uc_dma_bd @blockwrite_data1, 5432, 2, false
+  }
+  aiex.cert.uc_dma_chain @chain_2 {
+    aiex.cert.uc_dma_bd @blockwrite_data2, 6543, 3, false
+  }
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@chain_0)
+    aiex.cert.uc_dma_write_des_sync(@chain_1)
+    aiex.cert.uc_dma_write_des_sync(@chain_2)
+  }
+}

--- a/test/Conversion/NpuToCert/merge_dma_chains_ordering.mlir
+++ b/test/Conversion/NpuToCert/merge_dma_chains_ordering.mlir
@@ -1,0 +1,193 @@
+//===- merge_dma_chains_ordering.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Limits on MergeConsecutiveCertUcDmaWriteDesSyncOps. Fusing two enqueues moves
+// the earlier DMA to the later enqueue's position, so the merge is legal only
+// when nothing in between observes the DMA and when neither chain symbol is
+// shared with an enqueue outside the pair.
+//
+// RUN: aie-opt -cert-legalize-pages --split-input-file %s | FileCheck %s
+
+// A local_barrier between the two enqueues blocks the merge: the first DMA must
+// stay ahead of the barrier.
+// CHECK-LABEL: @d1_barrier
+// CHECK:      aiex.cert.uc_dma_chain @c1_barrier {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d1_barrier, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.uc_dma_chain @c2_barrier {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d2_barrier, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_barrier)
+// CHECK-NEXT:   aiex.cert.local_barrier(0, 2)
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c2_barrier)
+// CHECK-NEXT: }
+aie.device(npu2) {
+  memref.global "private" constant @d1_barrier : memref<8xi32> = dense<0>
+  memref.global "private" constant @d2_barrier : memref<8xi32> = dense<1>
+  aiex.cert.uc_dma_chain @c1_barrier { aiex.cert.uc_dma_bd @d1_barrier, 0, 8, false }
+  aiex.cert.uc_dma_chain @c2_barrier { aiex.cert.uc_dma_bd @d2_barrier, 0, 8, false }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@c1_barrier)
+      aiex.cert.local_barrier(0, 2)
+      aiex.cert.uc_dma_write_des_sync(@c2_barrier)
+    }
+  }
+}
+
+// -----
+
+// A remote_barrier also blocks the merge.
+// CHECK-LABEL: @d1_remote
+// CHECK:      aiex.cert.uc_dma_chain @c1_remote {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d1_remote, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.uc_dma_chain @c2_remote {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d2_remote, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_remote)
+// CHECK-NEXT:   aiex.cert.remote_barrier(1, 3)
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c2_remote)
+// CHECK-NEXT: }
+aie.device(npu2) {
+  memref.global "private" constant @d1_remote : memref<8xi32> = dense<0>
+  memref.global "private" constant @d2_remote : memref<8xi32> = dense<1>
+  aiex.cert.uc_dma_chain @c1_remote { aiex.cert.uc_dma_bd @d1_remote, 0, 8, false }
+  aiex.cert.uc_dma_chain @c2_remote { aiex.cert.uc_dma_bd @d2_remote, 0, 8, false }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@c1_remote)
+      aiex.cert.remote_barrier(1, 3)
+      aiex.cert.uc_dma_write_des_sync(@c2_remote)
+    }
+  }
+}
+
+// -----
+
+// cert.nop has no architectural effect, so it stays transparent to the merge.
+// CHECK-LABEL: @d1_nop
+// CHECK:      aiex.cert.uc_dma_chain @[[SYM:[a-zA-Z0-9_]+]] {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d1_nop, 0, 8, true
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d2_nop, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.nop
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@[[SYM]])
+// CHECK-NEXT: }
+aie.device(npu2) {
+  memref.global "private" constant @d1_nop : memref<8xi32> = dense<0>
+  memref.global "private" constant @d2_nop : memref<8xi32> = dense<1>
+  aiex.cert.uc_dma_chain @c1_nop { aiex.cert.uc_dma_bd @d1_nop, 0, 8, false }
+  aiex.cert.uc_dma_chain @c2_nop { aiex.cert.uc_dma_bd @d2_nop, 0, 8, false }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@c1_nop)
+      aiex.cert.nop
+      aiex.cert.uc_dma_write_des_sync(@c2_nop)
+    }
+  }
+}
+
+// -----
+
+// @c1_shared is enqueued again from another job, so it may be neither folded
+// away nor erased -- erasing it would leave job(2) pointing at a dead symbol.
+// CHECK-LABEL: @d1_shared
+// CHECK:      aiex.cert.uc_dma_chain @c1_shared {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d1_shared, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.uc_dma_chain @c2_shared {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d2_shared, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_shared)
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c2_shared)
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(2) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_shared)
+// CHECK-NEXT: }
+aie.device(npu2) {
+  memref.global "private" constant @d1_shared : memref<8xi32> = dense<0>
+  memref.global "private" constant @d2_shared : memref<8xi32> = dense<1>
+  aiex.cert.uc_dma_chain @c1_shared { aiex.cert.uc_dma_bd @d1_shared, 0, 8, false }
+  aiex.cert.uc_dma_chain @c2_shared { aiex.cert.uc_dma_bd @d2_shared, 0, 8, false }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@c1_shared)
+      aiex.cert.uc_dma_write_des_sync(@c2_shared)
+    }
+  }
+  aiex.cert.page {
+    aiex.cert.job(2) {
+      aiex.cert.uc_dma_write_des_sync(@c1_shared)
+    }
+  }
+}
+
+// -----
+
+// Mirror image of @d1_shared: this time it's the *surviving* (later) chain
+// that's shared with another job, not the erased (earlier) one. Folding
+// @c1_sur's BD into @c2_sur would still be wrong -- job(2)'s enqueue of
+// @c2_sur would silently pick up @c1_sur's transfer too.
+// CHECK-LABEL: @d1_sur
+// CHECK:      aiex.cert.uc_dma_chain @c1_sur {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d1_sur, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.uc_dma_chain @c2_sur {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d2_sur, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_sur)
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c2_sur)
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(2) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c2_sur)
+// CHECK-NEXT: }
+aie.device(npu2) {
+  memref.global "private" constant @d1_sur : memref<8xi32> = dense<0>
+  memref.global "private" constant @d2_sur : memref<8xi32> = dense<1>
+  aiex.cert.uc_dma_chain @c1_sur { aiex.cert.uc_dma_bd @d1_sur, 0, 8, false }
+  aiex.cert.uc_dma_chain @c2_sur { aiex.cert.uc_dma_bd @d2_sur, 0, 8, false }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@c1_sur)
+      aiex.cert.uc_dma_write_des_sync(@c2_sur)
+    }
+  }
+  aiex.cert.page {
+    aiex.cert.job(2) {
+      aiex.cert.uc_dma_write_des_sync(@c2_sur)
+    }
+  }
+}
+
+// -----
+
+// A chain enqueued twice within one job is likewise left alone: folding into it
+// would change what the second enqueue transfers.
+// CHECK-LABEL: @d1_self
+// CHECK:      aiex.cert.uc_dma_chain @c1_self {
+// CHECK-NEXT:   aiex.cert.uc_dma_bd @d1_self, 0, 8, false
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.job(1) {
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_self)
+// CHECK-NEXT:   aiex.cert.uc_dma_write_des_sync(@c1_self)
+// CHECK-NEXT: }
+aie.device(npu2) {
+  memref.global "private" constant @d1_self : memref<8xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1_self { aiex.cert.uc_dma_bd @d1_self, 0, 8, false }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@c1_self)
+      aiex.cert.uc_dma_write_des_sync(@c1_self)
+    }
+  }
+}

--- a/test/Conversion/NpuToCert/npu_to_cert.mlir
+++ b/test/Conversion/NpuToCert/npu_to_cert.mlir
@@ -5,7 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-npu-to-cert -split-input-file %s | FileCheck %s
+// RUN: aie-opt --aie-npu-to-cert -split-input-file %s | FileCheck %s --implicit-check-not=memref.get_global --implicit-check-not=arith.constant
+// RUN: aie-opt --aie-npu-to-cert -split-input-file %s | aie-translate --aie-cert-to-asm -split-input-file
 
 // CHECK: aiex.cert.job
 // CHECK: aiex.cert.write32(12345, 65244)
@@ -20,10 +21,16 @@ aie.device(npu2) {
 
 // -----
 
+// The blockwrite's memref.get_global becomes dead once the op is converted
+// (the new op references the global by symbol, not by SSA value); it must be
+// cleaned up here, since CertJobOp's verifier rejects it and
+// cert-legalize-pages isn't guaranteed to run afterward. The
+// --implicit-check-not on the RUN line above catches a leak anywhere in this
+// file, not just here.
 // CHECK: aiex.cert.uc_dma_chain @chain_0 {
 // CHECK:   aiex.cert.uc_dma_bd @blockwrite_data, 4321, 11, false
 // CHECK: aiex.cert.job(1) {
-// CHECK:   aiex.cert.uc_dma_write_des_sync(@chain_0)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@chain_0)
 aie.device(npu2) {
   memref.global "private" constant @blockwrite_data : memref<11xi32> = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]>
   aie.runtime_sequence @configure() {
@@ -67,13 +74,23 @@ aie.device(npu2) {
 
 // -----
 
-// CHECK: aiex.cert.uc_dma_chain @[[SYM:.*]] {
-// CHECK:   aiex.cert.uc_dma_bd @blockwrite_data0, 4321, 1, true
-// CHECK:   aiex.cert.uc_dma_bd @blockwrite_data1, 5432, 2, true
+// aie-npu-to-cert does NOT merge uc_dma chains: merging is speculative before
+// pages exist and can destroy split points the page splitter needs. Chains
+// pass through untouched here and are merged by cert-legalize-pages after the
+// split -- see merge_dma_chains.mlir.
+// CHECK: aiex.cert.uc_dma_chain @chain_0 {
+// CHECK:   aiex.cert.uc_dma_bd @blockwrite_data0, 4321, 1, false
+// CHECK: }
+// CHECK: aiex.cert.uc_dma_chain @chain_1 {
+// CHECK:   aiex.cert.uc_dma_bd @blockwrite_data1, 5432, 2, false
+// CHECK: }
+// CHECK: aiex.cert.uc_dma_chain @chain_2 {
 // CHECK:   aiex.cert.uc_dma_bd @blockwrite_data2, 6543, 3, false
 // CHECK: }
 // CHECK: aiex.cert.job(1) {
-// CHECK:   aiex.cert.uc_dma_write_des_sync(@[[SYM]])
+// CHECK:   aiex.cert.uc_dma_write_des_sync(@chain_0)
+// CHECK:   aiex.cert.uc_dma_write_des_sync(@chain_1)
+// CHECK:   aiex.cert.uc_dma_write_des_sync(@chain_2)
 // CHECK: }
 
 aie.device(npu2) {

--- a/test/Conversion/NpuToCert/page_legalize.mlir
+++ b/test/Conversion/NpuToCert/page_legalize.mlir
@@ -6,9 +6,18 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
-// CHECK: aiex.cert.job(1)
-// CHECK: aiex.cert.job(2)
-// CHECK: aiex.cert.job(3)
+// The two contiguous top-level bare jobs are first grouped into one implicit
+// page, then re-split by size. Size-based splitting yields three pages: the
+// first two hold split fragments (job(1), job(2)), and the last page holds the
+// remaining fragment of the first job (job(3)) together with the second job
+// (job(4)).
+// CHECK: aiex.cert.page
+// CHECK-NEXT: aiex.cert.job(1)
+// CHECK: aiex.cert.page
+// CHECK-NEXT: aiex.cert.job(2)
+// CHECK: aiex.cert.page
+// CHECK-NEXT: aiex.cert.job(3)
+// CHECK-NOT: aiex.cert.page
 // CHECK: aiex.cert.job(4)
 
 module {

--- a/test/Conversion/NpuToCert/page_split_diagnostics.mlir
+++ b/test/Conversion/NpuToCert/page_split_diagnostics.mlir
@@ -1,0 +1,168 @@
+//===- page_split_diagnostics.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Diagnostics when auto-splitting an oversized page.
+//  - splitting an implicit page (formed from contiguous top-level jobs)
+//    into sequential pages emits a remark;
+//  - if no split keeps a local_barrier group intact, splitting is refused.
+//    Leaving the page whole is the safer of two bad options -- severing a
+//    barrier hangs the firmware -- but that only holds while the page still
+//    fits, so it is an error once the page passes the 8192-byte limit. Fires
+//    for implicit and explicit pages alike; only the remedy differs.
+//  - Same 8192-byte rule when the page offers no split point at all, which
+//    happens when its bulk sits in a single one-op job.
+//
+// Note the two thresholds: 8000 triggers a split attempt, 8192 is the hardware
+// page limit and the only thing worth erroring about. A page between them trips
+// the trigger yet loads fine, so failing to split it is not a diagnostic.
+
+// RUN: aie-opt -cert-legalize-pages --split-input-file --verify-diagnostics %s
+
+// Remark: an oversized implicit page with no blocking barrier splits into two
+// sequential pages -> remark on the implicit page.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<1300xi32> = dense<0>
+  memref.global "private" constant @d2 : memref<1300xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 1300, false
+  }
+  aiex.cert.uc_dma_chain @c2 {
+    aiex.cert.uc_dma_bd @d2, 0, 1300, false
+  }
+  // expected-remark@+1 {{auto-split of implicit cert.page serializes cooperatively-scheduled jobs}}
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@c1)
+    aiex.cert.uc_dma_write_des_sync(@c2)
+  }
+}
+
+// -----
+
+// No remark: the same oversized job, but tagged {cert.configure}. That page is
+// synthesized by the compiler from the @configure runtime sequence, so the
+// remark's advice -- add an explicit cert.page boundary -- is not something the
+// user can act on, and config transactions are routinely large enough to split.
+// formImplicitPagesInBlock therefore isolates it WITHOUT the cert.implicit tag.
+// --verify-diagnostics fails on an unexpected remark, so this case passing is
+// the assertion. It still splits; it just splits quietly.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<1300xi32> = dense<0>
+  memref.global "private" constant @d2 : memref<1300xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 1300, false
+  }
+  aiex.cert.uc_dma_chain @c2 {
+    aiex.cert.uc_dma_bd @d2, 0, 1300, false
+  }
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@c1)
+    aiex.cert.uc_dma_write_des_sync(@c2)
+  } {cert.configure}
+}
+
+// -----
+
+// Error: an oversized implicit page whose only local_barrier group spans the
+// whole page cannot be split without separating the participants -> error.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<1300xi32> = dense<0>
+  memref.global "private" constant @d2 : memref<1300xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 1300, false
+  }
+  aiex.cert.uc_dma_chain @c2 {
+    aiex.cert.uc_dma_bd @d2, 0, 1300, false
+  }
+  // expected-error@+1 {{over the 8192-byte microcontroller page limit, and cannot be split without separating a local_barrier participant set across pages; insert an explicit cert.page boundary}}
+  aiex.cert.job(1) {
+    aiex.cert.local_barrier(0, 2)
+    aiex.cert.uc_dma_write_des_sync(@c1)
+    aiex.cert.uc_dma_write_des_sync(@c2)
+    aiex.cert.local_barrier(0, 2)
+  }
+}
+
+// -----
+
+// Error: same situation, but the oversized page is an EXPLICIT user-authored
+// cert.page. There is still no legal lowering, so it must not pass silently --
+// the remedy is to shrink the page or regroup the participants, since the user
+// already chose this boundary. Compare page_split_localbar.mlir, where an
+// explicit page of the same shape DOES have a legal cut and splits cleanly.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<1300xi32> = dense<0>
+  memref.global "private" constant @d2 : memref<1300xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 1300, false
+  }
+  aiex.cert.uc_dma_chain @c2 {
+    aiex.cert.uc_dma_bd @d2, 0, 1300, false
+  }
+  // expected-error@+1 {{over the 8192-byte microcontroller page limit, and cannot be split without separating a local_barrier participant set across pages; reduce the page's contents or regroup its local_barrier participants}}
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.local_barrier(0, 2)
+      aiex.cert.uc_dma_write_des_sync(@c1)
+      aiex.cert.uc_dma_write_des_sync(@c2)
+      aiex.cert.local_barrier(0, 2)
+    }
+  }
+}
+
+// -----
+
+// Error: an oversized page whose bulk is a single one-op job. A split point has
+// to fall inside a job with at least one op ahead of it, so this page offers
+// none at all -- no barrier is involved. Over the 8192-byte limit, so it is an
+// error rather than a silent oversized page.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<2500xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 2500, false
+  }
+  // expected-error@+1 {{offers no split point (a split must fall inside a job, after at least one of its ops); break the oversized job into smaller jobs}}
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@c1)
+  }
+}
+
+// -----
+
+// The 8192 boundary, both sides. These two cases were validated end to end
+// against the real toolchain -- aie-translate --aie-cert-to-asm piped into
+// `aiebu-asm` -- and the assembler's own accounting agrees with
+// estimateCost byte for byte: it accepts 2032 and rejects 2034 with
+// "text and data section size 8200 > pagesize(8192)". Both text and chain data
+// count toward the page, which is why data_cost is charged to the page budget.
+//
+// Under the limit: estimate is exactly 8192 (32 page + 8 START_JOB + 4
+// write_des_sync + 4 END_JOB + 16 BD + 2032 x 4 data). It trips the 8000 split
+// trigger and has no split point, but it fits, so it must pass silently. This
+// is the case that keeps the two thresholds from collapsing into one.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<2032xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 2032, false
+  }
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@c1)
+  }
+}
+
+// -----
+
+// Two elements over: estimate 8200, past the limit, no split point -> error.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<2034xi32> = dense<0>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 2034, false
+  }
+  // expected-error@+1 {{cert.page is an estimated 8200 bytes, over the 8192-byte microcontroller page limit, and offers no split point}}
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@c1)
+  }
+}

--- a/test/Conversion/NpuToCert/page_split_diagnostics.mlir
+++ b/test/Conversion/NpuToCert/page_split_diagnostics.mlir
@@ -115,18 +115,43 @@ aie.device(npu2) {
 
 // -----
 
-// Error: an oversized page whose bulk is a single one-op job. A split point has
-// to fall inside a job with at least one op ahead of it, so this page offers
-// none at all -- no barrier is involved. Over the 8192-byte limit, so it is an
-// error rather than a silent oversized page.
+// Error: an oversized page whose bulk is a single one-op job. Every cut has to
+// leave at least one op on each side and this page holds exactly one op, so it
+// offers no split point at all -- no barrier is involved. Over the 8192-byte
+// limit, so it is an error rather than a silent oversized page.
 aie.device(npu2) {
   memref.global "private" constant @d1 : memref<2500xi32> = dense<0>
   aiex.cert.uc_dma_chain @c1 {
     aiex.cert.uc_dma_bd @d1, 0, 2500, false
   }
-  // expected-error@+1 {{offers no split point (a split must fall inside a job, after at least one of its ops); break the oversized job into smaller jobs}}
+  // expected-error@+1 {{offers no split point (a split must leave at least one op on each page); break the oversized job into smaller jobs}}
   aiex.cert.job(1) {
     aiex.cert.uc_dma_write_des_sync(@c1)
+  }
+}
+
+// -----
+
+// Remark, not an error: two one-op jobs, each individually fine and jointly over
+// the limit, grouped into one implicit page. The only cut available is the
+// boundary between them, which is a real split -- so this takes the ordinary
+// implicit-page serialization remark and not the "offers no split point" error.
+// See page_split_job_boundary.mlir for the explicit-page form of this shape.
+aie.device(npu2) {
+  memref.global "private" constant @d1 : memref<1200xi32> = dense<0>
+  memref.global "private" constant @d2 : memref<1200xi32> = dense<1>
+  aiex.cert.uc_dma_chain @c1 {
+    aiex.cert.uc_dma_bd @d1, 0, 1200, false
+  }
+  aiex.cert.uc_dma_chain @c2 {
+    aiex.cert.uc_dma_bd @d2, 0, 1200, false
+  }
+  // expected-remark@+1 {{auto-split of implicit cert.page serializes cooperatively-scheduled jobs}}
+  aiex.cert.job(1) {
+    aiex.cert.uc_dma_write_des_sync(@c1)
+  }
+  aiex.cert.job(2) {
+    aiex.cert.uc_dma_write_des_sync(@c2)
   }
 }
 

--- a/test/Conversion/NpuToCert/page_split_dma_chain_overhead.mlir
+++ b/test/Conversion/NpuToCert/page_split_dma_chain_overhead.mlir
@@ -1,0 +1,178 @@
+//===- page_split_dma_chain_overhead.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// 48 independent 40-element (160-byte) blockwrites: 48*160 = 7680 bytes of
+// payload, under cert_page_size (8000), but 48*(160+16) = 8448 bytes once the
+// splitter's per-BD descriptor overhead is counted -- over the hard 8192-byte
+// uC page limit. Merging all 48 into one atomic chain before any page exists
+// would make the resulting oversized page unsplittable (the splitter can only
+// cut between sibling ops, never inside a chain's BD list). Expect two legal
+// pages instead, each holding one fully-merged chain.
+
+// RUN: aie-opt --aie-npu-to-cert %s | aie-opt --cert-legalize-pages | FileCheck %s
+
+// CHECK:      aiex.cert.uc_dma_chain @[[C0:[a-zA-Z0-9_]+]] {
+// CHECK-COUNT-22: aiex.cert.uc_dma_bd
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.uc_dma_chain @[[C1:[a-zA-Z0-9_]+]] {
+// CHECK-COUNT-26: aiex.cert.uc_dma_bd
+// CHECK-NEXT: }
+// CHECK:      aiex.cert.page {
+// CHECK-NEXT:   aiex.cert.job
+// CHECK-NEXT:     aiex.cert.uc_dma_write_des_sync(@[[C0]])
+// CHECK:      aiex.cert.page {
+// CHECK-NEXT:   aiex.cert.job
+// CHECK-NEXT:     aiex.cert.uc_dma_write_des_sync(@[[C1]])
+
+aie.device(npu2) {
+  memref.global "private" constant @data_0 : memref<40xi32> = dense<1>
+  memref.global "private" constant @data_1 : memref<40xi32> = dense<2>
+  memref.global "private" constant @data_2 : memref<40xi32> = dense<3>
+  memref.global "private" constant @data_3 : memref<40xi32> = dense<4>
+  memref.global "private" constant @data_4 : memref<40xi32> = dense<5>
+  memref.global "private" constant @data_5 : memref<40xi32> = dense<6>
+  memref.global "private" constant @data_6 : memref<40xi32> = dense<7>
+  memref.global "private" constant @data_7 : memref<40xi32> = dense<8>
+  memref.global "private" constant @data_8 : memref<40xi32> = dense<9>
+  memref.global "private" constant @data_9 : memref<40xi32> = dense<10>
+  memref.global "private" constant @data_10 : memref<40xi32> = dense<11>
+  memref.global "private" constant @data_11 : memref<40xi32> = dense<12>
+  memref.global "private" constant @data_12 : memref<40xi32> = dense<13>
+  memref.global "private" constant @data_13 : memref<40xi32> = dense<14>
+  memref.global "private" constant @data_14 : memref<40xi32> = dense<15>
+  memref.global "private" constant @data_15 : memref<40xi32> = dense<16>
+  memref.global "private" constant @data_16 : memref<40xi32> = dense<17>
+  memref.global "private" constant @data_17 : memref<40xi32> = dense<18>
+  memref.global "private" constant @data_18 : memref<40xi32> = dense<19>
+  memref.global "private" constant @data_19 : memref<40xi32> = dense<20>
+  memref.global "private" constant @data_20 : memref<40xi32> = dense<21>
+  memref.global "private" constant @data_21 : memref<40xi32> = dense<22>
+  memref.global "private" constant @data_22 : memref<40xi32> = dense<23>
+  memref.global "private" constant @data_23 : memref<40xi32> = dense<24>
+  memref.global "private" constant @data_24 : memref<40xi32> = dense<25>
+  memref.global "private" constant @data_25 : memref<40xi32> = dense<26>
+  memref.global "private" constant @data_26 : memref<40xi32> = dense<27>
+  memref.global "private" constant @data_27 : memref<40xi32> = dense<28>
+  memref.global "private" constant @data_28 : memref<40xi32> = dense<29>
+  memref.global "private" constant @data_29 : memref<40xi32> = dense<30>
+  memref.global "private" constant @data_30 : memref<40xi32> = dense<31>
+  memref.global "private" constant @data_31 : memref<40xi32> = dense<32>
+  memref.global "private" constant @data_32 : memref<40xi32> = dense<33>
+  memref.global "private" constant @data_33 : memref<40xi32> = dense<34>
+  memref.global "private" constant @data_34 : memref<40xi32> = dense<35>
+  memref.global "private" constant @data_35 : memref<40xi32> = dense<36>
+  memref.global "private" constant @data_36 : memref<40xi32> = dense<37>
+  memref.global "private" constant @data_37 : memref<40xi32> = dense<38>
+  memref.global "private" constant @data_38 : memref<40xi32> = dense<39>
+  memref.global "private" constant @data_39 : memref<40xi32> = dense<40>
+  memref.global "private" constant @data_40 : memref<40xi32> = dense<41>
+  memref.global "private" constant @data_41 : memref<40xi32> = dense<42>
+  memref.global "private" constant @data_42 : memref<40xi32> = dense<43>
+  memref.global "private" constant @data_43 : memref<40xi32> = dense<44>
+  memref.global "private" constant @data_44 : memref<40xi32> = dense<45>
+  memref.global "private" constant @data_45 : memref<40xi32> = dense<46>
+  memref.global "private" constant @data_46 : memref<40xi32> = dense<47>
+  memref.global "private" constant @data_47 : memref<40xi32> = dense<48>
+  aie.runtime_sequence @seq() {
+    %g0 = memref.get_global @data_0 : memref<40xi32>
+    aiex.npu.blockwrite(%g0) {address = 0 : ui32} : memref<40xi32>
+    %g1 = memref.get_global @data_1 : memref<40xi32>
+    aiex.npu.blockwrite(%g1) {address = 160 : ui32} : memref<40xi32>
+    %g2 = memref.get_global @data_2 : memref<40xi32>
+    aiex.npu.blockwrite(%g2) {address = 320 : ui32} : memref<40xi32>
+    %g3 = memref.get_global @data_3 : memref<40xi32>
+    aiex.npu.blockwrite(%g3) {address = 480 : ui32} : memref<40xi32>
+    %g4 = memref.get_global @data_4 : memref<40xi32>
+    aiex.npu.blockwrite(%g4) {address = 640 : ui32} : memref<40xi32>
+    %g5 = memref.get_global @data_5 : memref<40xi32>
+    aiex.npu.blockwrite(%g5) {address = 800 : ui32} : memref<40xi32>
+    %g6 = memref.get_global @data_6 : memref<40xi32>
+    aiex.npu.blockwrite(%g6) {address = 960 : ui32} : memref<40xi32>
+    %g7 = memref.get_global @data_7 : memref<40xi32>
+    aiex.npu.blockwrite(%g7) {address = 1120 : ui32} : memref<40xi32>
+    %g8 = memref.get_global @data_8 : memref<40xi32>
+    aiex.npu.blockwrite(%g8) {address = 1280 : ui32} : memref<40xi32>
+    %g9 = memref.get_global @data_9 : memref<40xi32>
+    aiex.npu.blockwrite(%g9) {address = 1440 : ui32} : memref<40xi32>
+    %g10 = memref.get_global @data_10 : memref<40xi32>
+    aiex.npu.blockwrite(%g10) {address = 1600 : ui32} : memref<40xi32>
+    %g11 = memref.get_global @data_11 : memref<40xi32>
+    aiex.npu.blockwrite(%g11) {address = 1760 : ui32} : memref<40xi32>
+    %g12 = memref.get_global @data_12 : memref<40xi32>
+    aiex.npu.blockwrite(%g12) {address = 1920 : ui32} : memref<40xi32>
+    %g13 = memref.get_global @data_13 : memref<40xi32>
+    aiex.npu.blockwrite(%g13) {address = 2080 : ui32} : memref<40xi32>
+    %g14 = memref.get_global @data_14 : memref<40xi32>
+    aiex.npu.blockwrite(%g14) {address = 2240 : ui32} : memref<40xi32>
+    %g15 = memref.get_global @data_15 : memref<40xi32>
+    aiex.npu.blockwrite(%g15) {address = 2400 : ui32} : memref<40xi32>
+    %g16 = memref.get_global @data_16 : memref<40xi32>
+    aiex.npu.blockwrite(%g16) {address = 2560 : ui32} : memref<40xi32>
+    %g17 = memref.get_global @data_17 : memref<40xi32>
+    aiex.npu.blockwrite(%g17) {address = 2720 : ui32} : memref<40xi32>
+    %g18 = memref.get_global @data_18 : memref<40xi32>
+    aiex.npu.blockwrite(%g18) {address = 2880 : ui32} : memref<40xi32>
+    %g19 = memref.get_global @data_19 : memref<40xi32>
+    aiex.npu.blockwrite(%g19) {address = 3040 : ui32} : memref<40xi32>
+    %g20 = memref.get_global @data_20 : memref<40xi32>
+    aiex.npu.blockwrite(%g20) {address = 3200 : ui32} : memref<40xi32>
+    %g21 = memref.get_global @data_21 : memref<40xi32>
+    aiex.npu.blockwrite(%g21) {address = 3360 : ui32} : memref<40xi32>
+    %g22 = memref.get_global @data_22 : memref<40xi32>
+    aiex.npu.blockwrite(%g22) {address = 3520 : ui32} : memref<40xi32>
+    %g23 = memref.get_global @data_23 : memref<40xi32>
+    aiex.npu.blockwrite(%g23) {address = 3680 : ui32} : memref<40xi32>
+    %g24 = memref.get_global @data_24 : memref<40xi32>
+    aiex.npu.blockwrite(%g24) {address = 3840 : ui32} : memref<40xi32>
+    %g25 = memref.get_global @data_25 : memref<40xi32>
+    aiex.npu.blockwrite(%g25) {address = 4000 : ui32} : memref<40xi32>
+    %g26 = memref.get_global @data_26 : memref<40xi32>
+    aiex.npu.blockwrite(%g26) {address = 4160 : ui32} : memref<40xi32>
+    %g27 = memref.get_global @data_27 : memref<40xi32>
+    aiex.npu.blockwrite(%g27) {address = 4320 : ui32} : memref<40xi32>
+    %g28 = memref.get_global @data_28 : memref<40xi32>
+    aiex.npu.blockwrite(%g28) {address = 4480 : ui32} : memref<40xi32>
+    %g29 = memref.get_global @data_29 : memref<40xi32>
+    aiex.npu.blockwrite(%g29) {address = 4640 : ui32} : memref<40xi32>
+    %g30 = memref.get_global @data_30 : memref<40xi32>
+    aiex.npu.blockwrite(%g30) {address = 4800 : ui32} : memref<40xi32>
+    %g31 = memref.get_global @data_31 : memref<40xi32>
+    aiex.npu.blockwrite(%g31) {address = 4960 : ui32} : memref<40xi32>
+    %g32 = memref.get_global @data_32 : memref<40xi32>
+    aiex.npu.blockwrite(%g32) {address = 5120 : ui32} : memref<40xi32>
+    %g33 = memref.get_global @data_33 : memref<40xi32>
+    aiex.npu.blockwrite(%g33) {address = 5280 : ui32} : memref<40xi32>
+    %g34 = memref.get_global @data_34 : memref<40xi32>
+    aiex.npu.blockwrite(%g34) {address = 5440 : ui32} : memref<40xi32>
+    %g35 = memref.get_global @data_35 : memref<40xi32>
+    aiex.npu.blockwrite(%g35) {address = 5600 : ui32} : memref<40xi32>
+    %g36 = memref.get_global @data_36 : memref<40xi32>
+    aiex.npu.blockwrite(%g36) {address = 5760 : ui32} : memref<40xi32>
+    %g37 = memref.get_global @data_37 : memref<40xi32>
+    aiex.npu.blockwrite(%g37) {address = 5920 : ui32} : memref<40xi32>
+    %g38 = memref.get_global @data_38 : memref<40xi32>
+    aiex.npu.blockwrite(%g38) {address = 6080 : ui32} : memref<40xi32>
+    %g39 = memref.get_global @data_39 : memref<40xi32>
+    aiex.npu.blockwrite(%g39) {address = 6240 : ui32} : memref<40xi32>
+    %g40 = memref.get_global @data_40 : memref<40xi32>
+    aiex.npu.blockwrite(%g40) {address = 6400 : ui32} : memref<40xi32>
+    %g41 = memref.get_global @data_41 : memref<40xi32>
+    aiex.npu.blockwrite(%g41) {address = 6560 : ui32} : memref<40xi32>
+    %g42 = memref.get_global @data_42 : memref<40xi32>
+    aiex.npu.blockwrite(%g42) {address = 6720 : ui32} : memref<40xi32>
+    %g43 = memref.get_global @data_43 : memref<40xi32>
+    aiex.npu.blockwrite(%g43) {address = 6880 : ui32} : memref<40xi32>
+    %g44 = memref.get_global @data_44 : memref<40xi32>
+    aiex.npu.blockwrite(%g44) {address = 7040 : ui32} : memref<40xi32>
+    %g45 = memref.get_global @data_45 : memref<40xi32>
+    aiex.npu.blockwrite(%g45) {address = 7200 : ui32} : memref<40xi32>
+    %g46 = memref.get_global @data_46 : memref<40xi32>
+    aiex.npu.blockwrite(%g46) {address = 7360 : ui32} : memref<40xi32>
+    %g47 = memref.get_global @data_47 : memref<40xi32>
+    aiex.npu.blockwrite(%g47) {address = 7520 : ui32} : memref<40xi32>
+  }
+}

--- a/test/Conversion/NpuToCert/page_split_job_boundary.mlir
+++ b/test/Conversion/NpuToCert/page_split_job_boundary.mlir
@@ -137,8 +137,9 @@ aie.device(npu2) {
 
 // -----
 
-// Case 4: a boundary cut is still subject to T5.1, and here it is the only cut
-// that obeys it. The local_barrier group spans jobs 2 and 3, so every interior
+// Case 4: a boundary cut is still subject to local_barrier co-location
+// (G-localbar), and here it is the only cut that obeys it. The local_barrier
+// group spans jobs 2 and 3, so every interior
 // position inside them separates its participants; the boundary between job 1
 // and job 2 sits just ahead of the group and keeps it whole. Cutting there is
 // the difference between splitting this page and refusing to (the cost search's

--- a/test/Conversion/NpuToCert/page_split_job_boundary.mlir
+++ b/test/Conversion/NpuToCert/page_split_job_boundary.mlir
@@ -1,0 +1,184 @@
+//===- page_split_job_boundary.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A page can be oversized without any single job being oversized: several small
+// jobs whose sizes merely sum past the limit. The cut such a page wants is a
+// job boundary -- whole jobs on either side, nothing partitioned -- and the
+// split-point search has to be able to name one. Both searches used to consider
+// only positions with an op of the *same* job ahead of them, so a job's first op
+// was never a candidate and these pages were reported as offering no split point
+// at all. A position is legal as soon as anything on the page precedes it, in
+// the same job or an earlier one.
+
+// RUN: aie-opt -cert-legalize-pages --split-input-file %s | FileCheck %s
+
+// Case 1: the minimal shape -- two one-op jobs, 9696 bytes together, neither
+// with an interior point to cut at. One job per page, both kept whole, and
+// because no job is partitioned the job ids are untouched.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@jb_c1)
+// CHECK-NOT: @jb_c2
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@jb_c2)
+aie.device(npu2) {
+  memref.global "private" constant @jb_d1 : memref<1200xi32> = dense<0>
+  memref.global "private" constant @jb_d2 : memref<1200xi32> = dense<1>
+  aiex.cert.uc_dma_chain @jb_c1 {
+    aiex.cert.uc_dma_bd @jb_d1, 0, 1200, false
+  }
+  aiex.cert.uc_dma_chain @jb_c2 {
+    aiex.cert.uc_dma_bd @jb_d2, 0, 1200, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@jb_c1)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.uc_dma_write_des_sync(@jb_c2)
+    }
+  }
+}
+
+// -----
+
+// Case 2: four one-op jobs of 2432 bytes each, 9760 in total. Several boundaries
+// are legal, so the search picks the one closest to the 4096 target -- the
+// middle one, two jobs each way -- rather than the first it happens to see.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@sum_c1)
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@sum_c2)
+// CHECK-NOT: @sum_c3
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(3)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@sum_c3)
+// CHECK: aiex.cert.job(4)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@sum_c4)
+aie.device(npu2) {
+  memref.global "private" constant @sum_d1 : memref<600xi32> = dense<0>
+  memref.global "private" constant @sum_d2 : memref<600xi32> = dense<1>
+  memref.global "private" constant @sum_d3 : memref<600xi32> = dense<2>
+  memref.global "private" constant @sum_d4 : memref<600xi32> = dense<3>
+  aiex.cert.uc_dma_chain @sum_c1 {
+    aiex.cert.uc_dma_bd @sum_d1, 0, 600, false
+  }
+  aiex.cert.uc_dma_chain @sum_c2 {
+    aiex.cert.uc_dma_bd @sum_d2, 0, 600, false
+  }
+  aiex.cert.uc_dma_chain @sum_c3 {
+    aiex.cert.uc_dma_bd @sum_d3, 0, 600, false
+  }
+  aiex.cert.uc_dma_chain @sum_c4 {
+    aiex.cert.uc_dma_bd @sum_d4, 0, 600, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@sum_c1)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.uc_dma_write_des_sync(@sum_c2)
+    }
+    aiex.cert.job(3) {
+      aiex.cert.uc_dma_write_des_sync(@sum_c3)
+    }
+    aiex.cert.job(4) {
+      aiex.cert.uc_dma_write_des_sync(@sum_c4)
+    }
+  }
+}
+
+// -----
+
+// Case 3: the same gap reached a step later. The one interior cut on this page
+// (in the first job, before its fat op) is the one the cost search takes, and
+// the page it leaves behind -- one fat op per one-op job -- is the shape of case
+// 1 again. Without a boundary cut available the second pass has nothing left to
+// try and the page fails, with the diagnostic pointing at a page that no longer
+// exists in the input. Three pages and no diagnostic is the whole assertion.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.uc_dma_write_des_sync(@def_tiny)
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.uc_dma_write_des_sync(@def_c1)
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.uc_dma_write_des_sync(@def_c2)
+aie.device(npu2) {
+  memref.global "private" constant @def_dt : memref<50xi32> = dense<0>
+  memref.global "private" constant @def_d1 : memref<1200xi32> = dense<0>
+  memref.global "private" constant @def_d2 : memref<1200xi32> = dense<1>
+  aiex.cert.uc_dma_chain @def_tiny {
+    aiex.cert.uc_dma_bd @def_dt, 0, 50, false
+  }
+  aiex.cert.uc_dma_chain @def_c1 {
+    aiex.cert.uc_dma_bd @def_d1, 0, 1200, false
+  }
+  aiex.cert.uc_dma_chain @def_c2 {
+    aiex.cert.uc_dma_bd @def_d2, 0, 1200, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@def_tiny)
+      aiex.cert.uc_dma_write_des_sync(@def_c1)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.uc_dma_write_des_sync(@def_c2)
+    }
+  }
+}
+
+// -----
+
+// Case 4: a boundary cut is still subject to T5.1, and here it is the only cut
+// that obeys it. The local_barrier group spans jobs 2 and 3, so every interior
+// position inside them separates its participants; the boundary between job 1
+// and job 2 sits just ahead of the group and keeps it whole. Cutting there is
+// the difference between splitting this page and refusing to (the cost search's
+// own pick, before job 2's fat op, splits the group).
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@bar_ca)
+// CHECK-NOT: aiex.cert.local_barrier
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.local_barrier(0, 2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@bar_cb)
+// CHECK: aiex.cert.job(3)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@bar_cc)
+// CHECK: aiex.cert.local_barrier(0, 2)
+aie.device(npu2) {
+  memref.global "private" constant @bar_da : memref<800xi32> = dense<0>
+  memref.global "private" constant @bar_db : memref<800xi32> = dense<1>
+  memref.global "private" constant @bar_dc : memref<800xi32> = dense<2>
+  aiex.cert.uc_dma_chain @bar_ca {
+    aiex.cert.uc_dma_bd @bar_da, 0, 800, false
+  }
+  aiex.cert.uc_dma_chain @bar_cb {
+    aiex.cert.uc_dma_bd @bar_db, 0, 800, false
+  }
+  aiex.cert.uc_dma_chain @bar_cc {
+    aiex.cert.uc_dma_bd @bar_dc, 0, 800, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@bar_ca)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.local_barrier(0, 2)
+      aiex.cert.uc_dma_write_des_sync(@bar_cb)
+    }
+    aiex.cert.job(3) {
+      aiex.cert.uc_dma_write_des_sync(@bar_cc)
+      aiex.cert.local_barrier(0, 2)
+    }
+  }
+}

--- a/test/Conversion/NpuToCert/page_split_last_op.mlir
+++ b/test/Conversion/NpuToCert/page_split_last_op.mlir
@@ -1,0 +1,167 @@
+//===- page_split_last_op.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The split-point search must not depend on where in a job the expensive op
+// sits. estimateCost walks a job charging op costs and records the first
+// position at which the running total crosses split_target; the natural
+// candidate is "immediately after the op that crossed". When that op is the
+// job's last real op, the only thing after it is the terminator, which is not a
+// split point -- so the search has to fall back to cutting immediately *before*
+// it. Without that fallback a page with its one fat op last was reported as
+// offering no split point, while the very same ops with the fat one first split
+// fine: a positional failure, not a size one.
+//
+// The first two cases below hold the same multiset of ops in opposite orders and
+// estimate to the same 8484 bytes. Both must split.
+
+// RUN: aie-opt -cert-legalize-pages --split-input-file %s | FileCheck %s
+
+// Case 1: fat op LAST. Running cost before it is 3660, under the 4000 target,
+// and it alone carries the page to 8484, past the 8192 limit. Cut before it.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@last_small)
+// CHECK-NOT: @last_fat
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@last_fat)
+aie.device(npu2) {
+  memref.global "private" constant @last_small_data : memref<900xi32> = dense<0>
+  memref.global "private" constant @last_fat_data : memref<1200xi32> = dense<0>
+  aiex.cert.uc_dma_chain @last_small {
+    aiex.cert.uc_dma_bd @last_small_data, 0, 900, false
+  }
+  aiex.cert.uc_dma_chain @last_fat {
+    aiex.cert.uc_dma_bd @last_fat_data, 0, 1200, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@last_small)
+      aiex.cert.uc_dma_write_des_sync(@last_fat)
+    }
+  }
+}
+
+// -----
+
+// Case 2: fat op FIRST -- the mirror image, which always split. Kept as the
+// control, so the two orders are asserted to behave the same way.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@first_fat)
+// CHECK-NOT: @first_small
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@first_small)
+aie.device(npu2) {
+  memref.global "private" constant @first_fat_data : memref<1200xi32> = dense<0>
+  memref.global "private" constant @first_small_data : memref<900xi32> = dense<0>
+  aiex.cert.uc_dma_chain @first_fat {
+    aiex.cert.uc_dma_bd @first_fat_data, 0, 1200, false
+  }
+  aiex.cert.uc_dma_chain @first_small {
+    aiex.cert.uc_dma_bd @first_small_data, 0, 900, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@first_fat)
+      aiex.cert.uc_dma_write_des_sync(@first_small)
+    }
+  }
+}
+
+// -----
+
+// Case 3: a distinct failure mode -- the crossing op is the last op of a job
+// that is NOT the page's last job. The search does not stop at the end of that
+// job, so it used to "recover" by taking the next position it could represent,
+// after the following job's first op, and split there. That cut is on the wrong
+// side of the fat op, so the earlier page came back over the limit and hit the
+// same blind spot on the re-split: the miss was deferred, not avoided. The cut
+// belongs before the fat op, on the first pass.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@mj_small)
+// CHECK-NOT: @mj_fat
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@mj_fat)
+// CHECK: aiex.cert.job(3)
+// CHECK: aiex.cert.maskwrite32
+// CHECK: aiex.cert.maskwrite32
+aie.device(npu2) {
+  memref.global "private" constant @mj_small_data : memref<900xi32> = dense<0>
+  memref.global "private" constant @mj_fat_data : memref<1200xi32> = dense<0>
+  aiex.cert.uc_dma_chain @mj_small {
+    aiex.cert.uc_dma_bd @mj_small_data, 0, 900, false
+  }
+  aiex.cert.uc_dma_chain @mj_fat {
+    aiex.cert.uc_dma_bd @mj_fat_data, 0, 1200, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@mj_small)
+      aiex.cert.uc_dma_write_des_sync(@mj_fat)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.maskwrite32(6959104, 0, 1)
+      aiex.cert.maskwrite32(6999568, 2, 2)
+    }
+  }
+}
+
+// -----
+
+// Case 4: the fallback must not manufacture a degenerate split. The op that
+// crosses the target is alone in its job, so there is nothing to cut before it
+// in that job, and the cost search gives up -- only the exhaustive fallback
+// resolves this page. Note that cutting before the crossing op whenever it is
+// merely "not the job's first" also fires on the job terminator, which puts the
+// whole job on the earlier page and an empty job on the later one, leaving the
+// page unchanged so the greedy driver re-splits it forever. This case is what
+// catches that.
+//
+// The fallback weighs every candidate by how close it lands to the target, and
+// here the boundary between the two jobs (3684 bytes) beats the interior point
+// between @alone_a and @alone_b (1860), so the cut goes between the jobs and
+// each stays whole. That is the better of the two -- one page each way either
+// way, but no job torn in half, which is also what lets @alone_a and @alone_b
+// stay adjacent and merge into a single chain.
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@alone_b)
+// CHECK-NOT: @alone_fat
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@alone_fat)
+aie.device(npu2) {
+  memref.global "private" constant @alone_a_data : memref<450xi32> = dense<0>
+  memref.global "private" constant @alone_b_data : memref<450xi32> = dense<0>
+  memref.global "private" constant @alone_fat_data : memref<1200xi32> = dense<0>
+  aiex.cert.uc_dma_chain @alone_a {
+    aiex.cert.uc_dma_bd @alone_a_data, 0, 450, false
+  }
+  aiex.cert.uc_dma_chain @alone_b {
+    aiex.cert.uc_dma_bd @alone_b_data, 0, 450, false
+  }
+  aiex.cert.uc_dma_chain @alone_fat {
+    aiex.cert.uc_dma_bd @alone_fat_data, 0, 1200, false
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.uc_dma_write_des_sync(@alone_a)
+      aiex.cert.uc_dma_write_des_sync(@alone_b)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.uc_dma_write_des_sync(@alone_fat)
+    }
+  }
+}

--- a/test/Conversion/NpuToCert/page_split_localbar.mlir
+++ b/test/Conversion/NpuToCert/page_split_localbar.mlir
@@ -1,0 +1,48 @@
+//===- page_split_localbar.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// an oversized page must never split a local_barrier participant set
+// across an .eop (G-localbar). The two local_barrier(0, 2) ops are participants
+// of one barrier; the cost-based mid-split would fall between them (separating
+// the group), so the splitter retargets to a legal cut after both participants.
+// Both barriers therefore land on the SAME emitted page.
+
+// RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.local_barrier(0, 2)
+// CHECK: aiex.cert.local_barrier(0, 2)
+// CHECK: aiex.cert.page
+// CHECK-NOT: aiex.cert.local_barrier
+
+module {
+  aie.device(npu2) {
+    memref.global "private" constant @dataA : memref<1300xi32> = dense<0>
+    memref.global "private" constant @dataB : memref<1300xi32> = dense<0>
+
+    aiex.cert.uc_dma_chain @chainA {
+      aiex.cert.uc_dma_bd @dataA, 0, 1300, false
+    }
+    aiex.cert.uc_dma_chain @chainB {
+      aiex.cert.uc_dma_bd @dataB, 0, 1300, false
+    }
+
+    // A single oversized page. Cost accumulates past the mid-split target after
+    // @chainA; the natural cut is before the second local_barrier, which would
+    // separate the barrier group. The legal alternative cut is before @chainB,
+    // keeping both local_barrier participants on the earlier page.
+    aiex.cert.page {
+      aiex.cert.job(1) {
+        aiex.cert.local_barrier(0, 2)
+        aiex.cert.uc_dma_write_des_sync(@chainA)
+        aiex.cert.local_barrier(0, 2)
+        aiex.cert.uc_dma_write_des_sync(@chainB)
+      }
+    }
+  }
+}

--- a/test/Conversion/NpuToCert/page_split_order.mlir
+++ b/test/Conversion/NpuToCert/page_split_order.mlir
@@ -1,0 +1,48 @@
+//===- page_split_order.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// the page splitter preserves IR (textual) order within and across the
+// two result pages. An oversized job with two uc_dma_write_des_sync enqueues
+// followed by a wait_tcts splits so the enqueues stay on the earlier page and
+// the wait_tcts lands on the later page (a legal backward dependency), with the
+// internal order of each page preserved.
+
+// RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
+
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@c1)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@c2)
+// CHECK-NOT: aiex.cert.wait_tcts
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.wait_tcts(0, 6, 1)
+
+module {
+  aie.device(npu2) {
+    memref.global "private" constant @c1data : memref<900xi32> = dense<0>
+    memref.global "private" constant @c2data : memref<1100xi32> = dense<0>
+
+    aiex.cert.uc_dma_chain @c1 {
+      aiex.cert.uc_dma_bd @c1data, 0, 900, false
+    }
+    aiex.cert.uc_dma_chain @c2 {
+      aiex.cert.uc_dma_bd @c2data, 0, 1100, false
+    }
+
+    // Oversized single job. The cost-based cut lands before wait_tcts, so both
+    // enqueues stay on the earlier page and the wait moves to the later page;
+    // the two chains do not merge (combined size >= page size).
+    aiex.cert.page {
+      aiex.cert.job(1) {
+        aiex.cert.uc_dma_write_des_sync(@c1)
+        aiex.cert.uc_dma_write_des_sync(@c2)
+        aiex.cert.wait_tcts(0, 6, 1)
+      }
+    }
+  }
+}

--- a/test/Conversion/NpuToCert/page_split_order.mlir
+++ b/test/Conversion/NpuToCert/page_split_order.mlir
@@ -6,20 +6,29 @@
 //===----------------------------------------------------------------------===//
 
 // the page splitter preserves IR (textual) order within and across the
-// two result pages. An oversized job with two uc_dma_write_des_sync enqueues
-// followed by a wait_tcts splits so the enqueues stay on the earlier page and
-// the wait_tcts lands on the later page (a legal backward dependency), with the
-// internal order of each page preserved.
+// result pages. An oversized job with two uc_dma_write_des_sync enqueues
+// followed by a wait_tcts splits so each enqueue and the wait land on pages in
+// their original order; splitting an enqueue from a later wait_tcts is a legal
+// backward dependency.
+//
+// The first cut lands before wait_tcts, leaving @c1 + @c2 (an estimated 8084
+// bytes) on the earlier page. That is still over the split trigger, so it is
+// cut again between the two enqueues -- the second cut relies on the splitter
+// being able to cut *before* the op that crosses the target when that op is its
+// job's last (see page_split_last_op.mlir).
 
 // RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
 
 // CHECK: aiex.cert.page
 // CHECK: aiex.cert.job(1)
 // CHECK: aiex.cert.uc_dma_write_des_sync(@c1)
-// CHECK: aiex.cert.uc_dma_write_des_sync(@c2)
 // CHECK-NOT: aiex.cert.wait_tcts
 // CHECK: aiex.cert.page
 // CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.uc_dma_write_des_sync(@c2)
+// CHECK-NOT: aiex.cert.wait_tcts
+// CHECK: aiex.cert.page
+// CHECK: aiex.cert.job(3)
 // CHECK: aiex.cert.wait_tcts(0, 6, 1)
 
 module {
@@ -34,9 +43,8 @@ module {
       aiex.cert.uc_dma_bd @c2data, 0, 1100, false
     }
 
-    // Oversized single job. The cost-based cut lands before wait_tcts, so both
-    // enqueues stay on the earlier page and the wait moves to the later page;
-    // the two chains do not merge (combined size >= page size).
+    // Oversized single job; the two chains do not merge (combined size >= page
+    // size).
     aiex.cert.page {
       aiex.cert.job(1) {
         aiex.cert.uc_dma_write_des_sync(@c1)

--- a/test/CppTests/target_model.cpp
+++ b/test/CppTests/target_model.cpp
@@ -143,7 +143,7 @@ void test() {
     if (AIE::getTargetModel(dev).rows() != 6) {
       throw std::runtime_error("Failed npu1_ncol rows");
     }
-    checkControllerTopology(dev, 0, 0);
+    checkControllerTopology(dev, 0, 1);
   }
 
   // AIEDevice::npu2
@@ -173,7 +173,7 @@ void test() {
   if (AIE::getTargetModel(AIE::AIEDevice::npu2).rows() != 6) {
     throw std::runtime_error("Failed npu2 rows");
   }
-  checkControllerTopology(AIE::AIEDevice::npu2, 0, 0);
+  checkControllerTopology(AIE::AIEDevice::npu2, 0, 1);
 
   // AIEDevice::npu2_1col, npu2_2col, npu2_3col, npu2_4col, npu2_5col,
   // npu2_6col, npu2_7col
@@ -211,7 +211,7 @@ void test() {
     if (AIE::getTargetModel(dev).rows() != 6) {
       throw std::runtime_error("Failed npu2_ncol rows");
     }
-    checkControllerTopology(dev, 0, 0);
+    checkControllerTopology(dev, 0, 1);
   }
 
   // AIEDevice::xcve3858 (AIE2PS)

--- a/test/Passes/materialize-to-cert/cross_device_inline_load_pdi.mlir
+++ b/test/Passes/materialize-to-cert/cross_device_inline_load_pdi.mlir
@@ -1,0 +1,154 @@
+//===- cross_device_inline_load_pdi.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-npu-to-cert --split-input-file %s | FileCheck %s
+
+// Test cross-device inlining of runtime sequences:
+// 1. Inlined load_pdi operations are preserved with original device_ref
+// 2. InsertLoadPdiForConfigurePattern adds load_pdi at start only if needed
+// 3. When callee starts with load_pdi, no duplicate is added
+// 4. Absorbed/callee devices are removed from output (only main device emitted)
+
+//===----------------------------------------------------------------------===//
+// TEST 1: Callee does NOT start with load_pdi - one should be added at start
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: module {
+module {
+  // The outer/caller device - anonymous (no symbol name)
+  // CHECK-NEXT: aie.device(npu2) {
+  aie.device(npu2) {
+    %tile00 = aie.tile(0, 0)
+
+    aie.runtime_sequence @caller_seq(%arg0: memref<16xi32>) {
+      // After inlining, we should have:
+      // 1. A load_pdi added by InsertLoadPdiForConfigurePattern (since the first inlined op is write32, not load_pdi)
+      // 2. All operations from the callee sequence inlined
+      // 3. The inlined load_pdi operations preserved with their original device_ref
+
+      aiex.configure @callee_device {
+        aiex.run @callee_seq(%arg0) : (memref<16xi32>)
+      }
+    }
+  }
+
+  // The callee device that contains the runtime sequence to be inlined
+  // This device will be absorbed and removed from the output
+  aie.device(npu2) @callee_device {
+    %tile10 = aie.tile(1, 0)
+
+    // This sequence has load_pdi operations embedded in it for reconfiguration
+    // between iterations. When inlined, these should be preserved.
+    aie.runtime_sequence @callee_seq(%arg0: memref<16xi32>) {
+      // First iteration
+      %wa0 = arith.constant 100 : i32
+      %wv0 = arith.constant 1 : i32
+      aiex.npu.write32(%wa0, %wv0) {column = 0 : i32, row = 0 : i32} : i32, i32
+
+      // Reconfigure for second iteration
+      aiex.npu.load_pdi {device_ref = @callee_device}
+      %wa1 = arith.constant 200 : i32
+      %wv1 = arith.constant 2 : i32
+      aiex.npu.write32(%wa1, %wv1) {column = 0 : i32, row = 0 : i32} : i32, i32
+
+      // Reconfigure for third iteration
+      aiex.npu.load_pdi {device_ref = @callee_device}
+      %wa2 = arith.constant 300 : i32
+      %wv2 = arith.constant 3 : i32
+      aiex.npu.write32(%wa2, %wv2) {column = 0 : i32, row = 0 : i32} : i32, i32
+    }
+  }
+}
+
+// After conversion to CERT (a bare cert.job, no enclosing page yet):
+// CHECK: aiex.cert.job(2) {
+// CHECK-NEXT: aiex.cert.load_pdi(1, @callee_device)
+// CHECK-NEXT: aiex.cert.write32(100, 1)
+// CHECK-NEXT: aiex.cert.load_pdi(1, @callee_device)
+// CHECK-NEXT: aiex.cert.write32(200, 2)
+// CHECK-NEXT: aiex.cert.load_pdi(1, @callee_device)
+// CHECK-NEXT: aiex.cert.write32(300, 3)
+// CHECK-NEXT: }
+// CHECK-NEXT: aiex.cert.section @callee_device {
+// CHECK-NEXT: aiex.cert.page {
+// CHECK-NEXT: aiex.cert.job(1) {
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// TEST 2: Callee STARTS with load_pdi - no duplicate should be added
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: module {
+module {
+  // CHECK-NEXT: aie.device(npu2) {
+  aie.device(npu2) {
+    %tile00 = aie.tile(0, 0)
+
+    aie.runtime_sequence @caller_seq2(%arg0: memref<16xi32>) {
+      // After inlining, the callee's load_pdi is at the start of the configure block.
+      // InsertLoadPdiForConfigurePattern should detect this and NOT add another one.
+      // We should see exactly 3 load_pdi operations (from the callee), not 4.
+
+      aiex.configure @callee_device2 {
+        aiex.run @callee_seq2(%arg0) : (memref<16xi32>)
+      }
+    }
+  }
+
+  // The callee device - its runtime sequence starts with load_pdi
+  // This device will be absorbed and removed from the output
+  aie.device(npu2) @callee_device2 {
+    %tile10 = aie.tile(1, 0)
+
+    // This sequence STARTS with a load_pdi operation.
+    // When inlined into a configure block, InsertLoadPdiForConfigurePattern
+    // should NOT add another load_pdi at the start.
+    aie.runtime_sequence @callee_seq2(%arg0: memref<16xi32>) {
+      // First load_pdi at the very start
+      aiex.npu.load_pdi {device_ref = @callee_device2}
+      %wa3 = arith.constant 100 : i32
+      %wv3 = arith.constant 1 : i32
+      aiex.npu.write32(%wa3, %wv3) {column = 0 : i32, row = 0 : i32} : i32, i32
+
+      // Second iteration
+      aiex.npu.load_pdi {device_ref = @callee_device2}
+      %wa4 = arith.constant 200 : i32
+      %wv4 = arith.constant 2 : i32
+      aiex.npu.write32(%wa4, %wv4) {column = 0 : i32, row = 0 : i32} : i32, i32
+
+      // Third iteration
+      aiex.npu.load_pdi {device_ref = @callee_device2}
+      %wa5 = arith.constant 300 : i32
+      %wv5 = arith.constant 3 : i32
+      aiex.npu.write32(%wa5, %wv5) {column = 0 : i32, row = 0 : i32} : i32, i32
+    }
+  }
+}
+
+// After conversion to CERT (a bare cert.job, no enclosing page yet):
+// CHECK: aiex.cert.job(2) {
+// CHECK-NEXT: aiex.cert.load_pdi(1, @callee_device2)
+// CHECK-NEXT: aiex.cert.write32(100, 1)
+// CHECK-NEXT: aiex.cert.load_pdi(1, @callee_device2)
+// CHECK-NEXT: aiex.cert.write32(200, 2)
+// CHECK-NEXT: aiex.cert.load_pdi(1, @callee_device2)
+// CHECK-NEXT: aiex.cert.write32(300, 3)
+// CHECK-NEXT: }
+// CHECK-NEXT: aiex.cert.section @callee_device2 {
+// CHECK-NEXT: aiex.cert.page {
+// CHECK-NEXT: aiex.cert.job(1) {
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }

--- a/test/Passes/materialize-to-cert/inline_and_load_pdi.mlir
+++ b/test/Passes/materialize-to-cert/inline_and_load_pdi.mlir
@@ -1,0 +1,46 @@
+//===- inline_and_load_pdi.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-npu-to-cert %s | FileCheck %s
+
+// Test that configure/run are converted to CERT with load_pdi and proper sections
+
+module {
+  // CHECK: aie.device(npu2) {
+  // CHECK-NOT: aie.device(npu2) @config_a
+  aie.device(npu2) @main {
+    %tile00 = aie.tile(0, 0)
+
+    // The main sequence is lowered to a bare cert.job (no enclosing page yet).
+    // CHECK: aiex.cert.job({{[0-9]+}}) {
+    // CHECK: aiex.cert.load_pdi(1, @config_a)
+    // CHECK: aiex.cert.write32(33554532, 42)
+    // CHECK: aiex.cert.write32(200, 99)
+    aie.runtime_sequence @main_seq(%arg0: memref<16xi32>) {
+      // CHECK: aiex.cert.section @config_a {
+      // CHECK: aiex.cert.page {
+      // CHECK: aiex.cert.job({{[0-9]+}}) {
+      // CHECK-NEXT: }
+      aiex.configure @config_a {
+        aiex.run @seq_a(%arg0) : (memref<16xi32>)
+      }
+      %wa0 = arith.constant 200 : i32
+      %wv0 = arith.constant 99 : i32
+      aiex.npu.write32(%wa0, %wv0) {column = 0 : i32, row = 0 : i32} : i32, i32
+    }
+  }
+
+  aie.device(npu2) @config_a {
+    %tile10 = aie.tile(1, 0)
+
+    aie.runtime_sequence @seq_a(%arg0: memref<16xi32>) {
+      %wa1 = arith.constant 100 : i32
+      %wv1 = arith.constant 42 : i32
+      aiex.npu.write32(%wa1, %wv1) {column = 1 : i32, row = 0 : i32} : i32, i32
+    }
+  }
+}

--- a/test/Passes/materialize-to-cert/inline_locks.mlir
+++ b/test/Passes/materialize-to-cert/inline_locks.mlir
@@ -1,0 +1,108 @@
+//===- inline_locks.mlir ----------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-lower-set-lock --aie-npu-to-cert --split-input-file %s | FileCheck %s
+
+// Test that lock SSA values are correctly inlined into the calling runtime
+// sequence, and that multiple locks referencing the same tile are properly
+// handled. This specifically tests the fix where argMap must be updated after
+// cloning lock operations to ensure that subsequent uses of the lock reference
+// the cloned lock rather than the original.
+
+module {
+  aie.device(npu2) {
+    // The following SSA values should be inlined from the aiex.run call.
+    // We should see one tile and multiple locks, each lock correctly
+    // referencing the inlined tile.
+
+    // CHECK: %[[TILE:.*]] = aie.tile(0, 2)
+    // Locks are cloned in reverse order due to processing, but that's okay
+    // CHECK-DAG: %[[LOCK2:.*]] = aie.lock(%[[TILE]], 2) {init = 0 : i32, sym_name = "lock_2"}
+    // CHECK-DAG: %[[LOCK1:.*]] = aie.lock(%[[TILE]], 1) {init = 1 : i32, sym_name = "lock_1"}
+    // CHECK-DAG: %[[LOCK0:.*]] = aie.lock(%[[TILE]], 0) {init = 0 : i32, sym_name = "lock_0"}
+
+    // The main sequence is lowered to a bare cert.job (no enclosing page yet).
+    // CHECK: aiex.cert.job
+    aie.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+      // CHECK: aiex.cert.load_pdi(1, @callee_device)
+      // The set_lock operations should be lowered to cert.write32 operations
+      // CHECK-NEXT: aiex.cert.write32
+      // CHECK-NEXT: aiex.cert.write32
+      // CHECK-NEXT: aiex.cert.write32
+      // CHECK-NEXT: aiex.cert.write32
+      aiex.configure @callee_device {
+        aiex.run @sequence(%arg0, %arg1) : (memref<64xi32>, memref<64xi32>)
+      }
+    }
+    // CHECK: aiex.cert.section @callee_device
+    // CHECK: aiex.cert.page
+    // CHECK: aiex.cert.job
+  }
+
+  // The callee device should not be emitted (absorbed into main device)
+  // CHECK-NOT: aie.device(npu2) @callee_device
+  aie.device(npu2) @callee_device {
+    %tile_0_2 = aie.tile(0, 2)
+
+    %lock_0 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "lock_0"}
+    %lock_1 = aie.lock(%tile_0_2, 1) {init = 1 : i32, sym_name = "lock_1"}
+    %lock_2 = aie.lock(%tile_0_2, 2) {init = 0 : i32, sym_name = "lock_2"}
+
+    aie.runtime_sequence (%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+      // Multiple set_lock operations with different locks and the same lock used multiple times
+      aiex.set_lock(%lock_0, 1)
+      aiex.set_lock(%lock_1, 0)
+      aiex.set_lock(%lock_2, 1)
+      // Use lock_0 again to verify the mapping is maintained
+      aiex.set_lock(%lock_0, 2)
+    }
+  }
+}
+
+// -----
+
+// Test with locks on multiple different tiles to ensure each lock correctly
+// references its respective tile after inlining.
+
+module {
+  aie.device(npu2) {
+    // CHECK: %[[TILE02:.*]] = aie.tile(0, 2)
+    // CHECK: %[[TILE12:.*]] = aie.tile(1, 2)
+    // CHECK-DAG: %[[LOCK12:.*]] = aie.lock(%[[TILE12]], 0)
+    // CHECK-DAG: %[[LOCK02:.*]] = aie.lock(%[[TILE02]], 0)
+
+    // The main sequence is lowered to a bare cert.job (no enclosing page yet).
+    // CHECK: aiex.cert.job
+    aie.runtime_sequence(%arg0: memref<64xi32>) {
+      // CHECK: aiex.cert.load_pdi(1, @multi_tile_device)
+      // The set_lock operations should be lowered to cert.write32 operations
+      // CHECK-NEXT: aiex.cert.write32
+      // CHECK-NEXT: aiex.cert.write32
+      aiex.configure @multi_tile_device {
+        aiex.run @sequence(%arg0) : (memref<64xi32>)
+      }
+    }
+    // CHECK: aiex.cert.section @multi_tile_device
+    // CHECK: aiex.cert.page
+    // CHECK: aiex.cert.job
+  }
+
+  // The callee device should not be emitted (absorbed into main device)
+  // CHECK-NOT: aie.device(npu2) @multi_tile_device
+  aie.device(npu2) @multi_tile_device {
+    %tile_0_2 = aie.tile(0, 2)
+    %tile_1_2 = aie.tile(1, 2)
+
+    %lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32}
+    %lock_1_2 = aie.lock(%tile_1_2, 0) {init = 0 : i32}
+
+    aie.runtime_sequence (%arg0: memref<64xi32>) {
+      aiex.set_lock(%lock_0_2, 1)
+      aiex.set_lock(%lock_1_2, 1)
+    }
+  }
+}

--- a/test/Passes/materialize-to-cert/inline_multiple_ssa.mlir
+++ b/test/Passes/materialize-to-cert/inline_multiple_ssa.mlir
@@ -1,0 +1,89 @@
+//===- inline_multiple_ssa.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-assign-lock-ids --aie-lower-set-lock --aie-npu-to-cert %s | FileCheck %s
+
+// Test a scenario where we call multiple runtime sequences that require hoisting multiple SSA values and symbol definitions into the calling device.
+// -> Symbol name collisions need to be resolved.
+// -> If two SSA values across devices are equivalent (e.g. refer to the same tile), only one definition should be hoisted.
+
+module {
+  aie.device(npu2) {
+    // The following SSA values should have been inlined from the aiex.run call, since the referenced runtime sequence references them.
+
+    // -> Both @other_device and @third_device reference tile 0, 2, but we should only hoist one definition and share it across calls.
+    // CHECK: %tile_0_2 = aie.tile(0, 2)
+    // CHECK-NOT: aie.tile(0, 2)
+
+    // -> For other operand types like locks, we don't do equivalence testing for now. Instead, each inlined device will generate its own copy.
+    //    This is easiest to avoid conflicts (e.g., if locks used between different devices had different initial values).
+    //    If we ever run into limitations (e.g., run out of lock IDs due to this), we can revisit this and optimize if needed.
+    // -> Buffers referenced in both devices have conflicting names -- check that the pass renamed the second buffer with a _0 prefix to disambiguate them.
+    // -> Lock IDs 0 and 1 are assigned to the two locks
+    // CHECK: %lock_0_2 = aie.lock(%tile_0_2, 0)
+    // CHECK: aie.buffer
+    // CHECK-SAME: sym_name = "[[BUF1_NAME:rtp_0_0[_0]*]]"
+    // CHECK: %lock_0_2_0 = aie.lock(%tile_0_2, 1)
+    // CHECK: aie.buffer
+    // CHECK-SAME: sym_name = "[[BUF2_NAME:rtp_0_0[_0]*]]"
+
+    // The main sequence is lowered to a bare cert.job (no enclosing page yet).
+    // CHECK: aiex.cert.job(
+    aie.runtime_sequence(%arg0: memref<64xi32>) {
+      // CHECK: aiex.cert.load_pdi({{[0-9]+}}, @other_device)
+      // CHECK-NEXT: aiex.npu.rtp_write(@{{rtp_0_0[_0]*}}
+      // CHECK-NEXT: aiex.cert.write32(
+      aiex.configure @other_device {
+        aiex.run @sequence(%arg0) : (memref<64xi32>)
+      }
+      // CHECK: aiex.cert.load_pdi({{[0-9]+}}, @third_device)
+      // CHECK-NEXT: aiex.npu.rtp_write(@{{rtp_0_0[_0]*}}
+      // CHECK-NEXT: aiex.cert.write32(
+      aiex.configure @third_device {
+        aiex.run @sequence(%arg0) : (memref<64xi32>)
+      }
+    }
+    // CHECK: }
+  }
+
+  // CHECK: aiex.cert.section @other_device {
+  // CHECK-NEXT: aiex.cert.page {
+  // CHECK-NEXT: aiex.cert.job(
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  aie.device(npu2) @other_device {
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp_0_0 = aie.buffer(%tile_0_2) {sym_name = "rtp_0_0", address = 0xDEADBEEF : i32} : memref<1xi32>
+    %lock_0_2 = aie.lock(%tile_0_2) {initial_value = 1 : i32}
+
+    aie.runtime_sequence (%arg0: memref<64xi32>) {
+      %rtpv0 = arith.constant -1168197103 : i32
+      aiex.npu.rtp_write(@rtp_0_0, 0, %rtpv0) : i32
+      aiex.set_lock(%lock_0_2, 1)
+    }
+  }
+
+  // CHECK: aiex.cert.section @third_device {
+  // CHECK-NEXT: aiex.cert.page {
+  // CHECK-NEXT: aiex.cert.job(
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NOT: aie.device
+  aie.device(npu2) @third_device {
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp_0_0 = aie.buffer(%tile_0_2) {sym_name = "rtp_0_0", address = 0xCAFEBABE : i32} : memref<1xi32>
+    %lock_0_2 = aie.lock(%tile_0_2)
+
+    aie.runtime_sequence (%arg0: memref<64xi32>) {
+      %rtpv1 = arith.constant -1168197103 : i32
+      aiex.npu.rtp_write(@rtp_0_0, 0, %rtpv1) : i32
+      aiex.set_lock(%lock_0_2, 1)
+    }
+  }
+}

--- a/test/Passes/materialize-to-cert/inline_ssa.mlir
+++ b/test/Passes/materialize-to-cert/inline_ssa.mlir
@@ -1,0 +1,51 @@
+//===- inline_ssa.mlir -----------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-assign-lock-ids --aie-lower-set-lock --aie-npu-to-cert %s | FileCheck %s
+
+// Test that SSA values like locks and tiles are inlined into the calling
+// calling runtime sequence.
+
+module {
+  aie.device(npu2) {
+    // The following SSA values should have been inlined from the aiex.run call, since the referenced runtime sequence references them.
+    // CHECK: %[[TILE:.*]] = aie.tile(0, 2)
+    // CHECK: %[[LOCK:.*]] = aie.lock(%[[TILE]], 0)
+    // CHECK: %[[BUFFER:.*]] = aie.buffer(%[[TILE]])
+
+    // The main sequence is lowered to a bare cert.job (no enclosing page yet).
+    aie.runtime_sequence(%arg0: memref<64xi32>) {
+      // CHECK: aiex.cert.job
+      // CHECK: aiex.cert.load_pdi(1, @other_device)
+      // CHECK: aiex.npu.rtp_write(@rtp_0_0, 0, %{{.*}}) : i32
+      // CHECK: aiex.cert.write32(2224128, 1)
+      aiex.configure @other_device {
+        aiex.run @sequence(%arg0) : (memref<64xi32>)
+      }
+    }
+  }
+
+  // The other_device is absorbed into a cert.section, not a separate device
+  // CHECK: aiex.cert.section @other_device
+  aie.device(npu2) @other_device {
+    // The following are the original SSA value definitions -- ensure they are still in the device.
+    // CHECK-NOT: aie.tile(0, 2)
+    // CHECK-NOT: aie.buffer
+    // CHECK-NOT: aie.lock
+    %tile_0_2 = aie.tile(0, 2)
+
+    %rtp_0_0 = aie.buffer(%tile_0_2) {sym_name = "rtp_0_0", address = 0xDEADBEEF : i32} : memref<1xi32>
+    %lock_0_2 = aie.lock(%tile_0_2)
+
+    aie.runtime_sequence (%arg0: memref<64xi32>) {
+      // These are the operations that reference other SSA values in the device, which will require hoisting those SSA values into the calling device.
+      %rtpv0 = arith.constant -1168197103 : i32
+      aiex.npu.rtp_write(@rtp_0_0, 0, %rtpv0) : i32
+      aiex.set_lock(%lock_0_2, 1)
+    }
+  }
+}

--- a/test/Passes/materialize-to-cert/inline_ssa.mlir
+++ b/test/Passes/materialize-to-cert/inline_ssa.mlir
@@ -8,7 +8,7 @@
 // RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-assign-lock-ids --aie-lower-set-lock --aie-npu-to-cert %s | FileCheck %s
 
 // Test that SSA values like locks and tiles are inlined into the calling
-// calling runtime sequence.
+// runtime sequence.
 
 module {
   aie.device(npu2) {

--- a/test/Passes/materialize-to-cert/inline_symbols.mlir
+++ b/test/Passes/materialize-to-cert/inline_symbols.mlir
@@ -1,0 +1,66 @@
+//===- inline_symbols.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences --convert-aie-to-transaction --aie-npu-to-cert %s | FileCheck %s
+
+// Test that symbol definitions (like shim_dma_allocation) are properly preserved
+// when inlining runtime sequences from other devices
+
+// NOTE: aiex.npu.dma_memcpy_nd is NOT yet converted to CERT format.
+// It remains as aiex.npu.dma_memcpy_nd in the output.
+
+module {
+  aie.device(npu2) @main {
+    %tile00 = aie.tile(0, 0)
+
+    aie.runtime_sequence @main_seq(%arg0: memref<64xi32>) {
+      aiex.configure @config_with_symbols {
+        aiex.run @seq_with_dma(%arg0) : (memref<64xi32>)
+      }
+    }
+  }
+
+  // The referenced device is absorbed into the main device as a cert.section
+  // and the original @config_with_symbols device is removed from output
+  aie.device(npu2) @config_with_symbols {
+    %tile20 = aie.tile(2, 0)
+    aie.shim_dma_allocation @buffer_in(%tile20, S2MM, 0)
+
+    aie.runtime_sequence @seq_with_dma(%arg0: memref<64xi32>) {
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) { metadata = @buffer_in, id = 0 : i64 } : memref<64xi32>
+    }
+  }
+}
+
+// CHECK: aie.device(npu2) {
+// CHECK-NOT: aie.device(npu2) @config_with_symbols
+
+// CHECK: aie.tile(2, 0)
+// CHECK: aie.shim_dma_allocation @buffer_in
+
+// Main control flow: a bare cert.job (a page is only formed later by
+// cert-legalize-pages).
+// CHECK: aiex.cert.job({{[0-9]+}}) {
+// CHECK-NEXT: ^bb0(%[[ARG0:.*]]: memref<64xi32>):
+
+// The configure op is converted to cert.load_pdi
+// CHECK-NEXT: aiex.cert.load_pdi(1, @config_with_symbols)
+
+// The inlined dma_memcpy_nd operation - NOT YET CONVERTED TO CERT
+// TODO: This should eventually be converted to CERT DMA operations
+// CHECK-NEXT: aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1])
+// CHECK-SAME: {id = 0 : i64, metadata = @buffer_in}
+
+// CHECK: }
+
+// The referenced device's configure sequence becomes a cert.section
+// CHECK: aiex.cert.section @config_with_symbols {
+// CHECK-NEXT: aiex.cert.page {
+// CHECK-NEXT: aiex.cert.job({{[0-9]+}}) {
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: }

--- a/test/Targets/AIETargetUcCert/cert_groups.mlir
+++ b/test/Targets/AIETargetUcCert/cert_groups.mlir
@@ -13,7 +13,7 @@
 // CHECK: START_JOB 1
 // CHECK: EOF
 
-aie.device(npu2) {
+aie.device(xcve3858) {
 
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {

--- a/test/Targets/AIETargetUcCert/implicit_page_release_then_wait.mlir
+++ b/test/Targets/AIETargetUcCert/implicit_page_release_then_wait.mlir
@@ -1,0 +1,52 @@
+//===- implicit_page_release_then_wait.mlir ---------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A non-blocking "release" job placed textually before a runtime-sequence job
+// containing wait_tcts ends up in the SAME implicit page, release first.
+// Because they share a page (one .eop), the WAIT_TCTS has no forward-page
+// dependency on the release — the release runs to completion (non-blocking)
+// before WAIT_TCTS blocks. This is the safe form of the release-then-wait
+// pattern a multi-uC design needs.
+
+// RUN: aie-opt --aie-npu-to-cert --cert-legalize-pages %s | FileCheck %s
+// RUN: aie-opt --aie-npu-to-cert --cert-legalize-pages %s | aie-translate --aie-cert-to-asm | FileCheck %s --check-prefix=ASM
+
+// Both jobs are in one page: no new cert.page opens between them.
+// CHECK: aiex.cert.page {
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.write32(8052816, 1)
+// CHECK-NOT: aiex.cert.page
+// CHECK: aiex.cert.job(3)
+// CHECK: aiex.cert.wait_tcts(0, 0, 1)
+
+// In the emitted asm, the release WRITE_32 precedes WAIT_TCTS with no .eop
+// (page break) between them; a single .eop follows both.
+// ASM: WRITE_32{{.*}}0x007ae050
+// ASM-NOT: .eop
+// ASM: WAIT_TCTS
+// ASM: .eop
+
+module {
+  aie.device(npu2) @main {
+    // Non-blocking release (writes a lock register), textually first.
+    aie.runtime_sequence @release() {
+      %ra = arith.constant 0x7AE050 : i32
+      %rv = arith.constant 1 : i32
+      aiex.npu.write32(%ra, %rv) : i32, i32
+    }
+    // Runtime sequence that waits for task-completion tokens.
+    aie.runtime_sequence @seq() {
+      %col = arith.constant 0 : i32
+      %row = arith.constant 0 : i32
+      %dir = arith.constant 0 : i32
+      %chan = arith.constant 0 : i32
+      %colnum = arith.constant 1 : i32
+      %rownum = arith.constant 1 : i32
+      aiex.npu.sync(%col, %row, %dir, %chan, %colnum, %rownum) : i32, i32, i32, i32, i32, i32
+    }
+  }
+}

--- a/test/Targets/AIETargetUcCert/job_textual_order.mlir
+++ b/test/Targets/AIETargetUcCert/job_textual_order.mlir
@@ -1,0 +1,29 @@
+//===- job_textual_order.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-cert-to-asm %s | FileCheck %s
+
+// Jobs must be emitted in textual (IR) order, not sorted by job_id. Here the
+// job with the *larger* id appears first in the IR, so it must be emitted
+// first. (Under the old job_id-sorting emitter this would fail: START_JOB 2
+// would be emitted before START_JOB 5.)
+
+// CHECK: START_JOB 5
+// CHECK:   WRITE_32               0x00001000, 0x0000002a
+// CHECK: START_JOB 2
+// CHECK:   WRITE_32               0x00002000, 0x0000002b
+
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(5) {
+      aiex.cert.write32(0x1000, 42)
+    }
+    aiex.cert.job(2) {
+      aiex.cert.write32(0x2000, 43)
+    }
+  }
+}

--- a/test/Targets/AIETargetUcCert/multi_uc_capstone.mlir
+++ b/test/Targets/AIETargetUcCert/multi_uc_capstone.mlir
@@ -12,7 +12,7 @@
 //  - uC0 releases its core, rendezvous with col1 via a remote barrier, then
 //    waits for TCTs -- all in one page (release before WAIT_TCTS, no forward
 //    dependency);
-//  - col1's controller (uC2, via placement=2) rendezvous on the same remote
+//  - col1's controller (uC1, via placement=1) rendezvous on the same remote
 //    barrier and releases its core;
 //  - the two uCs form independent ordered streams;
 //  - aie-cert-verify accepts it (matching rendezvous, valid ids).
@@ -20,10 +20,10 @@
 // The design verifies cleanly (no diagnostics => aie-opt exits 0).
 // RUN: aie-opt -cert-legalize-pages -aie-cert-verify %s | FileCheck %s
 
-// Config page is first on uC0; col1 work is grouped under uC 2.
+// Config page is first on uC0; col1 work is grouped under uC 1.
 // CHECK: aiex.cert.job(1)
 // CHECK: aiex.cert.write32(393216, 1)
-// CHECK: aiex.cert.attach_to_group(2)
+// CHECK: aiex.cert.attach_to_group(1)
 
 // RUN: aie-opt -cert-legalize-pages %s | aie-translate --aie-cert-to-asm | FileCheck %s --check-prefix=ASM
 
@@ -36,12 +36,12 @@
 // ASM-NOT: .eop
 // ASM: REMOTE_BARRIER
 // ASM: WAIT_TCTS
-// uC2 stream: rendezvous then release col1's core.
-// ASM: .attach_to_group 2
+// uC1 stream: rendezvous then release col1's core.
+// ASM: .attach_to_group 1
 // ASM: REMOTE_BARRIER
 // ASM: WRITE_32{{.*}}0x026ae050
 
-aie.device(npu2) {
+aie.device(xcve3858) {
   // Configuration job (forced first on uC0).
   aiex.cert.job(1) {
     aiex.cert.write32(0x60000, 1)
@@ -51,16 +51,16 @@ aie.device(npu2) {
   aiex.cert.page {
     aiex.cert.job(2) {
       aiex.cert.write32(0x7AE050, 1)
-      aiex.cert.remote_barrier(1, 0x5)
+      aiex.cert.remote_barrier(1, 0x3)
       aiex.cert.wait_tcts(0, 0, 1)
     }
   }
 
-  // uC2 (col1 controller): rendezvous, then release col1 core.
+  // uC1 (col1 controller): rendezvous, then release col1 core.
   aiex.cert.page {
     aiex.cert.job(3) {
-      aiex.cert.remote_barrier(1, 0x5)
+      aiex.cert.remote_barrier(1, 0x3)
       aiex.cert.write32(0x26AE050, 1)
     }
-  } {placement = 2 : i32}
+  } {placement = 1 : i32}
 }

--- a/test/Targets/AIETargetUcCert/multi_uc_capstone.mlir
+++ b/test/Targets/AIETargetUcCert/multi_uc_capstone.mlir
@@ -1,0 +1,66 @@
+//===- multi_uc_capstone.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// End-to-end capstone for the CERT ordering/placement model on a target with
+// more than one microcontroller, covering the shape a real multi-uC design
+// takes:
+//  - @configure is the first page on uC0;
+//  - uC0 releases its core, rendezvous with col1 via a remote barrier, then
+//    waits for TCTs -- all in one page (release before WAIT_TCTS, no forward
+//    dependency);
+//  - col1's controller (uC2, via placement=2) rendezvous on the same remote
+//    barrier and releases its core;
+//  - the two uCs form independent ordered streams;
+//  - aie-cert-verify accepts it (matching rendezvous, valid ids).
+
+// The design verifies cleanly (no diagnostics => aie-opt exits 0).
+// RUN: aie-opt -cert-legalize-pages -aie-cert-verify %s | FileCheck %s
+
+// Config page is first on uC0; col1 work is grouped under uC 2.
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.write32(393216, 1)
+// CHECK: aiex.cert.attach_to_group(2)
+
+// RUN: aie-opt -cert-legalize-pages %s | aie-translate --aie-cert-to-asm | FileCheck %s --check-prefix=ASM
+
+// uC0 stream: config first, then release-before-WAIT_TCTS in one page.
+// ASM: .attach_to_group 0
+// ASM: START_JOB 1
+// ASM: WRITE_32{{.*}}0x00060000
+// ASM: START_JOB 2
+// ASM: WRITE_32{{.*}}0x007ae050
+// ASM-NOT: .eop
+// ASM: REMOTE_BARRIER
+// ASM: WAIT_TCTS
+// uC2 stream: rendezvous then release col1's core.
+// ASM: .attach_to_group 2
+// ASM: REMOTE_BARRIER
+// ASM: WRITE_32{{.*}}0x026ae050
+
+aie.device(npu2) {
+  // Configuration job (forced first on uC0).
+  aiex.cert.job(1) {
+    aiex.cert.write32(0x60000, 1)
+  } {cert.configure}
+
+  // uC0: release col0 core, rendezvous with col1, wait for TCTs (one page).
+  aiex.cert.page {
+    aiex.cert.job(2) {
+      aiex.cert.write32(0x7AE050, 1)
+      aiex.cert.remote_barrier(1, 0x5)
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+
+  // uC2 (col1 controller): rendezvous, then release col1 core.
+  aiex.cert.page {
+    aiex.cert.job(3) {
+      aiex.cert.remote_barrier(1, 0x5)
+      aiex.cert.write32(0x26AE050, 1)
+    }
+  } {placement = 2 : i32}
+}

--- a/test/Targets/AIETargetUcCert/page_legalize.mlir
+++ b/test/Targets/AIETargetUcCert/page_legalize.mlir
@@ -6,9 +6,18 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
-// CHECK: aiex.cert.job(1)
-// CHECK: aiex.cert.job(2)
-// CHECK: aiex.cert.job(3)
+// The two contiguous top-level bare jobs are first grouped into one implicit
+// page, then re-split by size. Size-based splitting yields three pages: the
+// first two hold split fragments (job(1), job(2)), and the last page holds the
+// remaining fragment of the first job (job(3)) together with the second job
+// (job(4)).
+// CHECK: aiex.cert.page
+// CHECK-NEXT: aiex.cert.job(1)
+// CHECK: aiex.cert.page
+// CHECK-NEXT: aiex.cert.job(2)
+// CHECK: aiex.cert.page
+// CHECK-NEXT: aiex.cert.job(3)
+// CHECK-NOT: aiex.cert.page
 // CHECK: aiex.cert.job(4)
 
 module {

--- a/test/Targets/AIETargetUcCert/uc0_textual_order.mlir
+++ b/test/Targets/AIETargetUcCert/uc0_textual_order.mlir
@@ -1,0 +1,37 @@
+//===- uc0_textual_order.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The emitter must preserve textual (encounter) order within a uC stream across
+// device-level content and attach_to_group content. Here a release job authored
+// in attach_to_group(0) appears BEFORE a device-level runtime-sequence page
+// (containing WAIT_TCTS); it must emit first on uC 0. The previous two-phase
+// emitter emitted all device-level pages before any attach_to_group content,
+// putting WAIT_TCTS on an earlier page than the release -- a forward-page
+// dependency, which is what mis-ordered real multi-uC designs.
+
+// RUN: aie-translate --aie-cert-to-asm %s | FileCheck %s
+
+// CHECK: .attach_to_group 0
+// CHECK: START_JOB 0
+// CHECK: WRITE_32{{.*}}0x007ae050
+// CHECK: START_JOB 2
+// CHECK: WAIT_TCTS
+
+aie.device(npu2) {
+  // Release job, authored first, on uC 0.
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x7AE050, 1)
+    }
+  }
+  // Runtime-sequence page (waits for TCTs), authored second, also uC 0.
+  aiex.cert.page {
+    aiex.cert.job(2) {
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+}

--- a/test/Targets/AIETargetUcCert/uc_stream_group0_unified.mlir
+++ b/test/Targets/AIETargetUcCert/uc_stream_group0_unified.mlir
@@ -1,0 +1,35 @@
+//===- uc_stream_group0_unified.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// device-level (group 0) content and an explicit attach_to_group(0) are
+// emitted as a single uC-0 stream, in IR order, under one ".attach_to_group 0"
+// header with one EOF (no second group header).
+
+// RUN: aie-translate --aie-cert-to-asm %s | FileCheck %s
+
+// CHECK: .attach_to_group 0
+// CHECK: START_JOB 0
+// CHECK: START_JOB 1
+// CHECK-NOT: .attach_to_group
+// CHECK: EOF
+
+module {
+  aie.device(npu2) {
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.write32(0x1000, 1)
+      }
+    }
+    aiex.cert.attach_to_group(0) {
+      aiex.cert.page {
+        aiex.cert.job(1) {
+          aiex.cert.write32(0x1000, 2)
+        }
+      }
+    }
+  }
+}

--- a/test/Targets/AIETargetUcCert/uc_stream_separation.mlir
+++ b/test/Targets/AIETargetUcCert/uc_stream_separation.mlir
@@ -20,7 +20,7 @@
 // CHECK: EOF
 
 module {
-  aie.device(npu2) {
+  aie.device(xcve3858) {
     // device-level page => uC 0
     aiex.cert.page {
       aiex.cert.job(0) {

--- a/test/Targets/AIETargetUcCert/uc_stream_separation.mlir
+++ b/test/Targets/AIETargetUcCert/uc_stream_separation.mlir
@@ -1,0 +1,39 @@
+//===- uc_stream_separation.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// a non-zero group must be emitted as its own uC stream (its own EOF),
+// even when there is device-level (group 0) content and no explicit
+// attach_to_group(0). Previously the emitter keyed blocks by loop counter, so a
+// lone non-zero group was lumped into the group-0 block and shared its EOF.
+
+// RUN: aie-translate --aie-cert-to-asm %s | FileCheck %s
+
+// CHECK: .attach_to_group 0
+// CHECK: START_JOB 0
+// CHECK: EOF
+// CHECK: .attach_to_group 2
+// CHECK: START_JOB 1
+// CHECK: EOF
+
+module {
+  aie.device(npu2) {
+    // device-level page => uC 0
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.write32(0x1000, 1)
+      }
+    }
+    // placed on uC 2 => its own stream
+    aiex.cert.attach_to_group(2) {
+      aiex.cert.page {
+        aiex.cert.job(1) {
+          aiex.cert.write32(0x2000, 2)
+        }
+      }
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_configure_first.mlir
+++ b/test/dialect/AIEX/cert_configure_first.mlir
@@ -1,0 +1,33 @@
+//===- cert_configure_first.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// the implicit @configure sequence must become the FIRST page on uC0,
+// even when it appears textually after a user runtime sequence.
+
+// RUN: aie-opt --aie-npu-to-cert --cert-legalize-pages %s | FileCheck %s
+
+// Config (job 1, writes 0x1000=4096) is emitted before the user job (job 2,
+// writes 0x2000=8192), despite @user_seq preceding @configure in the input.
+// CHECK: aiex.cert.job(1)
+// CHECK: aiex.cert.write32(4096, 1)
+// CHECK: aiex.cert.job(2)
+// CHECK: aiex.cert.write32(8192, 99)
+
+module {
+  aie.device(npu2) @main {
+    aie.runtime_sequence @user_seq() {
+      %ua = arith.constant 0x2000 : i32
+      %uv = arith.constant 99 : i32
+      aiex.npu.write32(%ua, %uv) : i32, i32
+    }
+    aie.runtime_sequence @configure() {
+      %ca = arith.constant 0x1000 : i32
+      %cv = arith.constant 1 : i32
+      aiex.npu.write32(%ca, %cv) : i32, i32
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_page_placement.mlir
+++ b/test/dialect/AIEX/cert_page_placement.mlir
@@ -10,7 +10,7 @@
 // RUN: aie-opt %s | aie-opt | FileCheck %s
 
 module {
-  aie.device(npu2) {
+  aie.device(xcve3858) {
     // A placed page carries its resolved group/uC id.
     // CHECK: aiex.cert.page {
     // CHECK:   aiex.cert.job(1)

--- a/test/dialect/AIEX/cert_page_placement.mlir
+++ b/test/dialect/AIEX/cert_page_placement.mlir
@@ -1,0 +1,34 @@
+//===- cert_page_placement.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Round-trip the optional `placement` attribute on cert.page.
+
+// RUN: aie-opt %s | aie-opt | FileCheck %s
+
+module {
+  aie.device(npu2) {
+    // A placed page carries its resolved group/uC id.
+    // CHECK: aiex.cert.page {
+    // CHECK:   aiex.cert.job(1)
+    // CHECK: } {placement = 2 : i32}
+    aiex.cert.page {
+      aiex.cert.job(1) {
+        aiex.cert.write32(0x2000, 43)
+      }
+    } {placement = 2 : i32}
+
+    // An unplaced page has no placement attribute (defaults to group 0).
+    // CHECK: aiex.cert.page {
+    // CHECK:   aiex.cert.job(0)
+    // CHECK-NOT: placement
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.write32(0x1000, 42)
+      }
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_page_placement_lowering.mlir
+++ b/test/dialect/AIEX/cert_page_placement_lowering.mlir
@@ -26,7 +26,7 @@
 // ASM: START_JOB 1
 
 module {
-  aie.device(npu2) {
+  aie.device(xcve3858) {
     aiex.cert.page {
       aiex.cert.job(0) {
         aiex.cert.write32(0x1000, 42)

--- a/test/dialect/AIEX/cert_page_placement_lowering.mlir
+++ b/test/dialect/AIEX/cert_page_placement_lowering.mlir
@@ -1,0 +1,41 @@
+//===- cert_page_placement_lowering.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// cert-legalize-pages lowers cert.page {placement = N} to an enclosing
+// cert.attach_to_group(N), dropping the redundant placement attr.
+
+// RUN: aie-opt --cert-legalize-pages %s | FileCheck %s
+// RUN: aie-opt --cert-legalize-pages %s | aie-translate --aie-cert-to-asm | FileCheck %s --check-prefix=ASM
+
+// The placed page moves under attach_to_group(2); an unplaced page stays at
+// device level (implicit group 0).
+// CHECK: aiex.cert.page {
+// CHECK:   aiex.cert.job(0)
+// CHECK: aiex.cert.attach_to_group(2)
+// CHECK:   aiex.cert.page
+// CHECK:     aiex.cert.job(1)
+// CHECK-NOT: placement
+
+// ASM: .attach_to_group 0
+// ASM: START_JOB 0
+// ASM: .attach_to_group 2
+// ASM: START_JOB 1
+
+module {
+  aie.device(npu2) {
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.write32(0x1000, 42)
+      }
+    }
+    aiex.cert.page {
+      aiex.cert.job(1) {
+        aiex.cert.write32(0x2000, 43)
+      }
+    } {placement = 2 : i32}
+  }
+}

--- a/test/dialect/AIEX/cert_placement_through_isolation.mlir
+++ b/test/dialect/AIEX/cert_placement_through_isolation.mlir
@@ -1,0 +1,44 @@
+//===- cert_placement_through_isolation.mlir -------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Regression for the placement-loss bug: a placed page (placement = 2) whose
+// job contains a preempt is split by full-page isolation into multiple pages.
+// Because placement is lowered to attach_to_group BEFORE isolation, every
+// resulting page stays on uC 2 (previously isolation created unplaced pages
+// that silently emitted on group 0).
+
+// RUN: aie-opt -cert-legalize-pages %s | FileCheck %s
+
+// CHECK: aiex.cert.attach_to_group(2)
+// CHECK: aiex.cert.write32(4096, 42)
+// CHECK: aiex.cert.preempt(0, @save, @restore)
+// CHECK-NOT: aiex.cert.attach_to_group
+
+module {
+  aie.device(npu2) {
+    aiex.cert.section @save {
+      aiex.cert.page {
+        aiex.cert.job(10) {
+          aiex.cert.write32(0x2100000, 0)
+        }
+      }
+    }
+    aiex.cert.section @restore {
+      aiex.cert.page {
+        aiex.cert.job(11) {
+          aiex.cert.write32(0x2100000, 1)
+        }
+      }
+    }
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.write32(0x1000, 42)
+        aiex.cert.preempt(0, @save, @restore)
+      }
+    } {placement = 2 : i32}
+  }
+}

--- a/test/dialect/AIEX/cert_placement_through_isolation.mlir
+++ b/test/dialect/AIEX/cert_placement_through_isolation.mlir
@@ -19,7 +19,7 @@
 // CHECK-NOT: aiex.cert.attach_to_group
 
 module {
-  aie.device(npu2) {
+  aie.device(xcve3858) {
     aiex.cert.section @save {
       aiex.cert.page {
         aiex.cert.job(10) {

--- a/test/dialect/AIEX/cert_verify_barlimits.mlir
+++ b/test/dialect/AIEX/cert_verify_barlimits.mlir
@@ -1,0 +1,67 @@
+//===- cert_verify_barlimits.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// G-barlimits: local_barrier_id in [0,15], remote_barrier_id in [1,8]; a uC may
+// use at most 16 distinct local and 8 distinct remote ids.
+
+// RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
+
+// Positive: local id 15 and remote id 8 are the in-range extremes -> OK.
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    aiex.cert.local_barrier(15, 2)
+    aiex.cert.remote_barrier(8, 0x1)
+  }
+}
+
+// -----
+
+// Negative: local_barrier_id 16 is out of range.
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    // expected-error@+1 {{cert.local_barrier local_barrier_id 16 out of range [0, 15]}}
+    aiex.cert.local_barrier(16, 2)
+  }
+}
+
+// -----
+
+// Negative: remote_barrier_id 9 is out of range.
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    // expected-error@+1 {{cert.remote_barrier remote_barrier_id 9 out of range [1, 8]}}
+    aiex.cert.remote_barrier(9, 0x1)
+  }
+}
+
+// -----
+
+// Negative: a single uC uses 17 distinct local ids (0..16). The out-of-range id
+// 16 also trips the range check; the budget check fires on the device.
+// expected-error@+1 {{uC 0 uses 17 distinct local_barrier ids (max 16)}}
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    aiex.cert.local_barrier(0, 2)
+    aiex.cert.local_barrier(1, 2)
+    aiex.cert.local_barrier(2, 2)
+    aiex.cert.local_barrier(3, 2)
+    aiex.cert.local_barrier(4, 2)
+    aiex.cert.local_barrier(5, 2)
+    aiex.cert.local_barrier(6, 2)
+    aiex.cert.local_barrier(7, 2)
+    aiex.cert.local_barrier(8, 2)
+    aiex.cert.local_barrier(9, 2)
+    aiex.cert.local_barrier(10, 2)
+    aiex.cert.local_barrier(11, 2)
+    aiex.cert.local_barrier(12, 2)
+    aiex.cert.local_barrier(13, 2)
+    aiex.cert.local_barrier(14, 2)
+    aiex.cert.local_barrier(15, 2)
+    // expected-error@+1 {{cert.local_barrier local_barrier_id 16 out of range [0, 15]}}
+    aiex.cert.local_barrier(16, 2)
+  }
+}

--- a/test/dialect/AIEX/cert_verify_groupid.mlir
+++ b/test/dialect/AIEX/cert_verify_groupid.mlir
@@ -6,13 +6,13 @@
 //===----------------------------------------------------------------------===//
 
 // Group/placement ids must be valid microcontroller indices for the device.
-// npu2 has 8 columns and 1 uC/column => 8 uCs (valid ids [0, 8)).
+// xcve3858 has 36 columns and 1 uC/column => 36 uCs (valid ids [0, 36)).
 
 // RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
 
 // Negative: group id 99 is out of range.
-aie.device(npu2) {
-  // expected-error@+1 {{cert.attach_to_group group id 99 is not a valid uC id [0, 8)}}
+aie.device(xcve3858) {
+  // expected-error@+1 {{cert.attach_to_group group id 99 is not a valid uC id [0, 36)}}
   aiex.cert.attach_to_group(99) {
     aiex.cert.job(0) {
       aiex.cert.write32(0x1000, 1)
@@ -23,8 +23,8 @@ aie.device(npu2) {
 // -----
 
 // Negative: an out-of-range placement attribute (pre-lowering IR).
-aie.device(npu2) {
-  // expected-error@+1 {{cert.page placement 42 is not a valid uC id [0, 8)}}
+aie.device(xcve3858) {
+  // expected-error@+1 {{cert.page placement 42 is not a valid uC id [0, 36)}}
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.write32(0x1000, 1)
@@ -34,9 +34,44 @@ aie.device(npu2) {
 
 // -----
 
-// Positive: group id 2 is a valid uC on npu2.
-aie.device(npu2) {
+// Positive: group id 2 is a valid uC on xcve3858.
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(2) {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x1000, 1)
+    }
+  }
+}
+
+// -----
+
+// Positive: AIE2 has one device-level uC, represented by group 0.
+aie.device(npu1) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x1000, 1)
+    }
+  }
+}
+
+// -----
+
+// Negative: AIE2P has only its device-level uC, so group 1 is invalid.
+aie.device(npu2) {
+  // expected-error@+1 {{cert.attach_to_group group id 1 is not a valid uC id [0, 1)}}
+  aiex.cert.attach_to_group(1) {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x1000, 1)
+    }
+  }
+}
+
+// -----
+
+// Negative: AIE1 has no microcontroller.
+aie.device(xcvc1902) {
+  // expected-error@+1 {{cert.attach_to_group group id 0 is not a valid uC id [0, 0)}}
+  aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       aiex.cert.write32(0x1000, 1)
     }

--- a/test/dialect/AIEX/cert_verify_groupid.mlir
+++ b/test/dialect/AIEX/cert_verify_groupid.mlir
@@ -1,0 +1,44 @@
+//===- cert_verify_groupid.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Group/placement ids must be valid microcontroller indices for the device.
+// npu2 has 8 columns and 1 uC/column => 8 uCs (valid ids [0, 8)).
+
+// RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
+
+// Negative: group id 99 is out of range.
+aie.device(npu2) {
+  // expected-error@+1 {{cert.attach_to_group group id 99 is not a valid uC id [0, 8)}}
+  aiex.cert.attach_to_group(99) {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x1000, 1)
+    }
+  }
+}
+
+// -----
+
+// Negative: an out-of-range placement attribute (pre-lowering IR).
+aie.device(npu2) {
+  // expected-error@+1 {{cert.page placement 42 is not a valid uC id [0, 8)}}
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x1000, 1)
+    }
+  } {placement = 42 : i32}
+}
+
+// -----
+
+// Positive: group id 2 is a valid uC on npu2.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.job(0) {
+      aiex.cert.write32(0x1000, 1)
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_verify_localbar.mlir
+++ b/test/dialect/AIEX/cert_verify_localbar.mlir
@@ -1,0 +1,75 @@
+//===- cert_verify_localbar.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// G-localbar: all cert.local_barrier ops sharing a local_barrier_id within a uC
+// must be on the same cert.page.
+
+// RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
+
+// Positive: both participants of local_barrier(0) are in the same page -> OK.
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.local_barrier(0, 2)
+    }
+    aiex.cert.job(1) {
+      aiex.cert.local_barrier(0, 2)
+    }
+  }
+}
+
+// -----
+
+// Positive: same id in different pages but different uCs -> OK (per-uC scope).
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.local_barrier(0, 1)
+      }
+    }
+  }
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.page {
+      aiex.cert.job(1) {
+        aiex.cert.local_barrier(0, 1)
+      }
+    }
+  }
+}
+
+// -----
+
+// Negative: local_barrier(0) split across two pages in the same uC -> error.
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.local_barrier(0, 2)
+    }
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      // expected-error@+1 {{cert.local_barrier with local_barrier_id 0 in uC 0 must be on the same page}}
+      aiex.cert.local_barrier(0, 2)
+    }
+  }
+}
+
+// -----
+
+// Negative: same id in two different standalone jobs (no page) is NOT
+// co-located -> error. Previously "no page" was treated as a shared page for
+// both, so this incorrectly passed.
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    aiex.cert.local_barrier(0, 2)
+  }
+  aiex.cert.job(1) {
+    // expected-error@+1 {{cert.local_barrier with local_barrier_id 0 in uC 0 must be on the same page as its other participants}}
+    aiex.cert.local_barrier(0, 2)
+  }
+}

--- a/test/dialect/AIEX/cert_verify_localbar.mlir
+++ b/test/dialect/AIEX/cert_verify_localbar.mlir
@@ -11,7 +11,7 @@
 // RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
 
 // Positive: both participants of local_barrier(0) are in the same page -> OK.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.local_barrier(0, 2)
@@ -25,7 +25,7 @@ aie.device(npu2) {
 // -----
 
 // Positive: same id in different pages but different uCs -> OK (per-uC scope).
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.page {
       aiex.cert.job(0) {
@@ -45,7 +45,7 @@ aie.device(npu2) {
 // -----
 
 // Negative: local_barrier(0) split across two pages in the same uC -> error.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.local_barrier(0, 2)
@@ -64,7 +64,7 @@ aie.device(npu2) {
 // Negative: same id in two different standalone jobs (no page) is NOT
 // co-located -> error. Previously "no page" was treated as a shared page for
 // both, so this incorrectly passed.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.job(0) {
     aiex.cert.local_barrier(0, 2)
   }

--- a/test/dialect/AIEX/cert_verify_preempt.mlir
+++ b/test/dialect/AIEX/cert_verify_preempt.mlir
@@ -10,7 +10,7 @@
 // RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
 
 // Positive: both uCs expose preempt id 0 -> OK.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       aiex.cert.preempt(0, @save0, @restore0)
@@ -26,7 +26,7 @@ aie.device(npu2) {
 // -----
 
 // Positive: device-level (uC 0) and group 2 both expose preempt id 0 -> OK.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.job(0) {
     aiex.cert.preempt(0, @save0, @restore0)
   }
@@ -40,7 +40,7 @@ aie.device(npu2) {
 // -----
 
 // Negative: uC 0 exposes preempt 0 but group 2 exposes none -> error on group 2.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.job(0) {
     aiex.cert.preempt(0, @save0, @restore0)
   }

--- a/test/dialect/AIEX/cert_verify_preempt.mlir
+++ b/test/dialect/AIEX/cert_verify_preempt.mlir
@@ -1,0 +1,53 @@
+//===- cert_verify_preempt.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// G-preempt: every uC must expose the same multiset of cert.preempt ids.
+
+// RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
+
+// Positive: both uCs expose preempt id 0 -> OK.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      aiex.cert.preempt(0, @save0, @restore0)
+    }
+  }
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.job(1) {
+      aiex.cert.preempt(0, @save0, @restore0)
+    }
+  }
+}
+
+// -----
+
+// Positive: device-level (uC 0) and group 2 both expose preempt id 0 -> OK.
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    aiex.cert.preempt(0, @save0, @restore0)
+  }
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.job(1) {
+      aiex.cert.preempt(0, @save0, @restore0)
+    }
+  }
+}
+
+// -----
+
+// Negative: uC 0 exposes preempt 0 but group 2 exposes none -> error on group 2.
+aie.device(npu2) {
+  aiex.cert.job(0) {
+    aiex.cert.preempt(0, @save0, @restore0)
+  }
+  // expected-error@+1 {{cert.preempt ids on uC 2 differ from uC 0}}
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.job(1) {
+      aiex.cert.write32(0x2000, 43)
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_verify_remotebar.mlir
+++ b/test/dialect/AIEX/cert_verify_remotebar.mlir
@@ -13,7 +13,7 @@
 
 // Positive: uCs 0 and 1 both have remote_barrier(1, 0x3); masks agree, own bits
 // set -> OK.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       aiex.cert.remote_barrier(1, 0x3)
@@ -29,7 +29,7 @@ aie.device(npu2) {
 // -----
 
 // Negative: mask 0x5 references uC 2, which has no group -> error.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       // expected-error@+1 {{party_mask references uC 2 which is not present in the design}}
@@ -47,7 +47,7 @@ aie.device(npu2) {
 
 // Negative (the key rendezvous check): uC 0 waits on remote_barrier(1, 0x3) but
 // uC 1 has no matching barrier -> uC 0 would wait forever.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       // expected-error@+1 {{party_mask includes uC 1 but that uC has no matching remote_barrier(1) to rendezvous with}}
@@ -64,7 +64,7 @@ aie.device(npu2) {
 // -----
 
 // Negative: both uCs participate, but uC 0's own bit is not set in the mask.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       // expected-error@+1 {{on uC 0 excludes its own uC from party_mask}}

--- a/test/dialect/AIEX/cert_verify_remotebar.mlir
+++ b/test/dialect/AIEX/cert_verify_remotebar.mlir
@@ -1,0 +1,79 @@
+//===- cert_verify_remotebar.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// G-uC / rendezvous: a cert.remote_barrier must actually rendezvous. Every uC
+// in the party_mask must be present AND have a matching remote_barrier with the
+// same id/mask; each participant sets its own bit.
+
+// RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
+
+// Positive: uCs 0 and 1 both have remote_barrier(1, 0x3); masks agree, own bits
+// set -> OK.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      aiex.cert.remote_barrier(1, 0x3)
+    }
+  }
+  aiex.cert.attach_to_group(1) {
+    aiex.cert.job(1) {
+      aiex.cert.remote_barrier(1, 0x3)
+    }
+  }
+}
+
+// -----
+
+// Negative: mask 0x5 references uC 2, which has no group -> error.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      // expected-error@+1 {{party_mask references uC 2 which is not present in the design}}
+      aiex.cert.remote_barrier(1, 0x5)
+    }
+  }
+  aiex.cert.attach_to_group(1) {
+    aiex.cert.job(1) {
+      aiex.cert.write32(0x2000, 43)
+    }
+  }
+}
+
+// -----
+
+// Negative (the key rendezvous check): uC 0 waits on remote_barrier(1, 0x3) but
+// uC 1 has no matching barrier -> uC 0 would wait forever.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      // expected-error@+1 {{party_mask includes uC 1 but that uC has no matching remote_barrier(1) to rendezvous with}}
+      aiex.cert.remote_barrier(1, 0x3)
+    }
+  }
+  aiex.cert.attach_to_group(1) {
+    aiex.cert.job(1) {
+      aiex.cert.write32(0x2000, 43)
+    }
+  }
+}
+
+// -----
+
+// Negative: both uCs participate, but uC 0's own bit is not set in the mask.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      // expected-error@+1 {{on uC 0 excludes its own uC from party_mask}}
+      aiex.cert.remote_barrier(1, 0x2)
+    }
+  }
+  aiex.cert.attach_to_group(1) {
+    aiex.cert.job(1) {
+      aiex.cert.remote_barrier(1, 0x2)
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_verify_tct.mlir
+++ b/test/dialect/AIEX/cert_verify_tct.mlir
@@ -1,0 +1,104 @@
+//===- cert_verify_tct.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// G-tct: within one page, at most one *job* may wait on a given (tile_id,
+// channel_id). The rule is about concurrency, so sequential waits -- two in the
+// same job, or two on different pages of a uC -- are legal.
+
+// RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
+
+// Positive: two wait_tcts on different (tile, channel) actors -> OK.
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.wait_tcts(0, 0, 1)
+      aiex.cert.wait_tcts(0, 1, 1)
+    }
+  }
+}
+
+// -----
+
+// Positive: two wait_tcts on the same actor in the SAME job -> OK. A job is one
+// thread of control, so they run in sequence and only one is outstanding. This
+// is what a runtime sequence with two npu.sync ops on one channel lowers to.
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.wait_tcts(0, 0, 1)
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+}
+
+// -----
+
+// Positive: same actor waited on from two different PAGES of one uC -> OK.
+// Pages execute strictly in order, so the first wait has retired before the
+// second page starts.
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+  aiex.cert.page {
+    aiex.cert.job(1) {
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+}
+
+// -----
+
+// Positive: same (tile, channel) but in different uCs -> OK (per-uC scope).
+aie.device(npu2) {
+  aiex.cert.attach_to_group(0) {
+    aiex.cert.job(0) {
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.job(1) {
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+  }
+}
+
+// -----
+
+// Negative: two jobs cooperatively scheduled on ONE page both wait on the same
+// (tile, channel) -> both waits can be outstanding at once -> error.
+aie.device(npu2) {
+  aiex.cert.page {
+    aiex.cert.job(0) {
+      aiex.cert.wait_tcts(0, 0, 1)
+    }
+    aiex.cert.job(1) {
+      // expected-error@+1 {{more than one job on this cert.page waits on tile 0 channel 0 in uC 0}}
+      aiex.cert.wait_tcts(0, 0, 2)
+    }
+  }
+}
+
+// -----
+
+// Negative: same, inside an attach_to_group -- the uC is reported from the
+// enclosing group.
+aie.device(npu2) {
+  aiex.cert.attach_to_group(2) {
+    aiex.cert.page {
+      aiex.cert.job(0) {
+        aiex.cert.wait_tcts(0, 0, 1)
+      }
+      aiex.cert.job(1) {
+        // expected-error@+1 {{more than one job on this cert.page waits on tile 0 channel 0 in uC 2}}
+        aiex.cert.wait_tcts(0, 0, 2)
+      }
+    }
+  }
+}

--- a/test/dialect/AIEX/cert_verify_tct.mlir
+++ b/test/dialect/AIEX/cert_verify_tct.mlir
@@ -12,7 +12,7 @@
 // RUN: aie-opt --aie-cert-verify --split-input-file --verify-diagnostics %s
 
 // Positive: two wait_tcts on different (tile, channel) actors -> OK.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.wait_tcts(0, 0, 1)
@@ -26,7 +26,7 @@ aie.device(npu2) {
 // Positive: two wait_tcts on the same actor in the SAME job -> OK. A job is one
 // thread of control, so they run in sequence and only one is outstanding. This
 // is what a runtime sequence with two npu.sync ops on one channel lowers to.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.wait_tcts(0, 0, 1)
@@ -40,7 +40,7 @@ aie.device(npu2) {
 // Positive: same actor waited on from two different PAGES of one uC -> OK.
 // Pages execute strictly in order, so the first wait has retired before the
 // second page starts.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.wait_tcts(0, 0, 1)
@@ -56,7 +56,7 @@ aie.device(npu2) {
 // -----
 
 // Positive: same (tile, channel) but in different uCs -> OK (per-uC scope).
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(0) {
     aiex.cert.job(0) {
       aiex.cert.wait_tcts(0, 0, 1)
@@ -73,7 +73,7 @@ aie.device(npu2) {
 
 // Negative: two jobs cooperatively scheduled on ONE page both wait on the same
 // (tile, channel) -> both waits can be outstanding at once -> error.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.page {
     aiex.cert.job(0) {
       aiex.cert.wait_tcts(0, 0, 1)
@@ -89,7 +89,7 @@ aie.device(npu2) {
 
 // Negative: same, inside an attach_to_group -- the uC is reported from the
 // enclosing group.
-aie.device(npu2) {
+aie.device(xcve3858) {
   aiex.cert.attach_to_group(2) {
     aiex.cert.page {
       aiex.cert.job(0) {

--- a/test/dialect/AIEX/npu_to_cert_configure.mlir
+++ b/test/dialect/AIEX/npu_to_cert_configure.mlir
@@ -1,0 +1,43 @@
+//===- npu_to_cert_configure.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-npu-to-cert %s | FileCheck %s
+
+// Test that aiex.configure operations are converted to cert.section + cert.load_pdi
+
+module {
+  // The @configure runtime sequence is lowered to a bare cert.job (no enclosing
+  // page yet) carrying the {cert.configure} unit attribute.
+  // CHECK: aie.device(npu2) {
+  // CHECK: aiex.cert.job({{[0-9]+}})
+  // CHECK: aiex.cert.load_pdi(1, @config_device)
+  // CHECK: aiex.cert.write32(6750208, 1)
+  // CHECK: aiex.cert.write32(6750212, 2)
+  // CHECK: {cert.configure}
+  // CHECK: aiex.cert.section @config_device
+  // CHECK: aiex.cert.page
+  // CHECK: aiex.cert.job({{[0-9]+}})
+  // CHECK-NOT: aie.device(npu2) @config_device
+  aie.device(npu2) @main {
+    aie.runtime_sequence @configure(%arg0: memref<16xi32>) {
+      aiex.configure @config_device {
+        aiex.run @setup(%arg0) : (memref<16xi32>)
+      }
+    }
+  }
+
+  aie.device(npu2) @config_device {
+    aie.runtime_sequence @setup(%buf: memref<16xi32>) {
+      %wa0 = arith.constant 6750208 : i32
+      %wv0 = arith.constant 1 : i32
+      aiex.npu.write32(%wa0, %wv0) : i32, i32
+      %wa1 = arith.constant 6750212 : i32
+      %wv1 = arith.constant 2 : i32
+      aiex.npu.write32(%wa1, %wv1) : i32, i32
+    }
+  }
+}

--- a/test/dialect/AIEX/npu_to_cert_configure_full.mlir
+++ b/test/dialect/AIEX/npu_to_cert_configure_full.mlir
@@ -1,0 +1,46 @@
+//===- npu_to_cert_configure_full.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-npu-to-cert %s | FileCheck %s
+
+// Test complete configure/run flow with multiple operations
+
+module {
+  // The @main_seq runtime sequence is lowered to a bare cert.job (no enclosing
+  // page yet); the callee @config_device is absorbed into a cert.section.
+  // CHECK: aie.device(npu2) {
+  // CHECK: aiex.cert.job({{[0-9]+}})
+  // CHECK: aiex.cert.write32(4096, 1)
+  // CHECK: aiex.cert.load_pdi(1, @config_device)
+  // CHECK: aiex.cert.write32(6750208, 42)
+  // CHECK: aiex.cert.write32(8192, 99)
+  // CHECK: aiex.cert.section @config_device
+  // CHECK: aiex.cert.page
+  // CHECK: aiex.cert.job({{[0-9]+}})
+  // CHECK-NOT: aie.device(npu2) @config_device
+  aie.device(npu2) @main {
+    aie.runtime_sequence @main_seq(%arg0: memref<1024xi32>) {
+      %wa0 = arith.constant 4096 : i32
+      %wv0 = arith.constant 1 : i32
+      aiex.npu.write32(%wa0, %wv0) {column = 0 : i32, row = 0 : i32} : i32, i32
+      aiex.configure @config_device {
+        aiex.run @setup_sequence(%arg0) : (memref<1024xi32>)
+      }
+      %wa1 = arith.constant 8192 : i32
+      %wv1 = arith.constant 99 : i32
+      aiex.npu.write32(%wa1, %wv1) {column = 0 : i32, row = 0 : i32} : i32, i32
+    }
+  }
+
+  aie.device(npu2) @config_device {
+    aie.runtime_sequence @setup_sequence(%buf: memref<1024xi32>) {
+      %wa2 = arith.constant 6750208 : i32
+      %wv2 = arith.constant 42 : i32
+      aiex.npu.write32(%wa2, %wv2) : i32, i32
+    }
+  }
+}

--- a/test/dialect/AIEX/npu_to_cert_pages.mlir
+++ b/test/dialect/AIEX/npu_to_cert_pages.mlir
@@ -1,0 +1,32 @@
+//===- npu_to_cert_pages.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-npu-to-cert %s | FileCheck %s
+// RUN: aie-opt --aie-npu-to-cert %s | aie-opt --cert-legalize-pages | FileCheck %s --check-prefix=PAGES
+
+// Test that runtime sequences are lowered to a bare cert.job at device level by
+// aie-npu-to-cert (no enclosing page yet), and that cert-legalize-pages then
+// wraps the contiguous job(s) into a cert.page.
+
+module {
+  aie.device(npu2) @main {
+    // After aie-npu-to-cert: a bare job, no enclosing page.
+    // CHECK-NOT: aiex.cert.page
+    // CHECK: aiex.cert.job({{[0-9]+}})
+    // CHECK: aiex.cert.write32(4096, 1)
+
+    // After cert-legalize-pages: the job is wrapped in a page.
+    // PAGES: aiex.cert.page
+    // PAGES-NEXT: aiex.cert.job({{[0-9]+}})
+    // PAGES: aiex.cert.write32(4096, 1)
+    aie.runtime_sequence @main_seq(%arg0: memref<1024xi32>) {
+      %wa0 = arith.constant 4096 : i32
+      %wv0 = arith.constant 1 : i32
+      aiex.npu.write32(%wa0, %wv0) {column = 0 : i32, row = 0 : i32} : i32, i32
+    }
+  }
+}

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -1162,6 +1162,38 @@ getTransactionPipeline(mlir::MLIRContext *ctx, llvm::StringRef elfDir,
   return pm;
 }
 
+// CERT pipeline: transaction generation, followed by lowering the
+// transaction into the microcontroller firmware's CERT representation. Mirrors
+// `builtin.module(aie.device(convert-aie-to-transaction{elf-dir=<elfDir>}),
+// aie-npu-to-cert, aie.device(cert-legalize-pages, aie-cert-verify))`.
+// `aie-npu-to-cert` runs
+// module-wide (its `device-name` option defaults to "main" and absorbs every
+// other device's load-pdi references into that device's cert sections), so
+// this pipeline is meant to run once over the whole module, not per device.
+// Feeds `--aie-cert-to-asm` (AIETranslateToUcDma) to produce the control-code
+// assembly consumed by the downstream CERT assembler. Returns nullptr on parse
+// failure.
+inline std::unique_ptr<mlir::PassManager>
+getCertPipeline(mlir::MLIRContext *ctx, llvm::StringRef elfDir) {
+  namespace X = xilinx::AIEX;
+  auto pm = std::make_unique<mlir::PassManager>(ctx);
+  std::string txnPipelineStr =
+      ("convert-aie-to-transaction{elf-dir=" + elfDir + "}").str();
+  auto &dpm = pm->nest<xilinx::AIE::DeviceOp>();
+  if (mlir::failed(mlir::parsePassPipeline(txnPipelineStr, dpm)))
+    return nullptr;
+  pm->addPass(X::createAIENpuToCertPass());
+  auto &certDpm = pm->nest<xilinx::AIE::DeviceOp>();
+  certDpm.addPass(X::createAIECertPagesPass());
+  // aie-cert-verify runs last, after page legalization and placement lowering,
+  // where final pages and uC (group) assignments are known. It turns CERT
+  // firmware constraints (barrier co-location, one wait_tcts per actor, remote
+  // barrier rendezvous, preempt-count parity, id budgets) into compile-time
+  // diagnostics instead of hardware hangs.
+  certDpm.addPass(X::createAIECertVerifyPass());
+  return pm;
+}
+
 // Control-packet generation: transaction pipeline, then rewrite the
 // transaction ops into control packets and legalize them — all in one device
 // nest. Same `elfDir` / `devName` semantics as getTransactionPipeline. Returns


### PR DESCRIPTION
## Description

Add a device-neutral CERT runtime model for deterministic multi-microcontroller execution.

- Preserve textual job and page order; treat job IDs as labels rather than priorities.
- Add target-model uC mapping, page placement, and lowering to attach_to_group.
- Use the target controller topology from #3593 for group validation and tile-to-controller mapping.
- Emit one ordered stream per actual uC group and unify explicit group 0 with device-level content.
- Form implicit cooperative pages, force the generated configure page first on uC0, and preserve placement through page legalization.
- Add aie-cert-verify for group IDs, local and remote barriers, TCT waits, preemption IDs, rendezvous membership, and firmware barrier budgets; run it in the aiecc CERT pipeline.
- Harden page sizing and splitting, including legal job-boundary cuts, local-barrier co-location, load_pdi/preempt ordering, and TCT-aware implicit boundaries.
- Make uC DMA-chain merging page-aware, ordering-safe, and safe for shared symbols.

This PR is stacked on the AIE2PS target-model foundation in #3593. The history contains six reviewable functional commits plus a small typo fix.

The independent rel_acq_sync operation in #3558 follows this PR in the stack.

## Testing

The PR adds focused lit coverage under Conversion/NpuToCert, Targets/AIETargetUcCert, dialect/AIEX, and Passes/materialize-to-cert; CI is expected to run these suites.