### PR TITLE
ci: pin and dependabot-cover the actions in .github/actions [LOW]

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -39,27 +39,27 @@ runs:
   steps:
     - name: Setup tmate session
       if: ${{ inputs.DEBUG_ENABLED && inputs.DEBUG_OS == inputs.MATRIX_OS && inputs.DEBUG_ARCH == inputs.MATRIX_ARCH }}
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113  # v3
       with:
         limit-access-to-actor: true
         detached: ${{ inputs.DEBUG_DETACHED }}
 
-    - uses: ilammy/msvc-dev-cmd@v1.4.1
+    - uses: ilammy/msvc-dev-cmd@ed94116c4d30d2091601b81f339a2eaa1c2ba0a6  # v1.4.1
       if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
 
     - name: Set up Visual Studio shell
       if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
-      uses: egor-tensin/vs-shell@v2
+      uses: egor-tensin/vs-shell@54e4148eac794e4580591c2e0b7750f14b7891fc  # v2
       with:
         arch: x64
 
     - name: MS Build
       if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506  # v1.1
 
     - name: Free disk space
       if: contains(inputs.MATRIX_OS, 'ubuntu')
-      uses: descriptinc/free-disk-space@main
+      uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main
       with:
         tool-cache: true
         android: true
@@ -68,7 +68,7 @@ runs:
         large-packages: true
         swap-storage: false # This frees space on the wrong partition.
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: '3.12'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,14 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # `/` covers .github/workflows. Composite actions are NOT covered by it --
+    # each one's own directory has to be listed, which is why the refs in
+    # .github/actions drifted unpinned and unbumped while every workflow file
+    # was kept current. Add a line here when a new composite action lands.
+    directories:
+      - "/"
+      - "/.github/actions/setup_base"
+      - "/.github/actions/setup_ccache"
     schedule:
       interval: "cron"
       cronjob: "0 6 8,22 * *"


### PR DESCRIPTION
## Problem

Every action in `.github/workflows` is SHA-pinned with a version comment.
`.github/actions/setup_base` is not: six of its seven refs are floating tags, and
one is a branch.

    mxschmitt/action-tmate@v3
    ilammy/msvc-dev-cmd@v1.4.1
    egor-tensin/vs-shell@v2
    microsoft/setup-msbuild@v1.1
    descriptinc/free-disk-space@main      <- branch, not a tag
    actions/setup-python@v5               <- workflows are on v6

The cause is the dependabot config, not neglect: the `github-actions` ecosystem
entry uses `directory: "/"`, which covers `.github/workflows` but not composite
actions -- each needs its own directory listed. `git log --format=%an --
.github/actions/` returns nine human authors and no dependabot, across the whole
history of that directory, while `.github/workflows` gets bumped on a fortnightly
cadence. That is why `setup-python` sits a major version behind there.

These refs run on every distro wheel build, and OSSF Scorecard's pinned-dependencies
check counts them.

## Fix

Pin all six to the commit their current ref resolves to today, and add the two
composite-action directories to the `github-actions` entry in `dependabot.yml`.

No version changes: each pin is the SHA the existing tag points at right now, so
behaviour is unchanged and the refs simply stop moving on their own. The two halves
have to land together -- pinning a floating tag without dependabot coverage would
freeze it with nothing left to advance it.

`descriptinc/free-disk-space` is pinned to `1b4b157`, which is what the workflow
files already pin it to, so the two now agree. Whether that fork is still the right
choice is a separate question.

## Evidence

    mxschmitt/action-tmate      v3      35b54afac29c97fb54faba5b513f8fbd1882f113
    ilammy/msvc-dev-cmd         v1.4.1  ed94116c4d30d2091601b81f339a2eaa1c2ba0a6
    egor-tensin/vs-shell        v2      54e4148eac794e4580591c2e0b7750f14b7891fc
    microsoft/setup-msbuild     v1.1    34cfbaee7f672c76950673338facd8a73f637506
    descriptinc/free-disk-space main    1b4b157593c6801212a2ed488c205e0a810b4592
    actions/setup-python        v5      a26af69be951a213d495a4c3e4e4022e16d87065

`action-tmate@v3` resolves to the same SHA `buildAndTestVitis.yml` already pins, so
that one is a no-op made explicit. `dependabot.yml` parses.

## Scope

`llvm/actions/install-ninja` is left alone here. It is already SHA-pinned, but it
declares `using: 'node16'` and pins a 2023 commit, so it needs replacing rather than
pinning. Separate PR.
