### PR TITLE
[AIE] Split the placer's DMA-exhaustion diagnostic from the merge lockout [LOW]

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -247,6 +247,24 @@ private:
                                              int requiredOutputChannels,
                                              AIETileType requestedType);
 
+  // Diagnosis for a failed findTileWithCapacity() call. `findTileWithCapacity`
+  // scans every tile of `requestedType` on the device -- `targetCol` orders
+  // candidates, it does not exclude any -- so a failure is either (a) no
+  // tile of this type has the requested channels free ANYWHERE (device-wide
+  // DMA exhaustion: pinning a column cannot create capacity), or (b) at
+  // least one tile has them free but is already claimed by a different
+  // non-core logical tile (only possible under merge-logical-tiles=false).
+  // `capacityExistsSomewhere` selects between the two; the totals let the
+  // caller report the real budget instead of guessing at it.
+  struct CapacityDiagnosis {
+    bool capacityExistsSomewhere = false;
+    int tilesOfType = 0;
+    int inUsed = 0, inMax = 0, outUsed = 0, outMax = 0;
+  };
+  CapacityDiagnosis diagnoseCapacityExhaustion(AIETileType requestedType,
+                                               int requiredInputChannels,
+                                               int requiredOutputChannels);
+
   void updateChannelUsage(TileID tile, DmaDir direction, int numChannels);
 
   bool hasAvailableChannels(TileID tile, int inputChannels, int outputChannels);

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1253,19 +1253,38 @@ LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
                                         numInputChannels, numOutputChannels,
                                         logicalTile.getTileType());
   if (!maybeTile) {
-    StringRef tileTypeName = stringifyAIETileType(logicalTile.getTileType());
+    AIETileType requestedType = logicalTile.getTileType();
+    StringRef tileTypeName = stringifyAIETileType(requestedType);
     auto diag = logicalTile.emitError();
-    diag << "no " << tileTypeName << " has sufficient DMA capacity for "
-         << numInputChannels << " input/" << numOutputChannels
-         << " output channels ";
-    if (colConstraint)
-      diag << "at column " << *colConstraint;
-    else
-      diag << "near centroid column " << centroidCol;
-    diag.attachNote() << "to fix, pin this " << tileTypeName
-                      << " to a column with available DMA budget, or rebalance "
-                         "compute peers so the centroid lands on a less-busy "
-                         "column";
+    CapacityDiagnosis diagnosis = diagnoseCapacityExhaustion(
+        requestedType, numInputChannels, numOutputChannels);
+    if (!diagnosis.capacityExistsSomewhere) {
+      diag << "no " << tileTypeName << " on the device has " << numInputChannels
+           << " input/" << numOutputChannels
+           << " output DMA channel(s) free: all " << diagnosis.tilesOfType
+           << " " << tileTypeName << "(s) are at " << diagnosis.inUsed << "/"
+           << diagnosis.inMax << " input, " << diagnosis.outUsed << "/"
+           << diagnosis.outMax << " output channels used";
+      diag.attachNote() << "this is the device's total " << tileTypeName
+                        << " DMA budget, not a placement choice -- no column "
+                           "has spare capacity to pin to; fan traffic "
+                           "through a MemTile, or reduce the number of "
+                           "DMA-attached ObjectFIFOs feeding this tile";
+    } else {
+      diag << "no " << tileTypeName << " has sufficient DMA capacity for "
+           << numInputChannels << " input/" << numOutputChannels
+           << " output channels ";
+      if (colConstraint)
+        diag << "at column " << *colConstraint;
+      else
+        diag << "near centroid column " << centroidCol;
+      diag.attachNote() << "every " << tileTypeName
+                        << " with spare DMA capacity already hosts a "
+                           "different logical tile (merge-logical-tiles is "
+                           "off); enable merging, or pin logical tiles "
+                           "one-per-column if fewer of them than physical "
+                        << tileTypeName << "s remain unclaimed";
+    }
     return failure();
   }
 
@@ -1321,6 +1340,34 @@ std::optional<TileID> SequentialPlacer::findTileWithCapacity(
   }
 
   return best;
