### PR TITLE
ci: lint the workflow files with actionlint, and fix what it finds [MED]

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# actionlint cannot see this repository's self-hosted runners, so every
+# `runs-on` naming one reads as an unknown label. Declare them here; a label
+# missing from this list is then a real typo rather than noise.
+self-hosted-runner:
+  labels:
+    - aie2-4col      # NPU1, 4 columns
+    - aie2p-8col     # NPU2, 8 columns
+    - npu2
+    - ryzenai
+    - ubuntu-vitis   # Vitis toolchain image

--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -32,7 +32,7 @@ outputs:
     description: ''
     value: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
 
-description: ''
+description: 'Prepare the workspace, toolchain and optional tmate debug session shared by the distro build jobs.'
 
 runs:
   using: "composite"

--- a/.github/actions/setup_ccache/action.yml
+++ b/.github/actions/setup_ccache/action.yml
@@ -19,7 +19,7 @@ outputs:
     description: ''
     value: ${{ steps.configure_ccache_dir_on_host.outputs.HOST_CCACHE_DIR }}
 
-description: ''
+description: 'Restore and configure a ccache instance for the calling build job.'
 
 runs:
   using: "composite"

--- a/.github/workflows/buildAndTestVitis.yml
+++ b/.github/workflows/buildAndTestVitis.yml
@@ -24,6 +24,7 @@ on:
   # - or edit directly the step below which runs tmate and push to the
   #   PR, ignoring the manual workflow launch.
   workflow_dispatch:
+    inputs:
       launch_tmate_terminal_for_debug:
         type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/dependabot-sync-locks.yml
+++ b/.github/workflows/dependabot-sync-locks.yml
@@ -64,6 +64,11 @@ jobs:
         run: utils/regenerate_lockfiles.sh
 
       - name: Commit regenerated lockfiles
+        # HEAD_REF goes through the environment rather than being interpolated
+        # into the script: a branch name is attacker-controlled text, and this
+        # job holds contents: write.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if git diff --quiet; then
             echo "Lockfiles already in sync; nothing to commit."
@@ -72,4 +77,4 @@ jobs:
           git config user.name "dependabot[bot]"
           git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
           git commit -am "Regenerate lockfiles [dependabot skip]"
-          git push origin HEAD:"${{ github.head_ref }}"
+          git push origin HEAD:"$HEAD_REF"

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -373,6 +373,9 @@ jobs:
       - name: Check filename case conflicts
         run: pre-commit run check-case-conflict --all-files --color never
 
+      - name: Lint workflow files (actionlint)
+        run: pre-commit run actionlint --all-files --color never
+
       - name: Run git-clang-format
         id: git-clang-format
         run: |

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -381,7 +381,7 @@ jobs:
         rm -rf build
 
     - name: Docker prune
-      if: contains(inputs.MATRIX_OS, 'ubuntu')
+      if: runner.os == 'Linux'
       shell: bash
       run: |
 

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -289,7 +289,7 @@ jobs:
         rm -rf build
 
     - name: Docker prune
-      if: contains(inputs.MATRIX_OS, 'ubuntu')
+      if: runner.os == 'Linux'
       shell: bash
       run: |
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,16 @@ repos:
       args: [--fix=lf]
       exclude: *generated_exclude
 
+- repo: https://github.com/rhysd/actionlint
+  rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
+  hooks:
+    - id: actionlint
+      # actionlint runs shellcheck and pyflakes over inline `run:` blocks when
+      # they are on PATH, as the runner images provide: 141 more findings here,
+      # 95 of them SC2086 (shellcheck 0.11.0). Off, to keep this hook on
+      # workflow schema, expressions and runner labels.
+      args: [-shellcheck=, -pyflakes=]
+
 # Regenerate hash-pinned lockfiles when their source manifests change.
 # Only fires if you've staged one of the source files below; if uv is missing
 # locally the hook fails with a clear install hint (the script does the check).


### PR DESCRIPTION
## Problem

Nothing checks the workflow files. actionlint over `.github/` finds four defects live on
main today:

- `buildAndTestVitis.yml:27` puts `launch_tmate_terminal_for_debug` directly under
  `workflow_dispatch:` instead of under `inputs:`. GitHub tolerates the stray key, so the
  workflow runs, but no input is ever registered and the tmate guard at `:83` is always
  empty. That debug path has never worked.
- `dependabot-sync-locks.yml:67` interpolates `github.head_ref` into an inline `run:`, in
  the one job holding `contents: write`. #3165 hardened this same pattern in two other
  workflows; this is the remaining instance. Quoting does not help here, since `${{ }}`
  substitutes into the script text before bash parses it.
- `setup_base` and `setup_ccache` declare `description: ''`, which action metadata requires
  to be non-empty.
- `mlirDistro.yml` and `mlirAIEDistro.yml` guard on `contains(inputs.MATRIX_OS, 'ubuntu')`,
  an input neither workflow defines, so both guards are dead.

That last one is the argument for the hook. It was found by hand in #3535, which closed
unmerged; I folded its two lines in here with a co-author trailer. actionlint flags that
class automatically, on the commit that introduces it.

## Fix

The four above, plus `.github/actionlint.yaml` declaring the five self-hosted runner labels,
and actionlint as a pre-commit hook run in the format job. It is a validator, so it runs on
every commit locally, matching the split already in `.pre-commit-config.yaml`; dependabot's
pre-commit ecosystem keeps the pin current.

## Evidence

actionlint v1.7.12 with `-shellcheck= -pyflakes=`: 17 findings on main at `4c8b56f5db2`,
0 on this branch, stable over 15 runs. One caveat if you re-run it: the `[action]` rule
reports a missing `description` at whichever call site it reaches first, so a parallel run
can report `setup_base` twice and total 18. Under `GOMAXPROCS=1` it is 17 every time.

Deleting `.github/actionlint.yaml` puts back exactly the 10 runner-label findings and
nothing else, and a typo'd label is still flagged with the config in place, so the allowlist
is precise rather than a blanket silence. Reverting the `inputs:` fix alone turns the hook
red on exactly the two findings above, and restoring it passes, so the wiring works end to
end. `pre-commit run actionlint --all-files` costs 0.11 s warm over the 19 workflow files.
`reuse lint-file` and `utils/check_copyright_format.py` accept the new file.

## Scope

actionlint also runs shellcheck and pyflakes over inline `run:` blocks whenever it finds
them on PATH, which the runner images do: 141 further findings here, 95 of them SC2086
(shellcheck 0.11.0). The hook passes `-shellcheck= -pyflakes=` to keep this change on
workflow schema, expressions and runner labels. The shell cleanup is a separate pass.

Composite actions stay unlinted either way: the upstream hook pins
`files: ^\.github/workflows/`, and actionlint cannot parse an `action.yml` on its own. The
`run:` steps in `setup_base` and `setup_ccache` are checked by nothing.
