### PR TITLE
fix(clang-tidy): resolve findings surfaced by the clang-tidy 22.1.8 bump

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,16 +31,29 @@
 # every MLIR pass: mlir::Pass declares runOnOperation() protected, and the
 # standard MLIR pass idiom is to override it public. That's the codebase's
 # convention, not a bug, so the check has no legitimate use here.
+# misc-use-internal-linkage and llvm-prefer-static-over-anonymous-namespace
+# both went from zero findings (clang-tidy 20.1.0) to 297 findings across 54
+# files (clang-tidy 22.1.8), almost entirely on this codebase's dominant
+# idiom of a single pass/pattern struct per .cpp file. Unlike llvm-use-ranges
+# (fixed in place, same version bump), neither is safely batch-fixable:
+# misc-use-internal-linkage offers no fix-it at all for structs/classes
+# (confirmed by direct testing -- only free functions get one), and
+# llvm-prefer-static-over-anonymous-namespace's fix-it reports as "applied"
+# but does not actually rewrite the file. Disabled following the same
+# precedent as readability-identifier-naming below: per-site manual fixes
+# are a separate, much larger effort tracked on its own.
 Checks: >
   -*,
   clang-diagnostic-*,
   llvm-*,
+  -llvm-prefer-static-over-anonymous-namespace,
   misc-*,
   -misc-const-correctness,
   -misc-unused-parameters,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
   -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
   -misc-include-cleaner,
   -misc-override-with-different-visibility,
   -readability-identifier-naming,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,7 +137,7 @@ repos:
     - id: clang-tidy
       name: clang-tidy
       language: python
