### PR TITLE
ci: cap self-hosted job runtime, repo-wide [MED]

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -53,6 +53,8 @@ jobs:
     # The goal for this job is to run the full test suite, including programming guide and examples, on a freshly built-from-source MLIR-AIE.
     # This also exercises the build-mlir-aie-from-wheels.sh script, which is the most common developer-facing way to rebuild MLIR-AIE from source.
     runs-on: ${{ matrix.runner_type }}
+    # Normal exec is 20-40 min; cap a hang well below GitHub's 360-min default.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -297,6 +299,7 @@ jobs:
     #     the normal single-dispatch path (vector_vector_add IRON +
     #     vector_reduce_max C++).
     runs-on: aie2p-8col
+    timeout-minutes: 30
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-hrx-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache-hrx-${{ github.run_id }}

--- a/.github/workflows/buildAndTestRyzenAIWindows.yml
+++ b/.github/workflows/buildAndTestRyzenAIWindows.yml
@@ -50,6 +50,8 @@ jobs:
     # in python/aie_lit_utils/lit_config_helpers.py); JIT-style Python
     # examples (@iron.jit) still run and cover the NPU end to end.
     runs-on: [self-hosted, windows, ryzenai, npu2]
+    # Normal exec is 19-21 min; observed hang on this job 71.4 min (2026-08-04).
+    timeout-minutes: 90
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}\iron-cache-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}\.pip-cache-${{ github.run_id }}

--- a/.github/workflows/buildAndTestVitis.yml
+++ b/.github/workflows/buildAndTestVitis.yml
@@ -61,6 +61,7 @@ jobs:
   build-tests:
     name: Run Tests on Vitis
     runs-on: ${{ matrix.runner_type }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -263,6 +263,8 @@ jobs:
     # nightly still get full from-source NPU coverage via buildAndTestRyzenAI.
     needs: build-repo
     runs-on: ${{ matrix.runner_type }}
+    # Normal exec is ~1 min; cap well below the sibling smoke job's 192.6-min hang.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -642,6 +644,8 @@ jobs:
     # 3.13 matches the runner's pre-provisioned interpreter (docs/buildHostWinNative.md).
     needs: build-windows
     runs-on: [self-hosted, windows, ryzenai, npu2]
+    # Normal exec is 3-6 min; observed hang 192.6 min on this job (2026-08-04).
+    timeout-minutes: 20
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}\iron-cache-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}\.pip-cache-${{ github.run_id }}


### PR DESCRIPTION
## Problem

No self-hosted job in the repo declares `timeout-minutes`. Repo-wide only three jobs set one, and
all three are GitHub-hosted (`dependabot-sync-locks` 15, `update-llvm` 180, `update-peano` 15), so
every NPU/Vitis job inherits GitHub's 360-minute default.

Hangs already happen on these capacity-1/few pools:

| job | normal exec | observed |
|---|---|---|
| `Smoke-Test Wheel on Ryzen AI (Windows)` (`buildRyzenWheels.yml`) | 3-6 min | **192.6 min**, cancelled |
| `Run Tests and Examples on Ryzen AI (Built from Source, Windows)` (`buildAndTestRyzenAIWindows.yml`) | 19-21 min | **71.4 min** |

The Windows pool is a single runner, so one stuck job blocks every queued PR behind it for as long
as GitHub lets it run.

## Fix

Add `timeout-minutes` to all 6 self-hosted job blocks in the repo (verified against `runs-on` +
runner-label census, not the 2 named above alone):

| file | job | cap | normal exec |
|---|---|---|---|
| `buildAndTestRyzenAI.yml` | `build-and-test-from-source` (aie2-4col/aie2p-8col) | 90 | 20-40 min |
| `buildAndTestRyzenAI.yml` | `build-and-test-pure-hrx` (aie2p-8col) | 30 | ~4-8 min |
| `buildAndTestRyzenAIWindows.yml` | `build-and-test-from-source` (npu2) | 90 | 19-21 min |
| `buildAndTestVitis.yml` | `build-tests` (ubuntu-vitis) | 30 | ~6-7.5 min |
| `buildRyzenWheels.yml` | `smoke-test-npu` (aie2-4col/aie2p-8col) | 20 | ~1 min |
| `buildRyzenWheels.yml` | `smoke-test-wheels-npu-windows` (npu2) | 20 | 3-6 min |

Each cap sits well above its job's observed max so it cannot fire on a healthy run, and well below
GitHub's 360-min default so an actual hang stops burying the queue.

## Test

`yaml.safe_load` on all 4 touched files. A scripted `runs-on` + label sweep over every
`.github/workflows/*.yml` job confirms these are the only 6 self-hosted blocks in the repo and that
all 6 now carry `timeout-minutes`. No behavior change on a normal run since every cap is above the
job's measured max.
