### PR TITLE
[python] hostruntime: open the NPU once per process, not once per tensor [MED]

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -56,6 +56,7 @@ declare_mlir_python_sources(AIEPythonSources.Utils
     utils/hostruntime/tensor_class.py
     utils/hostruntime/torch_interop.py
     utils/hostruntime/xrtruntime/__init__.py
+    utils/hostruntime/xrtruntime/device.py
     utils/hostruntime/xrtruntime/hostruntime.py
     utils/hostruntime/xrtruntime/parameter_scratchpad.py
     utils/hostruntime/xrtruntime/tensor.py

--- a/python/utils/hostruntime/xrtruntime/device.py
+++ b/python/utils/hostruntime/xrtruntime/device.py
@@ -1,0 +1,116 @@
+# device.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""Opening the NPU, once per process.
+
+``pyxrt.device(index)`` is an open, not a lookup. XRT calls into the shim on
+every construction and hands back a handle whose deleter closes the device
+again, while the shim refcounts the file descriptor: the last handle going out
+of scope closes ``/dev/accel/accel0``, and the next construction reopens it. So
+a caller that keeps one handle per object turns allocation into open/close
+churn, and it is the reopen that fails, with ``ENODEV``, under an unrelated
+transient on the device.
+
+One handle per process removes both halves of that. It is also the ownership
+order the runtime needs on Windows, where an XRT object outliving what it was
+allocated from is an access violation rather than a leak (#3100): a handle held
+for the life of the process cannot be outlived by the buffers derived from it.
+"""
+
+import gc
+import logging
+import os
+import shutil
+import subprocess
+import time
+
+import pyxrt  # pyright: ignore[reportMissingImports]
+
+logger = logging.getLogger(__name__)
+
+# Handles by device index, kept for the life of the process. Deliberately not
+# released by ``cleanup_npu_runtime()``: that releases hw contexts and insts
+# BOs, which are derived from a device and must not outlive it.
+_DEVICES: dict[int, "pyxrt.device"] = {}
+
+# A failed open is retried this many times before it is allowed to propagate.
+# Retrying at all is what #2814 established, from a CI run where the device was
+# briefly unopenable and no state of this process explained it.
+_MAX_RETRIES = 5
+
+
+def _log_device_state():
+    """Report what the host thinks of the NPU, after an open has failed.
+
+    Best-effort and informational: it names the single-NPU device node rather
+    than resolving the one behind a given index, and it must not raise, since
+    it runs on the way to reporting a different failure.
+    """
+    try:
+        if os.path.exists("/dev/accel/accel0"):
+            logger.debug("/dev/accel/accel0 exists")
+            logger.debug("Stat: %s", os.stat("/dev/accel/accel0"))
+        else:
+            logger.debug("/dev/accel/accel0 does not exist")
+
+        xrt_bin = shutil.which("xrt-smi")
+        if xrt_bin is None:
+            xrt_base = os.environ.get("XILINX_XRT", "/opt/xilinx/xrt")
+            xrt_bin = xrt_base + "/bin/xrt-smi"
+        if os.path.exists(xrt_bin):
+            logger.debug("Running %s examine", xrt_bin)
+            result = subprocess.run(
+                [xrt_bin, "examine"],
+                timeout=5,
+                capture_output=True,
+                text=True,
+            )
+            logger.debug("xrt-smi stdout:\n%s", result.stdout)
+            logger.debug("xrt-smi stderr:\n%s", result.stderr)
+    except Exception as debug_e:
+        logger.debug("Failed to run debug checks: %s", debug_e)
+
+
+def _open_device(index: int):
+    """Open device ``index``, retrying a failure that may not be permanent."""
+    for attempt in range(_MAX_RETRIES):
+        try:
+            return pyxrt.device(index)
+        except RuntimeError as e:
+            logger.warning(
+                "Failed to acquire NPU device %d (attempt %d/%d): %s",
+                index,
+                attempt + 1,
+                _MAX_RETRIES,
+                e,
+            )
+            _log_device_state()
+            if attempt + 1 == _MAX_RETRIES:
+                raise
+            gc.collect()  # a handle awaiting collection still holds the device
+            time.sleep(1.0 * (attempt + 1))  # linear backoff
+    raise AssertionError("_MAX_RETRIES must be at least 1")
+
+
+def acquire_device(index: int = 0):
+    """Return this process's handle on NPU device ``index``.
+
+    The device is opened on the first call and the handle is reused after it,
+    so a process holds one however many buffers it allocates.
+
+    Args:
+        index (int, optional): Device index to open. Defaults to 0.
+
+    Returns:
+        pyxrt.device: The handle for ``index``.
+
+    Raises:
+        RuntimeError: If the device could not be opened, after retries.
+    """
+    device = _DEVICES.get(index)
+    if device is None:
+        device = _open_device(index)
+        _DEVICES[index] = device
+    return device

--- a/python/utils/hostruntime/xrtruntime/hostruntime.py
+++ b/python/utils/hostruntime/xrtruntime/hostruntime.py
@@ -7,8 +7,6 @@ import atexit
 import gc
 import logging
 import os
-import shutil
-import subprocess
 import time
 import weakref
 from collections import OrderedDict
@@ -18,6 +16,7 @@ from typing import TYPE_CHECKING
 import pyxrt  # pyright: ignore[reportMissingImports]
 
 from ..hostruntime import HostRuntime, HostRuntimeError, KernelHandle, KernelResult
+from .device import acquire_device
 
 if TYPE_CHECKING:
     from aie.iron.device import Device
@@ -97,53 +96,7 @@ class XRTHostRuntime(HostRuntime):
 
     def __init__(self):
         """Initialize the XRTHostRuntime."""
-        # Retry logic for device acquisition to handle transient failures
-        max_retries = 5
-        for attempt in range(max_retries):
-            try:
-                self._device = pyxrt.device(0)
-                break
-            except RuntimeError as e:
-                logger.warning(
-                    "XRTHostRuntime: Failed to acquire device (attempt %d/%d): %s",
-                    attempt + 1,
-                    max_retries,
-                    e,
-                )
-
-                # Debugging info
-                try:
-                    if os.path.exists("/dev/accel/accel0"):
-                        logger.debug("/dev/accel/accel0 exists")
-                        # Stat it
-                        st = os.stat("/dev/accel/accel0")
-                        logger.debug("Stat: %s", st)
-                    else:
-                        logger.debug("/dev/accel/accel0 does not exist")
-
-                    # Try running xrt-smi examine
-                    xrt_bin = shutil.which("xrt-smi")
-                    if xrt_bin is None:
-                        xrt_base = os.environ.get("XILINX_XRT", "/opt/xilinx/xrt")
-                        xrt_bin = xrt_base + "/bin/xrt-smi"
-                    if os.path.exists(xrt_bin):
-                        logger.debug("Running %s examine", xrt_bin)
-                        result = subprocess.run(
-                            [xrt_bin, "examine"],
-                            timeout=5,
-                            capture_output=True,
-                            text=True,
-                        )
-                        logger.debug("xrt-smi stdout:\n%s", result.stdout)
-                        logger.debug("xrt-smi stderr:\n%s", result.stderr)
-                except Exception as debug_e:
-                    logger.debug("Failed to run debug checks: %s", debug_e)
-
-                if attempt == max_retries - 1:
-                    raise e
-
-                gc.collect()  # Make sure contexts are garbage collected.
-                time.sleep(1.0 * (attempt + 1))  # Exponential backoff
+        self._device = acquire_device()
 
         self._device_type_str = self._device.get_info(pyxrt.xrt_info_device.name)
 

--- a/python/utils/hostruntime/xrtruntime/tensor.py
+++ b/python/utils/hostruntime/xrtruntime/tensor.py
@@ -12,6 +12,7 @@ from aie.helpers.util import np_ndarray_type_get_shape
 
 from ..buffer import Storage, Transport
 from ..tensor_class import NpuTensor
+from .device import acquire_device
 
 
 class XrtTransport(Transport):
@@ -89,10 +90,12 @@ class XRTTensor(NpuTensor):
             flags (optional): XRT buffer object flags. Defaults to xrt.bo.host_only.
             group_id (int, optional): XRT buffer object group ID. Defaults to 0.
             xrt_device (optional): Existing PyXRT device handle to use for BO allocation.
-                When omitted, a new handle for device index 0 is opened for this tensor.
+                When omitted, the process's handle on device 0 is used. Opening
+                one per tensor instead closes and reopens the device as tensors
+                come and go; see :mod:`.device`.
         """
         super().__init__(shape_or_data, dtype=dtype, device=device)
-        self.xrt_device = xrt_device if xrt_device is not None else xrt.device(0)
+        self.xrt_device = xrt_device if xrt_device is not None else acquire_device()
 
         np_data = None
         # Extract the shape

--- a/test/python/npu-xrt/test_xrt_device_handle.py
+++ b/test/python/npu-xrt/test_xrt_device_handle.py
@@ -1,0 +1,135 @@
+# test_xrt_device_handle.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# RUN: %run_on_npu1% %pytest %s
+# RUN: %run_on_npu2% %pytest %s
+# REQUIRES: xrt_python_bindings
+
+"""How many times allocating tensors opens the device, with the open substituted.
+
+Both halves are counted rather than asserted about indirectly: the open is what
+fails transiently, and closing it is what makes the next allocation reopen it.
+Substituting ``pyxrt.device`` and the XRT allocation leaves the real
+``XRTTensor.__init__`` under test, so a call site that goes back to opening its
+own handle is caught here rather than as a flake on a device runner.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyxrt")
+
+from aie.utils.hostruntime.xrtruntime import device as device_module  # noqa: E402
+from aie.utils.hostruntime.xrtruntime import tensor as xrt_tensor_module  # noqa: E402
+from aie.utils.hostruntime.xrtruntime.tensor import XRTTensor  # noqa: E402
+
+
+class FakeBo:
+    """Stands in for a pyxrt buffer object over a bytearray."""
+
+    def __init__(self, nbytes):
+        self.storage = bytearray(nbytes)
+        self.size = nbytes
+
+    def map(self):
+        return memoryview(self.storage)
+
+    def sync(self, direction):
+        pass
+
+
+@pytest.fixture
+def opens(monkeypatch):
+    """Count device opens, and start from a process that has not opened one."""
+    monkeypatch.setattr(device_module, "_DEVICES", {})
+    monkeypatch.setattr(xrt_tensor_module.xrt, "bo", lambda *args: FakeBo(args[1]))
+
+    calls = []
+
+    def fake_device(index):
+        calls.append(index)
+        return object()
+
+    monkeypatch.setattr(device_module.pyxrt, "device", fake_device)
+    return calls
+
+
+def test_allocating_many_tensors_opens_the_device_once(opens):
+    """The reason this test exists.
+
+    Every ``pyxrt.device()`` is a real open, and the handle closes the device
+    when it is dropped, so a handle per tensor closes and reopens the device as
+    tensors come and go. That reopen is what returned ENODEV mid-suite.
+    """
+    tensors = [XRTTensor((64,), dtype=np.uint8) for _ in range(4)]
+
+    assert opens == [0]
+    assert len({id(t.xrt_device) for t in tensors}) == 1
+
+
+def test_a_supplied_device_is_used_as_given(opens):
+    """A caller holding its own handle keeps it, and no open happens."""
+    supplied = object()
+    tensor = XRTTensor((64,), dtype=np.uint8, xrt_device=supplied)
+
+    assert opens == []
+    assert tensor.xrt_device is supplied
+
+
+def test_a_view_shares_its_parents_handle(opens):
+    parent = XRTTensor((128,), dtype=np.uint8)
+    view = parent.subview(64, (64,))
+
+    assert opens == [0]
+    assert view.xrt_device is parent.xrt_device
+
+
+def test_a_failed_open_is_retried(monkeypatch, opens):
+    monkeypatch.setattr(device_module.time, "sleep", lambda _: None)
+    handle = object()
+    attempts = []
+
+    def flaky(index):
+        attempts.append(index)
+        if len(attempts) < 3:
+            raise RuntimeError("No such device with index '0'")
+        return handle
+
+    monkeypatch.setattr(device_module.pyxrt, "device", flaky)
+
+    assert device_module.acquire_device() is handle
+    assert len(attempts) == 3
+
+
+def test_an_open_that_never_succeeds_propagates(monkeypatch, opens):
+    monkeypatch.setattr(device_module.time, "sleep", lambda _: None)
+    attempts = []
+
+    def never(index):
+        attempts.append(index)
+        raise RuntimeError("No such device with index '0'")
+
+    monkeypatch.setattr(device_module.pyxrt, "device", never)
+
+    with pytest.raises(RuntimeError):
+        device_module.acquire_device()
+    assert len(attempts) == device_module._MAX_RETRIES
+
+
+def test_a_failed_open_is_not_cached(monkeypatch, opens):
+    """A device that comes back is usable, rather than poisoned for the process."""
+    monkeypatch.setattr(device_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        device_module.pyxrt,
+        "device",
+        lambda index: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    with pytest.raises(RuntimeError):
+        device_module.acquire_device()
+
+    handle = object()
+    monkeypatch.setattr(device_module.pyxrt, "device", lambda index: handle)
+    assert device_module.acquire_device() is handle


### PR DESCRIPTION
## Problem

`XRTTensor` opens its own `pyxrt.device(0)` when no handle is passed
(`xrtruntime/tensor.py`). That is an open, not a lookup: `get_userpf_device`
calls into the shim on every construction and returns a handle whose deleter
closes the device again, and the shim refcounts the fd, so the last handle
going out of scope closes `/dev/accel/accel0` and the next allocation reopens
it. A test or example that allocates tensors in a loop therefore opens and
closes the device in a loop.

That reopen is what fails. On the aie2-4col runner it returned `ENODEV`
mid-suite and took out 27 of `test_torch_comparison.py`'s XRTTensor cases,
while the 1127 other tests in the same job passed and `xrt-smi` found the
device at the start of the step.

#3100 moved runtime-owned insts BOs off a fresh `xrt.device(0)` for the same
ownership reason; user tensors kept it.

## Fix

`acquire_device()` in a new `xrtruntime/device.py` opens a device index once
per process and reuses the handle. `XRTTensor` uses it when no `xrt_device=`
is supplied; an explicitly supplied handle is still used as given.

`XRTHostRuntime.__init__`'s retry loop moves into the same function, so there
is one implementation of "open device 0" rather than two that drift. Retrying
at all is #2814; a failed open is not cached, so a device that comes back is
usable rather than poisoned for the process.

A handle held for the life of the process also cannot be outlived by the
buffers derived from it, which is the ownership order #3100 needed on Windows.

## Evidence

Measured on npu2 (Gorgon Point), pinned, minimum of many runs:

| | |
|---|---|
| full open/close cycle of the device | 19.0 ms |
| construction with the fd already held | 2.24 us |

Allocating 200 tensors goes from 200 device opens to 1, and from 17.67 to
14.83 us per tensor when the tensors are held.

## Test

`test/python/npu-xrt/test_xrt_device_handle.py` counts opens with
`pyxrt.device` and the XRT allocation substituted, so the real
`XRTTensor.__init__` is under test and a call site that goes back to opening
its own handle is caught here rather than as a flake on a device runner.
Reverting the one line in `tensor.py` fails it at 4 opens instead of 1.

On device: `test/python/npu/test_torch_comparison.py` and `test_tensor.py`,
569 passed.

Not covered locally: `XRTHostRuntime.__init__`. This host's device reports as
`NPU Gorgon Point 1`, which `NPU_MODELS` does not map, so that constructor
raises before and after this change here. The change to it is an extraction of
the existing loop.