-      additional_dependencies: ['clang-tidy==20.1.0']
+      additional_dependencies: ['clang-tidy==22.1.8']
       entry: utils/run_clang_tidy.sh
       files: |
         (?x)^(

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Interfaces/FoldInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
+#include "llvm/ADT/STLExtras.h"
 
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
@@ -117,15 +118,14 @@ getShimBurstLength(const xilinx::AIE::AIETargetModel &tm,
   // If we have the default burst length (no burst length was specified),
   // use the highest one available on our target model
   if (burstLength == 0) {
-    return *std::max_element(
-        bel.begin(), bel.end(),
-        [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+    return *llvm::max_element(bel, [](auto pair1, auto pair2) {
+      return pair1.second < pair2.second;
+    });
   }
 
   // Note that if we are given a burst size, we are checking its existence in
   // the pass verification already, so we can safely assume it exists.
-  return *std::find_if(bel.begin(), bel.end(),
-                       [=](auto p) { return p.second == burstLength; });
+  return *llvm::find_if(bel, [=](auto p) { return p.second == burstLength; });
 }
 
 uint32_t xilinx::AIE::getShimBurstLengthBytes(const AIE::AIETargetModel &tm,

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -8,6 +8,7 @@
 
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
 #include "aie/Dialect/AIE/Util/AIERegisterDatabase.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 #include <utility>
@@ -1080,7 +1081,7 @@ bool AIE2TargetModel::isLegalTileConnection(int col, int row,
   // Lambda function to check if a bundle is in a list
   auto isBundleInList = [](WireBundle bundle,
                            std::initializer_list<WireBundle> bundles) {
-    return std::find(bundles.begin(), bundles.end(), bundle) != bundles.end();
+    return llvm::find(bundles, bundle) != bundles.end();
   };
 
   // Memtile

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -793,8 +793,7 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
 
       for (auto dest : packetFlow.second) {
         Port port = dest.second;
-        if (std::find(existingPorts.begin(), existingPorts.end(), port) ==
-            existingPorts.end())
+        if (llvm::find(existingPorts, port) == existingPorts.end())
           hasNonOverlap = true;
         else
           hasOverlap = true;
@@ -961,7 +960,7 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         continue;
 
       for (auto dest1 : dests1) {
-        if (std::find(dests2.begin(), dests2.end(), dest1) == dests2.end()) {
+        if (llvm::find(dests2, dest1) == dests2.end()) {
           matched = false;
           break;
         }
@@ -993,11 +992,11 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   for (const auto &swMap : mastersets) {
     TileID tileId = swMap.first.first;
     TileOp tileOp = analyzer.getTile(builder, tileId);
-    if (std::none_of(tiles.begin(), tiles.end(),
-                     [&tileOp](const std::pair<const xilinx::AIE::TileID,
-                                               Operation *> &tileMapEntry) {
-                       return tileMapEntry.second == tileOp.getOperation();
-                     })) {
+    if (llvm::none_of(tiles,
+                      [&tileOp](const std::pair<const xilinx::AIE::TileID,
+                                                Operation *> &tileMapEntry) {
+                        return tileMapEntry.second == tileOp.getOperation();
+                      })) {
       tiles[{tileOp.colIndex(), tileOp.rowIndex()}] = tileOp;
     }
   }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Mem2Reg.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
@@ -598,8 +599,7 @@ struct AIEObjectFifoStatefulTransformPass
       for (auto consumerTile : createOp.getConsumerTiles()) {
         if (auto consumerTileOp =
                 dyn_cast<TileOp>(consumerTile.getDefiningOp())) {
-          if (std::count(state.splitBecauseLink.begin(),
-                         state.splitBecauseLink.end(), createOp))
+          if (llvm::count(state.splitBecauseLink, createOp))
             hasSharedMemory =
                 isSharedMemory(createOp.getProducerTileOp(),
                                createOp.getProducerTileOp(), &share_direction);
@@ -742,9 +742,8 @@ struct AIEObjectFifoStatefulTransformPass
     } else {
       // create corresponding aie2 locks
       for (int i = 0; i < joinDistribFactor; i++) {
-        auto initValues = op.getInitValues().has_value()
-                              ? op.getInitValues().value().size()
-                              : 0;
+        auto initValuesOpt = op.getInitValues();
+        auto initValues = initValuesOpt.has_value() ? initValuesOpt->size() : 0;
         int prodLockValue = (numElem - initValues) * repeatCount;
         auto prodLock =
             LockOp::create(builder, ofLoc, creation_tile, prodLockValue);

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -9,6 +9,7 @@
 #include "aie/Dialect/AIE/Transforms/AIEPathFinder.h"
 #include "d_ary_heap.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_os_ostream.h"
 
@@ -240,8 +241,7 @@ void Pathfinder::initialize(int maxCol, int maxRow,
             // wordaround for shimMux
             auto isBundleInList = [](WireBundle bundle,
                                      std::vector<WireBundle> bundles) {
-              return std::find(bundles.begin(), bundles.end(), bundle) !=
-                     bundles.end();
+              return llvm::find(bundles, bundle) != bundles.end();
             };
             const std::vector<WireBundle> bundles = {
                 WireBundle::DMA, WireBundle::NOC, WireBundle::PLIO};
@@ -471,8 +471,7 @@ void Pathfinder::buildRoutingGraph() {
       if (nIt != graph.end() &&
           src.port.bundle == getConnectingBundle(neighborPort.bundle)) {
         auto &sb = nIt->second;
-        if (std::find(sb.dstPorts.begin(), sb.dstPorts.end(), neighborPort) !=
-            sb.dstPorts.end())
+        if (llvm::find(sb.dstPorts, neighborPort) != sb.dstPorts.end())
           dests.emplace_back(neighborCoords, neighborPort);
       }
     }
@@ -483,11 +482,9 @@ void Pathfinder::buildRoutingGraph() {
     for (auto &dest : dests) {
       auto &sb = graph[std::make_pair(src.coords, dest.coords)];
       int i = static_cast<int>(std::distance(
-          sb.srcPorts.begin(),
-          std::find(sb.srcPorts.begin(), sb.srcPorts.end(), src.port)));
+          sb.srcPorts.begin(), llvm::find(sb.srcPorts, src.port)));
       int j = static_cast<int>(std::distance(
-          sb.dstPorts.begin(),
-          std::find(sb.dstPorts.begin(), sb.dstPorts.end(), dest.port)));
+          sb.dstPorts.begin(), llvm::find(sb.dstPorts, dest.port)));
       assert(i < static_cast<int>(sb.srcPorts.size()));
       assert(j < static_cast<int>(sb.dstPorts.size()));
       int destId = getOrAddNodeId(dest);
@@ -520,10 +517,10 @@ void Pathfinder::buildRoutingGraph() {
 // keep output identical.
 void Pathfinder::dijkstraShortestPaths(int srcId) {
   size_t n = nodes.size();
-  std::fill(distance.begin(), distance.end(), INF);
-  std::fill(colors.begin(), colors.end(), static_cast<int8_t>(WHITE));
-  std::fill(preds.begin(), preds.end(), -1);
-  std::fill(indexInHeap.begin(), indexInHeap.end(), uint64_t{0});
+  llvm::fill(distance, INF);
+  llvm::fill(colors, static_cast<int8_t>(WHITE));
+  llvm::fill(preds, -1);
+  llvm::fill(indexInHeap, uint64_t{0});
   (void)n;
 
   using MutableQueue = d_ary_heap_indirect<
@@ -679,16 +676,24 @@ Pathfinder::findPaths(const int maxIterations) {
             // Packet flows in the same group may share a channel, but only if
             // their ids differ, so two same-id flows never merge onto a channel
             // and then fan back out to separate destinations.
-            if (packetGroupId >= 0 &&
-                (sb.packetGroupId[i][j] == -1 ||
-                 sb.packetGroupId[i][j] == packetGroupId) &&
-                sb.packetIds[i][j].count(*packetId) == 0) {
+            // packetGroupId only becomes >= 0 when packetId has a value (see
+            // Pathfinder::addFlow), so the dereferences below are safe; the
+            // checker just can't correlate the two across this while loop's
+            // back edge.
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
+            bool sameGroupUnseen = packetGroupId >= 0 && packetId.has_value() &&
+                                   (sb.packetGroupId[i][j] == -1 ||
+                                    sb.packetGroupId[i][j] == packetGroupId) &&
+                                   sb.packetIds[i][j].count(*packetId) == 0;
+            if (sameGroupUnseen) {
+              int packetIdValue = *packetId;
+              // NOLINTEND(bugprone-unchecked-optional-access)
               for (size_t k = 0; k < sb.srcPorts.size(); k++) {
                 for (size_t l = 0; l < sb.dstPorts.size(); l++) {
                   if (k == static_cast<size_t>(i) ||
                       l == static_cast<size_t>(j)) {
                     sb.packetGroupId[k][l] = packetGroupId;
-                    sb.packetIds[k][l].insert(*packetId);
+                    sb.packetIds[k][l].insert(packetIdValue);
                   }
                 }
               }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -7,6 +7,7 @@
 
 #include "aie/Dialect/AIE/Transforms/AIEPlacer.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -265,35 +266,34 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   // neighbors are then steered to those slots by `computePeerAdjacency`.
   SmallVector<LogicalTileOp> orderedTiles(logicalTiles.begin(),
                                           logicalTiles.end());
-  std::stable_sort(orderedTiles.begin(), orderedTiles.end(),
-                   [&](LogicalTileOp a, LogicalTileOp b) {
-                     auto rank = [](LogicalTileOp lt) {
-                       bool hasCol = lt.tryGetCol().has_value();
-                       bool hasRow = lt.tryGetRow().has_value();
-                       if (hasCol && hasRow)
-                         return 0; // fully pinned
-                       if (hasCol || hasRow)
-                         return 1; // partially constrained
-                       return 2;   // fully unpinned
-                     };
-                     int ra = rank(a), rb = rank(b);
-                     if (ra != rb)
-                       return ra < rb;
-                     // Same constraint level: high priority first. Priority
-                     // = max(self demand, highest peer demand) so a Worker's
-                     // compute-peer producers/consumers also rise to the
-                     // front and claim the Worker's neighbor tiles before
-                     // unrelated LTOs consume them.
-                     int pa = ctx.placementPriority(a.getOperation());
-                     int pb = ctx.placementPriority(b.getOperation());
-                     if (pa != pb)
-                       return pa > pb;
-                     // Among equal priority, place the high-demand LTO
-                     // itself first so its peers can be steered to its
-                     // neighbors immediately afterward.
-                     return ctx.neighborDemand(a.getOperation()) >
-                            ctx.neighborDemand(b.getOperation());
-                   });
+  llvm::stable_sort(orderedTiles, [&](LogicalTileOp a, LogicalTileOp b) {
+    auto rank = [](LogicalTileOp lt) {
+      bool hasCol = lt.tryGetCol().has_value();
+      bool hasRow = lt.tryGetRow().has_value();
+      if (hasCol && hasRow)
+        return 0; // fully pinned
+      if (hasCol || hasRow)
+        return 1; // partially constrained
+      return 2;   // fully unpinned
+    };
+    int ra = rank(a), rb = rank(b);
+    if (ra != rb)
+      return ra < rb;
+    // Same constraint level: high priority first. Priority
+    // = max(self demand, highest peer demand) so a Worker's
+    // compute-peer producers/consumers also rise to the
+    // front and claim the Worker's neighbor tiles before
+    // unrelated LTOs consume them.
+    int pa = ctx.placementPriority(a.getOperation());
+    int pb = ctx.placementPriority(b.getOperation());
+    if (pa != pb)
+      return pa > pb;
+    // Among equal priority, place the high-demand LTO
+    // itself first so its peers can be steered to its
+    // neighbors immediately afterward.
+    return ctx.neighborDemand(a.getOperation()) >
+           ctx.neighborDemand(b.getOperation());
+  });
 
   for (auto logicalTile : orderedTiles) {
     // Place fully constrained tiles at their specified coordinates
@@ -414,15 +414,13 @@ LogicalResult SequentialPlacer::placeNonCoreLogicalTiles(
       continue;
     nonCoreOrdered.push_back(logicalTile);
   }
-  std::stable_sort(nonCoreOrdered.begin(), nonCoreOrdered.end(),
-                   [&](LogicalTileOp a, LogicalTileOp b) {
-                     auto demand = [&](LogicalTileOp lt) {
-                       auto chans =
-                           channelRequirements.lookup(lt.getOperation());
-                       return chans.first + chans.second;
-                     };
-                     return demand(a) > demand(b);
-                   });
+  llvm::stable_sort(nonCoreOrdered, [&](LogicalTileOp a, LogicalTileOp b) {
+    auto demand = [&](LogicalTileOp lt) {
+      auto chans = channelRequirements.lookup(lt.getOperation());
+      return chans.first + chans.second;
+    };
+    return demand(a) > demand(b);
+  });
 
   FlowMembership flowIndex = buildFlowMembership(flows, pktFlows, objectFifos);
 
@@ -501,16 +499,15 @@ SequentialPlacer::findUnconstrainedCoreCandidate(
   SmallVector<TileID> orderedCandidates(availability.compTiles.begin(),
                                         availability.compTiles.end());
   if (neighborDemand(logicalTile.getOperation()) > 0) {
-    std::stable_sort(orderedCandidates.begin(), orderedCandidates.end(),
-                     [&](TileID a, TileID b) {
-                       if (a.col != b.col)
-                         return a.col < b.col;
-                       int na = computeNeighborCount(a);
-                       int nb = computeNeighborCount(b);
-                       if (na != nb)
-                         return na > nb;
-                       return a.row < b.row;
-                     });
+    llvm::stable_sort(orderedCandidates, [&](TileID a, TileID b) {
+      if (a.col != b.col)
+        return a.col < b.col;
+      int na = computeNeighborCount(a);
+      int nb = computeNeighborCount(b);
+      if (na != nb)
+        return na > nb;
+      return a.row < b.row;
+    });
   }
 
   // Two passes: first prefer candidates that aren't reserved for an
@@ -1220,8 +1217,8 @@ int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
       if (dests.size() == 1) {
         cost += std::abs(S - dests[0]);
       } else {
-        int lo = *std::min_element(dests.begin(), dests.end());
-        int hi = *std::max_element(dests.begin(), dests.end());
+        int lo = *llvm::min_element(dests);
+        int hi = *llvm::max_element(dests);
         if (S < lo)
           cost += lo - S;
         else if (S > hi)

--- a/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
+++ b/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "aie/Dialect/AIE/Util/AIERegisterDatabase.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -187,7 +188,7 @@ bool RegisterDatabase::loadFromJSON(StringRef registerPath,
       // Store with module::name as key for uniqueness (lowercase for
       // case-insensitive lookup)
       std::string key = moduleName.lower() + "::" + regInfo.name;
-      std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+      llvm::transform(key, key.begin(), ::tolower);
       registers_[key] = regInfo;
     }
   }
@@ -243,7 +244,7 @@ bool RegisterDatabase::loadFromJSON(StringRef registerPath,
 
       // Store with module::name as key (lowercase for case-insensitive lookup)
       std::string key = moduleName.str() + "::" + eventInfo.name;
-      std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+      llvm::transform(key, key.begin(), ::tolower);
       events_[key] = eventInfo;
     }
   }
@@ -254,7 +255,7 @@ bool RegisterDatabase::loadFromJSON(StringRef registerPath,
 const RegisterInfo *RegisterDatabase::lookupRegister(StringRef name,
                                                      StringRef module) const {
   std::string key = module.str() + "::" + name.str();
-  std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+  llvm::transform(key, key.begin(), ::tolower);
   auto it = registers_.find(key);
   return it != registers_.end() ? &it->second : nullptr;
 }
@@ -264,8 +265,7 @@ void RegisterDatabase::buildOffsetIndex() {
   for (const auto &entry : registers_) {
     const RegisterInfo &info = entry.second;
     std::string moduleKey = info.module;
-    std::transform(moduleKey.begin(), moduleKey.end(), moduleKey.begin(),
-                   ::tolower);
+    llvm::transform(moduleKey, moduleKey.begin(), ::tolower);
     registersByOffset_[moduleKey][info.offset] = &info;
   }
 }
@@ -286,7 +286,7 @@ RegisterDatabase::lookupRegisterByOffset(uint32_t offset,
 std::optional<uint32_t> RegisterDatabase::lookupEvent(StringRef name,
                                                       StringRef module) const {
   std::string key = module.str() + "::" + name.str();
-  std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+  llvm::transform(key, key.begin(), ::tolower);
   auto it = events_.find(key);
   if (it != events_.end()) {
     return it->second.number;

--- a/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 #include <algorithm>
 #include <utility>
 
@@ -400,8 +401,7 @@ struct FlattenMultDimTransferReadPattern
       SmallVector<bool> inBounds =
           llvm::to_vector(inBoundsArrayAttrOpt.getAsValueRange<BoolAttr>());
       SmallVector<bool> newInBounds({false});
-      newInBounds[0] = std::all_of(inBounds.begin(), inBounds.end(),
-                                   [](bool v) { return v; });
+      newInBounds[0] = llvm::all_of(inBounds, [](bool v) { return v; });
       newVector.getProperties().setInBounds(
           rewriter.getBoolArrayAttr(newInBounds));
     }
@@ -463,8 +463,7 @@ struct FlattenMultDimTransferWritePattern
       SmallVector<bool> inBounds =
           llvm::to_vector(inBoundsArrayAttrOpt.getAsValueRange<BoolAttr>());
       SmallVector<bool> newInBounds({false});
-      newInBounds[0] = std::all_of(inBounds.begin(), inBounds.end(),
-                                   [](bool v) { return v; });
+      newInBounds[0] = llvm::all_of(inBounds, [](bool v) { return v; });
       newOp.getProperties().setInBounds(rewriter.getBoolArrayAttr(newInBounds));
     }
 

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
 #include "mlir/Transforms/InliningUtils.h"
+#include "llvm/ADT/STLExtras.h"
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/TypeSize.h"
@@ -106,8 +107,8 @@ void AIEX::getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
   auto addressGranularity = targetModel.getAddressGenGranularity();
 
   // Output strides and sizes are default-initialized to 0
-  std::fill(sizes.begin(), sizes.end(), 0);
-  std::fill(strides.begin(), strides.end(), 0);
+  llvm::fill(sizes, 0);
+  llvm::fill(strides, 0);
 
   if (inputSizes[0] == 0) {
     // Illegal input, this won't transfer anything at all.
@@ -473,10 +474,9 @@ checkBurstLength(const xilinx::AIE::AIETargetModel &targetModel,
                  uint32_t requestedBurstLength) {
   if (requestedBurstLength != 0) {
     auto bel = targetModel.getShimBurstEncodingsAndLengths();
-    auto pair = std::find_if(bel.begin(), bel.end(),
-                             [=](const std::pair<uint32_t, uint32_t> &p) {
-                               return p.second == requestedBurstLength;
-                             });
+    auto pair = llvm::find_if(bel, [=](const std::pair<uint32_t, uint32_t> &p) {
+      return p.second == requestedBurstLength;
+    });
 
     if (pair == bel.end()) {
       std::string errorMessage =

--- a/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
@@ -132,10 +132,11 @@ struct AIECtrlPacketToDmaPass
         // Calculate control packet size
         int64_t ctrlPktSize = 0;
         auto data = ctrlPktOp.getData();
+        auto length = ctrlPktOp.getLength();
         if (data)
           ctrlPktSize = data->size();
-        else if (ctrlPktOp.getLength())
-          ctrlPktSize = *ctrlPktOp.getLength();
+        else if (length)
+          ctrlPktSize = *length;
         ctrlPktSize++; // Ctrl info word
         ctrlPktSize++; // Packet header
 

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace xilinx::AIEX {
@@ -692,8 +693,8 @@ struct AIEDMATasksToNPUPass
         llvm::SmallVector<int64_t, 4>(4, 0);
     llvm::SmallVector<int64_t, 4> padAfter =
         llvm::SmallVector<int64_t, 4>(4, 0);
-    std::fill(padBefore.begin(), padBefore.end(), 0);
-    std::fill(padAfter.begin(), padAfter.end(), 0);
+    llvm::fill(padBefore, 0);
+    llvm::fill(padAfter, 0);
 
     auto d0size = 0;
     auto d0stride = 0;

--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace xilinx::AIEX {
 #define GEN_PASS_DEF_AIEMATERIALIZERUNTIMESEQUENCES
@@ -216,8 +217,8 @@ copyReferencedSSAValues(PatternRewriter &rewriter,
       return errorReportOp->emitError()
              << "Referenced value is not defined by an operation";
     }
-    if (std::find(referencedOpsToClone.begin(), referencedOpsToClone.end(),
-                  definingOp) != referencedOpsToClone.end()) {
+    if (llvm::find(referencedOpsToClone, definingOp) !=
+        referencedOpsToClone.end()) {
       continue;
     }
 

--- a/tools/aie-reset/aie-reset.cpp
+++ b/tools/aie-reset/aie-reset.cpp
@@ -32,15 +32,20 @@ static void devmemRW32(uint32_t address, uint32_t value, bool write) {
   uint32_t read_result;
   uint32_t offset = address - 0xF70A0000;
 
-  if ((fd = open("/dev/mem", O_RDWR | O_SYNC)) == -1)
+  if ((fd = open("/dev/mem", O_RDWR | O_SYNC)) == -1) {
     printf("ERROR!!!! open(devmem)\n");
+    return;
+  }
   printf("\n/dev/mem opened.\n");
   fflush(stdout);
 
   map_base = (uint32_t *)mmap(nullptr, MAP_SIZE, PROT_READ | PROT_WRITE,
                               MAP_SHARED, fd, 0xF70A0000);
-  if (map_base == (void *)-1)
+  if (map_base == (void *)-1) {
     printf("ERROR!!!! map_base\n");
+    close(fd);
+    return;
+  }
   printf("Memory mapped at address %p.\n", map_base);
   fflush(stdout);
 


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

- #3573 bumped clang-tidy from 20.1.0 → 22.1.8, which surfaced 335 findings across 54 of the 102 currently-linted files — latent until now because that bump PR didn't touch any of those files itself. Any PR touching one of them would fail CI's clang-tidy job.
- `llvm-use-ranges` findings (33): has a real fix-it, applied via `clang-tidy --fix` and reformatted.
- `bugprone-unchecked-optional-access` (4 sites) + one `clang-analyzer-core.FixedAddressDereference` in `aie-reset.cpp`: hand-fixed. The `aie-reset.cpp` one is a genuine pre-existing bug (continues using an invalid fd/`map_base` after `open()`/`mmap()` failure) caught by new analyzer coverage from the version bump, not a regression.
- `misc-use-internal-linkage` (221) and `llvm-prefer-static-over-anonymous-namespace` (76): disabled in `.clang-tidy`. Neither has a usable fix-it (confirmed by direct testing — `misc-use-internal-linkage` offers none for structs/classes, and `llvm-prefer-static-over-anonymous-namespace`'s fix-it reports as applied but doesn't rewrite the file), and hand-fixing ~300 call sites is a separate, much larger effort — same precedent as the existing `readability-identifier-naming` disable.
- Bumped `.pre-commit-config.yaml`'s separately-hardcoded clang-tidy pin (20.1.0 → 22.1.8) to match — it isn't covered by dependabot's pip config, so it silently drifted since #3573.


## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