+}
+
+SequentialPlacer::CapacityDiagnosis
+SequentialPlacer::diagnoseCapacityExhaustion(AIETileType requestedType,
+                                             int requiredInputChannels,
+                                             int requiredOutputChannels) {
+  // Walk the device directly rather than `availability.nonCompTiles`: a
+  // fully-exhausted tile is meant to stay enumerable here even if a future
+  // fix makes `updateChannelUsage`'s prune (see its `removeTile` call)
+  // actually fire, which today it structurally cannot.
+  CapacityDiagnosis diagnosis;
+  for (int col = 0, numCols = targetModel->columns(); col < numCols; ++col) {
+    for (int row = 0, numRows = targetModel->rows(); row < numRows; ++row) {
+      if (targetModel->getTileType(col, row) != requestedType)
+        continue;
+      TileID tile{col, row};
+      ++diagnosis.tilesOfType;
+      auto [maxIn, maxOut] = getDMACapacity(*targetModel, tile);
+      diagnosis.inMax += maxIn;
+      diagnosis.outMax += maxOut;
+      diagnosis.inUsed += availability.inputChannelsUsed.lookup(tile);
+      diagnosis.outUsed += availability.outputChannelsUsed.lookup(tile);
+      if (hasAvailableChannels(tile, requiredInputChannels,
+                               requiredOutputChannels))
+        diagnosis.capacityExistsSomewhere = true;
+    }
+  }
+  return diagnosis;
 }
 
 void SequentialPlacer::updateChannelUsage(TileID tile, DmaDir direction,

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -60,8 +60,10 @@ module @memtile_exhaustion {
     %mem4 = aie.logical_tile<MemTile>(?, ?)
     %mem5 = aie.logical_tile<MemTile>(?, ?)
     %mem6 = aie.logical_tile<MemTile>(?, ?)
-    // CHECK: error: no MemTile has sufficient DMA capacity for {{[0-9]+ input/[0-9]+ output channels}}
-    // CHECK: note: to fix, pin this MemTile
+    // Global exhaustion: npu1_1col has exactly one MemTile, and it is
+    // already fully booked, so no column pin could ever help.
+    // CHECK: error: no MemTile on the device has {{[0-9]+ input/[0-9]+ output}} DMA channel(s) free: all 1 MemTile(s) are at {{[0-9]+/[0-9]+}} input, {{[0-9]+/[0-9]+}} output channels used
+    // CHECK: note: this is the device's total MemTile DMA budget
     %mem7 = aie.logical_tile<MemTile>(?, ?)
 
     aie.objectfifo @of1 (%mem1, {%core1}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
@@ -144,8 +146,10 @@ module @shimnoc_exhaustion {
     // First two shims merge, using 2 output channels
     %shim1 = aie.logical_tile<ShimNOCTile>(?, ?)
     %shim2 = aie.logical_tile<ShimNOCTile>(?, ?)
-    // CHECK: error: no ShimNOCTile has sufficient DMA capacity for {{[0-9]+ input/[0-9]+ output channels}}
-    // CHECK: note: to fix, pin this ShimNOCTile
+    // Global exhaustion: npu1_1col has exactly one ShimNOCTile, and it is
+    // already fully booked, so no column pin could ever help.
+    // CHECK: error: no ShimNOCTile on the device has {{[0-9]+ input/[0-9]+ output}} DMA channel(s) free: all 1 ShimNOCTile(s) are at {{[0-9]+/[0-9]+}} input, {{[0-9]+/[0-9]+}} output channels used
+    // CHECK: note: this is the device's total ShimNOCTile DMA budget
     %shim3 = aie.logical_tile<ShimNOCTile>(?, ?)
 
     aie.objectfifo @of1 (%shim1, {%core1}, 2 : i32) : !aie.objectfifo<memref<16xi32>>

--- a/test/place-tiles/sequential_placer/test_place_merge_logical_tiles_overflow.mlir
+++ b/test/place-tiles/sequential_placer/test_place_merge_logical_tiles_overflow.mlir
@@ -17,8 +17,10 @@
 // RUN:   | FileCheck %s --check-prefix=NOMERGE-OOC
 // RUN: aie-opt --aie-place-tiles %s | FileCheck %s --check-prefix=MERGE-OK
 
+// Every ShimNOCTile here still has a free output channel (2 per tile, 1
+// used) -- this is the merge-exclusivity branch, not DMA exhaustion.
 // NOMERGE-OOC: error: no ShimNOCTile has sufficient DMA capacity for {{[0-9]+ input/[0-9]+ output channels}}
-// NOMERGE-OOC: note: to fix, pin this ShimNOCTile
+// NOMERGE-OOC: note: every ShimNOCTile with spare DMA capacity already hosts a different logical tile (merge-logical-tiles is off)
 
 // MERGE-OK-LABEL: @nomerge_overflow
 // MERGE-OK:       aie.device(npu1)


### PR DESCRIPTION
## Problem

`SequentialPlacer::findTileWithCapacity` scans every tile of the requested type on the whole device -- `targetCol` only orders candidates by distance, it never excludes one -- so when it returns no candidate, there are exactly two possible causes: (a) no tile of that type anywhere has the requested channels free, or (b) at least one does, but every such tile is already claimed by a different `aie.logical_tile` under `merge-logical-tiles=false`. The current message conflates both into "pin this to a column with available DMA budget, or rebalance compute peers", which is unactionable for (a): there is no column with budget, and rebalancing compute peers cannot create shim/memtile DMA channels.

I hit this row-tiling a design that fills all 16 shim MM2S channels on npu2 (8 ShimNOCTiles x 2 channels/direction). The note sent me looking for a placement fix when the real answer was fan out through a MemTile.

## Fix

Split the diagnostic. For (a), report the actual per-type channel budget and usage instead of suggesting a pin, e.g. `"no ShimNOCTile on the device has 0 input/1 output DMA channel(s) free: all 1 ShimNOCTile(s) are at 0/2 input, 2/2 output channels used"` on the single-column `shimnoc_exhaustion` test, and point at MemTile fan-out or reducing DMA-attached ObjectFIFOs. For (b), keep the "no X has sufficient DMA capacity" wording (still accurate -- the tile the search accepted really is short on channels) but replace the note with the actual cause: every tile with spare capacity already hosts another logical tile, so the fix is enabling merge or pinning one-per-column, not chasing a busier column.

Diagnostics only; no placement decision changes.

## Test

Confirmed both branches are real using the existing suite rather than adding a synthetic repro: `test_place_errors.mlir`'s `memtile_exhaustion`/`shimnoc_exhaustion` (npu1_1col, one physical tile of each type, genuinely zero spare capacity anywhere) exercise (a); `test_place_merge_logical_tiles_overflow.mlir`'s `nomerge_overflow` (4 ShimNOC columns, 5 unhinted logical tiles, `merge-logical-tiles=false`) exercises (b) -- each ShimNOCTile there still has 1 of 2 output channels free. Updated the CHECK lines in both files to the new, distinct wording per branch.

Built `aie-opt` standalone against the pinned MLIR/LLVM distro and ran every `RUN:` line in all 24 `test/place-tiles/*.mlir` files (not just the 2 touched ones) through it with `FileCheck`: 32/32 pass, including the two updated files and the 22 untouched ones. clang-format clean at both 17.0.1 and 22.1.8.
