### PR TITLE
[AIE] Give the pathfinder graph a port direction

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -228,15 +228,30 @@ private:
     int j;
   };
 
+  // A `Port` is (bundle, channel) with no direction, so one dense node stands
+  // for both a switchbox port's input side and its output side. Dijkstra
+  // therefore searches over states, not nodes: a state is a node paired with
+  // the side of that port the stream is currently on. A stream enters a
+  // switchbox on an input port, crosses the crossbar once to an output port,
+  // and then rides the wire to the neighbour's input port -- so In only ever
+  // takes intra-switchbox edges and Out only ever takes inter-switchbox ones.
+  // Without the split, Dijkstra can chain two crossbar hops through one port
+  // and turn the stream around inside a switchbox; the settings it emits then
+  // dead-end and AIECreatePathFindFlows reports the flow as unroutable.
+  enum PortSide : int { In = 0, Out = 1 };
+  static int stateId(int nodeId, PortSide side) { return 2 * nodeId + side; }
+  static int stateNode(int stateId) { return stateId >> 1; }
+
   // Build the dense integer node numbering and per-node adjacency from `graph`
   // and `flows`. Topology is fixed across congestion iterations, so this runs
   // once. Edge order per node matches the legacy PathEndPoint-sorted order to
   // preserve identical routing output.
   void buildRoutingGraph();
 
-  // Dijkstra over the dense graph from dense node `srcId`. Fills `preds` (dense
-  // predecessor id per node, or -1) and `predEdge` (the edge taken to reach
-  // each node). Reuses the scratch buffers below.
+  // Dijkstra over the dense graph from dense node `srcId`, whose port is the
+  // stream's entry into its switchbox and so starts on the In side. Fills
+  // `preds` (predecessor state id, or -1) and `predEdge` (the edge taken to
+  // reach each state). Reuses the scratch buffers below.
   void dijkstraShortestPaths(int srcId);
 
   // Flows to be routed
@@ -254,7 +269,8 @@ private:
   std::vector<PathEndPoint> nodes;          // dense id -> PathEndPoint
   std::vector<std::vector<Edge>> adjacency; // dense id -> out-edges
 
-  // Dijkstra scratch, sized to nodes.size() and reused across calls.
+  // Dijkstra scratch, indexed by state id (2 * nodes.size()) and reused across
+  // calls.
   std::vector<double> distance;
   std::vector<uint64_t> indexInHeap;
   std::vector<int8_t> colors;

--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -240,7 +240,7 @@ private:
   // dead-end and AIECreatePathFindFlows reports the flow as unroutable.
   enum PortSide : int { In = 0, Out = 1 };
   static int stateId(int nodeId, PortSide side) { return 2 * nodeId + side; }
-  static int stateNode(int stateId) { return stateId >> 1; }
+  static int stateNode(int state) { return state >> 1; }
 
   // Build the dense integer node numbering and per-node adjacency from `graph`
   // and `flows`. Topology is fixed across congestion iterations, so this runs

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -500,28 +500,26 @@ void Pathfinder::buildRoutingGraph() {
   if (adjacency.size() < n)
     adjacency.resize(n);
 
-  // Size the reusable Dijkstra scratch buffers.
-  distance.assign(n, INF);
-  indexInHeap.assign(n, 0);
-  colors.assign(n, WHITE);
-  preds.assign(n, -1);
-  predEdge.assign(n, Edge{-1, nullptr, 0, 0});
+  // Size the reusable Dijkstra scratch buffers. These are indexed by state id,
+  // i.e. two entries per node -- one per side of the port.
+  distance.assign(2 * n, INF);
+  indexInHeap.assign(2 * n, 0);
+  colors.assign(2 * n, WHITE);
+  preds.assign(2 * n, -1);
+  predEdge.assign(2 * n, Edge{-1, nullptr, 0, 0});
   graphBuilt = true;
 }
 
-// Dijkstra over the dense graph from dense node `srcId`. Fills the `preds` and
-// `predEdge` scratch buffers. This is a 1:1 port of the legacy
-// PathEndPoint-keyed version with all per-node std::map lookups replaced by
-// flat vector indexing; the push/relax control flow (including the WHITE-node
-// always-push behavior and the absence of a heap decrease-key) is preserved to
-// keep output identical.
+// Dijkstra over the dense graph from dense node `srcId`, searching states
+// (node, PortSide) rather than bare nodes. Fills the `preds` and `predEdge`
+// scratch buffers, both indexed by state id. The push/relax control flow
+// (including the WHITE-node always-push behavior and the absence of a heap
+// decrease-key) is inherited from the legacy PathEndPoint-keyed version.
 void Pathfinder::dijkstraShortestPaths(int srcId) {
-  size_t n = nodes.size();
   llvm::fill(distance, INF);
   llvm::fill(colors, static_cast<int8_t>(WHITE));
   llvm::fill(preds, -1);
   llvm::fill(indexInHeap, uint64_t{0});
-  (void)n;
 
   using MutableQueue = d_ary_heap_indirect<
       /*Value=*/int, /*Arity=*/4,
@@ -530,13 +528,24 @@ void Pathfinder::dijkstraShortestPaths(int srcId) {
       /*Compare=*/std::less<>>;
   MutableQueue Q(distance, indexInHeap);
 
-  distance[srcId] = 0.0;
-  Q.push(srcId);
+  // The flow source port feeds into its switchbox, so the search starts on the
+  // In side and the first edge taken is necessarily a crossbar hop.
+  int srcState = stateId(srcId, In);
+  distance[srcState] = 0.0;
+  Q.push(srcState);
   while (!Q.empty()) {
     int s = Q.top();
     Q.pop();
-    for (Edge &e : adjacency[s]) {
-      int dst = e.dst;
+    // In takes crossbar edges and lands on the Out side of the port it picks;
+    // Out takes the wire to the neighbour and lands on that tile's In side. Any
+    // other pairing would either turn the stream around inside a switchbox or
+    // ride a wire the crossbar was never set to drive.
+    const bool sIsOut = (s & 1) == Out;
+    for (Edge &e : adjacency[stateNode(s)]) {
+      const bool isIntra = e.sb->srcCoords == e.sb->dstCoords;
+      if (sIsOut == isIntra)
+        continue;
+      int dst = stateId(e.dst, isIntra ? Out : In);
       double w = e.sb->demand[e.i][e.j];
       bool relax = distance[s] + w < distance[dst];
       if (colors[dst] == WHITE) {
@@ -572,7 +581,7 @@ Pathfinder::findPaths(const int maxIterations) {
   if (!graphBuilt)
     buildRoutingGraph();
   // Stamp-based "processed" set (avoids O(n) clears per flow).
-  std::vector<uint32_t> processedStamp(nodes.size(), 0);
+  std::vector<uint32_t> processedStamp(2 * nodes.size(), 0);
   uint32_t curStamp = 0;
   // initialize all Channel histories to 0
   for (auto &[_, sb] : graph) {
@@ -650,14 +659,19 @@ Pathfinder::findPaths(const int maxIterations) {
         // increment used_capacity for the associated channels
         SwitchSettings switchSettings;
         ++curStamp;
-        processedStamp[srcId] = curStamp;
+        processedStamp[stateId(srcId, In)] = curStamp;
         for (auto endPoint : dsts) {
           if (endPoint == src) {
-            // route to self
+            // Route to self: the port is both ends, so there is no path to
+            // trace. The source was stamped on the In side, so falling through
+            // would trace back from an Out state Dijkstra never reached.
             switchSettings[src.coords].srcs.push_back(src.port);
             switchSettings[src.coords].dsts.push_back(src.port);
+            continue;
           }
-          int currId = nodeIds.at(endPoint);
+          // A destination port is driven by its switchbox, so it is reached on
+          // the Out side.
+          int currId = stateId(nodeIds.at(endPoint), Out);
           // trace backwards until a vertex already processed is reached
           while (processedStamp[currId] != curStamp) {
             // If Dijkstra never reached this node it has no predecessor; the
@@ -665,10 +679,10 @@ Pathfinder::findPaths(const int maxIterations) {
             // this iteration rather than indexing with a -1 predecessor.
             if (preds[currId] < 0)
               return std::nullopt;
-            const PathEndPoint &curr = nodes[currId];
+            const PathEndPoint &curr = nodes[stateNode(currId)];
             const Edge &e = predEdge[currId];
             int predId = preds[currId];
-            const PathEndPoint &pred = nodes[predId];
+            const PathEndPoint &pred = nodes[stateNode(predId)];
             SwitchboxConnect &sb = *e.sb;
             int i = e.i;
             int j = e.j;

--- a/test/create-flows/broadcast.mlir
+++ b/test/create-flows/broadcast.mlir
@@ -38,7 +38,7 @@
 // CHECK1: aie.flow(%[[T60]], DMA : 0, %[[T22]], DMA : 1)
 // CHECK1: aie.flow(%[[T60]], DMA : 0, %[[T02]], DMA : 1)
 
-// CHECK2: "total_path_length": 27
+// CHECK2: "total_path_length": 26
 
 module {
     aie.device(xcvc1902) {

--- a/test/create-flows/loc_preservation.mlir
+++ b/test/create-flows/loc_preservation.mlir
@@ -25,6 +25,9 @@ module {
 // Synthesized aie.connect ops inside switchboxes carry the FlowOp's loc.
 // CHECK-DAG: aie.connect<{{.*}}> loc(#[[FLOWLOC:loc[0-9]*]])
 // Synthesized aie.wire ops between switchboxes/tiles carry the tile's loc.
-// CHECK-DAG: aie.wire({{.*}}) loc(#[[TILELOC:loc[0-9]*]])
+// Name the tile: tiles the router synthesizes to complete a route have no
+// source loc, so an unanchored match would bind TILELOC to whichever wire the
+// chosen route happens to emit first.
+// CHECK-DAG: aie.wire(%tile_2_3 : Core, %switchbox_2_3 : Core) loc(#[[TILELOC:loc[0-9]*]])
 // CHECK-DAG: #[[FLOWLOC]] = loc("user_design.py":42:4)
 // CHECK-DAG: #[[TILELOC]] = loc("user_design.py":50:8)

--- a/test/create-flows/same_id_shared_link.mlir
+++ b/test/create-flows/same_id_shared_link.mlir
@@ -24,7 +24,7 @@
 
 // CHECK-LABEL: aie.device(npu2)
 
-// Destination tile: both id-0 streams arrive on separate input ports (North : 0
+// Destination tile: both id-0 streams arrive on separate input ports (North : 2
 // and North : 3) and fan in to the single DMA : 3 endpoint.
 // CHECK:      %[[mem_tile_1_1:.*]] = aie.tile(1, 1)
 // CHECK:      aie.switchbox(%[[mem_tile_1_1]]) {
@@ -32,7 +32,7 @@
 // CHECK-NEXT:   %[[b1:.*]] = aie.amsel<1> (0)
 // CHECK-NEXT:   aie.masterset(DMA : 3, %[[b1]])
 // CHECK-NEXT:   aie.masterset(North : 1, %[[b0]])
-// CHECK-NEXT:   aie.packet_rules(North : 0) {
+// CHECK-NEXT:   aie.packet_rules(North : 2) {
 // CHECK-NEXT:     aie.rule(31, 0, %[[b1]])
 // CHECK-NEXT:   }
 // CHECK-NEXT:   aie.packet_rules(North : 3) {
@@ -44,21 +44,21 @@
 // CHECK-NEXT: }
 
 // Merge tile: the two id-0 streams stay on distinct amsels, each driving exactly
-// one output port (North : 1 -> South : 3 via %[[a1]]; North : 3 -> South : 0 via
+// one output port (North : 2 -> South : 2 via %[[a1]]; East : 2 -> South : 3 via
 // %[[a2]]). No single amsel fans out to two ports.
 // CHECK:      %[[tile_1_2:.*]] = aie.tile(1, 2)
 // CHECK:      aie.switchbox(%[[tile_1_2]]) {
 // CHECK-NEXT:   %[[a0:.*]] = aie.amsel<0> (0)
 // CHECK-NEXT:   %[[a1:.*]] = aie.amsel<1> (0)
 // CHECK-NEXT:   %[[a2:.*]] = aie.amsel<2> (0)
-// CHECK-NEXT:   aie.masterset(South : 0, %[[a2]])
-// CHECK-NEXT:   aie.masterset(South : 3, %[[a1]])
-// CHECK-NEXT:   aie.masterset(East : 3, %[[a0]])
-// CHECK-NEXT:   aie.packet_rules(North : 3) {
-// CHECK-NEXT:     aie.rule(31, 0, %[[a2]])
-// CHECK-NEXT:   }
-// CHECK-NEXT:   aie.packet_rules(North : 1) {
+// CHECK-NEXT:   aie.masterset(South : 2, %[[a1]])
+// CHECK-NEXT:   aie.masterset(South : 3, %[[a2]])
+// CHECK-NEXT:   aie.masterset(East : 2, %[[a0]])
+// CHECK-NEXT:   aie.packet_rules(North : 2) {
 // CHECK-NEXT:     aie.rule(31, 0, %[[a1]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(East : 2) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a2]])
 // CHECK-NEXT:   }
 // CHECK-NEXT:   aie.packet_rules(South : 1) {
 // CHECK-NEXT:     aie.rule(31, 2, %[[a0]])

--- a/test/create-packet-flows/distinct_id_fanin_3way_npu1.mlir
+++ b/test/create-packet-flows/distinct_id_fanin_3way_npu1.mlir
@@ -12,56 +12,51 @@
 //
 // This pins the behaviour that PR #3472 deliberately kept. Channel sharing is
 // the entire point of packet flows, and it stays legal here precisely because
-// the ids differ:
+// the ids differ: ids that travel together can be told apart again downstream
+// by their rules, so they may ride one amsel and one link. Two same-id flows
+// could not be, which is why #3472 forces those onto disjoint paths instead.
 //
-//   tile_0_3  merges its own DMA:0 (id 1) with the incoming North:1 (id 2)
-//             onto a SINGLE amsel and a single link  -- sharing, allowed
-//   tile_0_2  splits that shared link back apart BY ID:
-//             rule(31, 2) -> its own amsel -> South:3
-//             rule(31, 1) -> its own amsel -> South:1
-//
-// Two same-id flows could not be split like this, which is why the id-gating
-// added in #3472 forces them onto disjoint paths instead. Note that no amsel
-// drives more than one master port in either test -- that invariant holds
-// regardless of whether links are shared.
+// The checks below follow the order the switchboxes are emitted in, which is
+// the shim first and then upward.
 
 // CHECK-LABEL: aie.device(npu1)
 
-// (Checks follow the order the switchboxes are emitted in, so the split point
-// at tile_0_2 is pinned before the merge point at tile_0_3 even though the data
-// flows the other way: tile_0_4 -> tile_0_3 -> tile_0_2 -> shim.)
+// The shim: all three ids converge on a single amsel and a single master port.
+// The rule(29, 0) cube covers ids 0 and 2 together -- the pair already merged
+// upstream -- and id 1 joins them here.
+// CHECK:      %[[shim:.*]] = aie.tile(0, 0)
+// CHECK:      aie.switchbox(%[[shim]]) {
+// CHECK-NEXT:   %[[sh:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:   aie.masterset(South : 2, %[[sh]])
+// CHECK-NEXT:   aie.packet_rules(North : 0) {
+// CHECK-NEXT:     aie.rule(29, 0, %[[sh]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(North : 1) {
+// CHECK-NEXT:     aie.rule(31, 1, %[[sh]])
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
-// The split point: the shared link is demultiplexed by packet id, each id onto
-// its own amsel and its own output port.
+// The upstream merge point: id 2 (arriving on North : 2) and id 0 (this tile's
+// own DMA) share ONE amsel and ONE master port. id 1 is kept on its own amsel.
 // CHECK:      %[[tile_0_2:.*]] = aie.tile(0, 2)
 // CHECK:      aie.switchbox(%[[tile_0_2]]) {
-// CHECK-NEXT:   %[[a0:.*]] = aie.amsel<0> (0)
-// CHECK-NEXT:   %[[a1:.*]] = aie.amsel<1> (0)
-// CHECK-NEXT:   %[[a2:.*]] = aie.amsel<2> (0)
-// CHECK-NEXT:   aie.masterset(South : 0, %[[a0]])
-// CHECK-NEXT:   aie.masterset(South : 1, %[[a1]])
-// CHECK-NEXT:   aie.masterset(South : 3, %[[a2]])
-// CHECK-NEXT:   aie.packet_rules(North : 1) {
-// CHECK-NEXT:     aie.rule(31, 2, %[[a2]])
-// CHECK-NEXT:     aie.rule(31, 1, %[[a1]])
+// CHECK-NEXT:   %[[shared:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:   %[[other:.*]] = aie.amsel<1> (0)
+// CHECK-NEXT:   aie.masterset(South : 0, %[[shared]])
+// CHECK-NEXT:   aie.masterset(South : 1, %[[other]])
+// CHECK-NEXT:   aie.packet_rules(North : 2) {
+// CHECK-NEXT:     aie.rule(31, 2, %[[shared]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(North : 0) {
+// CHECK-NEXT:     aie.rule(31, 1, %[[other]])
 // CHECK-NEXT:   }
 // CHECK-NEXT:   aie.packet_rules(DMA : 0) {
-// CHECK-NEXT:     aie.rule(31, 0, %[[a0]])
+// CHECK-NEXT:     aie.rule(31, 0, %[[shared]])
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-// The merge point: two flows with different ids share one amsel and one link.
-// CHECK:      %[[tile_0_3:.*]] = aie.tile(0, 3)
-// CHECK:      aie.switchbox(%[[tile_0_3]]) {
-// CHECK-NEXT:   %[[m:.*]] = aie.amsel<0> (0)
-// CHECK-NEXT:   aie.masterset(South : 1, %[[m]])
-// CHECK-NEXT:   aie.packet_rules(North : 1) {
-// CHECK-NEXT:     aie.rule(31, 2, %[[m]])
-// CHECK-NEXT:   }
-// CHECK-NEXT:   aie.packet_rules(DMA : 0) {
-// CHECK-NEXT:     aie.rule(31, 1, %[[m]])
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
+// No amsel drives more than one master port in either this test or its same-id
+// companion; that invariant holds regardless of whether links are shared.
 
 module {
   aie.device(npu1) {

--- a/test/create-packet-flows/incomplete_route_edge_merge.mlir
+++ b/test/create-packet-flows/incomplete_route_edge_merge.mlir
@@ -5,17 +5,42 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --verify-diagnostics %s
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
 
-// Regression test: the pathfinder must not SILENTLY drop a packet_source.
+// Regression test: the pathfinder must not drop a packet_source, silently or
+// otherwise.
 //
 // Five same-id packet sources merge into a single mem_tile S2MM DMA channel.
-// Same-id flows cannot share a switch channel, so each source needs its own path
-// to the destination. The congestion-aware pathfinder does not find a complete
-// assignment for this placement and drops one source's connection, producing an
-// incomplete routing. The design used to compile "successfully" while silently
-// delivering only four of the five sources on device. The pass must instead fail
-// loudly.
+// Same-id flows may not share a switch channel, so each source is pushed onto
+// its own crossbar entry into (0,1) DMA0. That congestion used to drive
+// Dijkstra onto a detour that leaves a switchbox on some "South N" and re-enters
+// the same switchbox on that same "South N" -- expressible only because a graph
+// node is (tile, bundle, channel) with no direction. The emitted route then
+// dead-ended and one source was reported unroutable.
+//
+// All five sources must arrive and merge onto DMA0.
+
+// Each source must land on its OWN input port -- same-id flows may not share a
+// channel -- and all five merge onto the one DMA : 0 endpoint via one amsel.
+// CHECK-LABEL: aie.switchbox(%mem_tile_0_1)
+// CHECK-NEXT:    %[[AMSEL:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:    aie.masterset(DMA : 0, %[[AMSEL]]) {keep_pkt_header = true}
+// CHECK-NEXT:    aie.packet_rules(North : 0) {
+// CHECK-NEXT:      aie.rule(31, 0, %[[AMSEL]])
+// CHECK-NEXT:    }
+// CHECK-NEXT:    aie.packet_rules(North : 3) {
+// CHECK-NEXT:      aie.rule(31, 0, %[[AMSEL]])
+// CHECK-NEXT:    }
+// CHECK-NEXT:    aie.packet_rules(North : 2) {
+// CHECK-NEXT:      aie.rule(31, 0, %[[AMSEL]])
+// CHECK-NEXT:    }
+// CHECK-NEXT:    aie.packet_rules(North : 1) {
+// CHECK-NEXT:      aie.rule(31, 0, %[[AMSEL]])
+// CHECK-NEXT:    }
+// CHECK-NEXT:    aie.packet_rules(South : 5) {
+// CHECK-NEXT:      aie.rule(31, 0, %[[AMSEL]])
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
 
 module {
   aie.device(npu2) {
@@ -25,7 +50,6 @@ module {
     %shim_noc_tile_4_0 = aie.tile(4, 0)
     %shim_noc_tile_5_0 = aie.tile(5, 0)
     %shim_noc_tile_6_0 = aie.tile(6, 0)
-    // expected-error @+1 {{could not be routed to destination}}
     aie.packet_flow(0) {
       aie.packet_source<%shim_noc_tile_2_0, DMA : 0>
       aie.packet_dest<%mem_tile_0_1, DMA : 0>

--- a/test/create-packet-flows/same_id_fanin_3way_npu1.mlir
+++ b/test/create-packet-flows/same_id_fanin_3way_npu1.mlir
@@ -29,20 +29,27 @@
 
 // CHECK-LABEL: aie.device(npu1)
 
-// Each source tile emits on exactly one master port, driven by exactly one amsel.
+// Every masterset below is fed by its own amsel, never a shared one. tile_0_2
+// carries two streams -- its own DMA:0 and tile_0_3's passing through -- so it
+// has two amsels and two master ports, one each.
 // CHECK:      %[[tile_0_2:.*]] = aie.tile(0, 2)
 // CHECK:      aie.switchbox(%[[tile_0_2]]) {
-// CHECK-NEXT:   %[[a:.*]] = aie.amsel<0> (0)
-// CHECK-NEXT:   aie.masterset(South : 2, %[[a]])
+// CHECK-NEXT:   %[[a0:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:   %[[a1:.*]] = aie.amsel<1> (0)
+// CHECK-NEXT:   aie.masterset(South : 1, %[[a1]])
+// CHECK-NEXT:   aie.masterset(South : 3, %[[a0]])
+// CHECK-NEXT:   aie.packet_rules(North : 3) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a1]])
+// CHECK-NEXT:   }
 // CHECK-NEXT:   aie.packet_rules(DMA : 0) {
-// CHECK-NEXT:     aie.rule(31, 0, %[[a]])
+// CHECK-NEXT:     aie.rule(31, 0, %[[a0]])
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 // CHECK:      %[[tile_0_3:.*]] = aie.tile(0, 3)
 // CHECK:      aie.switchbox(%[[tile_0_3]]) {
 // CHECK-NEXT:   %[[b:.*]] = aie.amsel<0> (0)
-// CHECK-NEXT:   aie.masterset(East : 0, %[[b]])
+// CHECK-NEXT:   aie.masterset(South : 3, %[[b]])
 // CHECK-NEXT:   aie.packet_rules(DMA : 0) {
 // CHECK-NEXT:     aie.rule(31, 0, %[[b]])
 // CHECK-NEXT:   }

--- a/test/create-packet-flows/same_id_fanin_4way_core_dest.mlir
+++ b/test/create-packet-flows/same_id_fanin_4way_core_dest.mlir
@@ -8,9 +8,9 @@
 // RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
 
 // Second geometry for the direction-alias routing bug, next to
-// incomplete_route_edge_merge.mlir. That one gathers five shim sources into a
-// mem tile; this one gathers four into a core tile, which has a different
-// switchbox topology (a mem tile has no East/West ports and only passes
+// same_id_fanin_5way_memtile_dest.mlir. That one gathers five shim sources
+// into a mem tile; this one gathers four into a core tile, which has a
+// different switchbox topology (a mem tile has no East/West ports and passes
 // North<->South on a matching channel). Both used to fail, so pinning only one
 // would let a fix that over-fits its shape through.
 //

--- a/test/create-packet-flows/same_id_fanin_4way_core_dest.mlir
+++ b/test/create-packet-flows/same_id_fanin_4way_core_dest.mlir
@@ -1,0 +1,75 @@
+//===- same_id_fanin_4way_core_dest.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// Second geometry for the direction-alias routing bug, next to
+// incomplete_route_edge_merge.mlir. That one gathers five shim sources into a
+// mem tile; this one gathers four into a core tile, which has a different
+// switchbox topology (a mem tile has no East/West ports and only passes
+// North<->South on a matching channel). Both used to fail, so pinning only one
+// would let a fix that over-fits its shape through.
+//
+// The router keys its graph on (tile, bundle, channel) with no direction, so a
+// single node stood for both a switchbox port's input side and its output side
+// and a path could take two crossbar hops in a row -- turning the stream around
+// inside one switchbox. Same-id fan-in is what surfaces it: same-id flows may
+// not share a channel, so each extra source is pushed off the cheap direct
+// entry until the two-edge aliased detour looks cheaper. The route that came
+// back then dead-ended and a source was reported unroutable.
+//
+// Note the threshold is congestion-dependent, not monotonic: before the fix
+// four and five sources here failed but six routed. Four is pinned because it
+// is the narrowest failing case at this geometry.
+//
+// All four sources must arrive, each on its own input port, and merge onto the
+// single DMA : 0 endpoint through one amsel.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK:      %[[tile_0_2:.*]] = aie.tile(0, 2)
+// CHECK:      aie.switchbox(%[[tile_0_2]]) {
+// CHECK-NEXT:   %[[a:.*]] = aie.amsel<0> (0)
+// CHECK-NEXT:   aie.masterset(DMA : 0, %[[a]]) {keep_pkt_header = true}
+// CHECK-NEXT:   aie.packet_rules(North : 3) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(North : 2) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(East : 0) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a]])
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.packet_rules(South : 4) {
+// CHECK-NEXT:     aie.rule(31, 0, %[[a]])
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+module {
+  aie.device(npu2) {
+    %d = aie.tile(0, 2)
+    %s0 = aie.tile(2, 0)
+    %s1 = aie.tile(3, 0)
+    %s2 = aie.tile(4, 0)
+    %s3 = aie.tile(5, 0)
+    aie.packet_flow(0) {
+      aie.packet_source<%s0, DMA : 0>
+      aie.packet_dest<%d, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%s1, DMA : 0>
+      aie.packet_dest<%d, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%s2, DMA : 0>
+      aie.packet_dest<%d, DMA : 0>
+    } {keep_pkt_header = true}
+    aie.packet_flow(0) {
+      aie.packet_source<%s3, DMA : 0>
+      aie.packet_dest<%d, DMA : 0>
+    } {keep_pkt_header = true}
+  }
+}

--- a/test/create-packet-flows/same_id_fanin_5way_memtile_dest.mlir
+++ b/test/create-packet-flows/same_id_fanin_5way_memtile_dest.mlir
@@ -1,4 +1,4 @@
-//===- incomplete_route_edge_merge.mlir ------------------------*- MLIR -*-===//
+//===- same_id_fanin_5way_memtile_dest.mlir --------------------*- MLIR -*-===//
 //
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -8,15 +8,25 @@
 // RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
 
 // Regression test: the pathfinder must not drop a packet_source, silently or
-// otherwise.
+// otherwise. Companion to same_id_fanin_4way_core_dest.mlir, which is the same
+// bug at a core-tile destination; a mem tile has no East/West ports and
+// passes North<->South only on a matching channel, so the two exercise
+// different switchbox topologies.
 //
 // Five same-id packet sources merge into a single mem_tile S2MM DMA channel.
 // Same-id flows may not share a switch channel, so each source is pushed onto
 // its own crossbar entry into (0,1) DMA0. That congestion used to drive
-// Dijkstra onto a detour that leaves a switchbox on some "South N" and re-enters
-// the same switchbox on that same "South N" -- expressible only because a graph
-// node is (tile, bundle, channel) with no direction. The emitted route then
-// dead-ended and one source was reported unroutable.
+// Dijkstra onto a detour that leaves a switchbox on some "South N" and then
+// re-enters the same switchbox on that same "South N" -- expressible only
+// because a graph node is (tile, bundle, channel) with no direction. The
+// emitted route then dead-ended and one source was reported unroutable.
+//
+// This file used to be named incomplete_route_edge_merge.mlir and asserted that
+// error, on the assumption that no complete assignment existed here. One does:
+// the route below is found by a search that is strictly more constrained than
+// the one that failed, over an unchanged graph. The pass still reports a
+// genuinely unroutable design loudly -- see
+// create-flows/unreachable_dest_err_test.mlir.
 //
 // All five sources must arrive and merge onto DMA0.
 

--- a/test/create-packet-flows/test_congestion_flow_pktflow_cascade_all_in_one.mlir
+++ b/test/create-packet-flows/test_congestion_flow_pktflow_cascade_all_in_one.mlir
@@ -21,25 +21,24 @@
 // CHECK:      aie.switchbox(%[[tile_0_0]]) {
 // CHECK-NEXT:   aie.connect<South : 3, North : 3>
 // CHECK-NEXT:   aie.connect<South : 7, North : 5>
-// CHECK-NEXT:   aie.connect<North : 3, South : 2>
+// CHECK-NEXT:   aie.connect<North : 2, South : 2>
 // CHECK-NEXT:   %[[v0:.*]] = aie.amsel<0> (0)
 // CHECK-NEXT:   aie.masterset(South : 3, %[[v0]]) {keep_pkt_header = true}
-// CHECK-NEXT:   aie.packet_rules(North : 2) {
+// CHECK-NEXT:   aie.packet_rules(North : 3) {
 // CHECK-NEXT:     aie.rule(31, 8, %[[v0]])
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
-
 // CHECK:      aie.switchbox(%[[tile_0_1]]) {
 // CHECK-NEXT:   aie.connect<South : 3, DMA : 0>
 // CHECK-NEXT:   aie.connect<South : 5, DMA : 1>
 // CHECK-NEXT:   aie.connect<DMA : 2, North : 5>
-// CHECK-NEXT:   aie.connect<North : 1, DMA : 2>
-// CHECK-NEXT:   aie.connect<DMA : 3, South : 3>
+// CHECK-NEXT:   aie.connect<North : 0, DMA : 2>
+// CHECK-NEXT:   aie.connect<DMA : 3, South : 2>
 // CHECK-NEXT:   %[[v0:.*]] = aie.amsel<0> (0)
 // CHECK-NEXT:   %[[v1:.*]] = aie.amsel<1> (0)
-// CHECK-NEXT:   aie.masterset(South : 2, %[[v1]])
+// CHECK-NEXT:   aie.masterset(South : 3, %[[v1]])
 // CHECK-NEXT:   aie.masterset(North : 1, %[[v0]])
-// CHECK-NEXT:   aie.packet_rules(North : 2) {
+// CHECK-NEXT:   aie.packet_rules(North : 3) {
 // CHECK-NEXT:     aie.rule(31, 8, %[[v1]])
 // CHECK-NEXT:   }
 // CHECK-NEXT:   aie.packet_rules(DMA : 0) {
@@ -55,7 +54,7 @@
 // CHECK-NEXT:   aie.connect<South : 1, DMA : 0>
 // CHECK-NEXT:   aie.connect<South : 5, DMA : 1>
 // CHECK-NEXT:   aie.connect<DMA : 2, North : 5>
-// CHECK-NEXT:   aie.connect<North : 1, DMA : 2>
+// CHECK-NEXT:   aie.connect<North : 3, DMA : 2>
 // CHECK-NEXT:   aie.connect<DMA : 3, South : 2>
 // CHECK-NEXT:   %[[v0:.*]] = aie.amsel<0> (0)
 // CHECK-NEXT:   aie.masterset(North : 1, %[[v0]])
@@ -89,7 +88,7 @@
 // CHECK-NEXT:   aie.connect<South : 0, DMA : 0>
 // CHECK-NEXT:   aie.connect<South : 1, DMA : 1>
 // CHECK-NEXT:   aie.connect<DMA : 2, North : 5>
-// CHECK-NEXT:   aie.connect<North : 1, DMA : 2>
+// CHECK-NEXT:   aie.connect<North : 3, DMA : 2>
 // CHECK-NEXT:   aie.connect<DMA : 3, South : 2>
 // CHECK-NEXT:   %[[v0:.*]] = aie.amsel<0> (0)
 // CHECK-NEXT:   aie.masterset(North : 1, %[[v0]])

--- a/test/create-packet-flows/test_create_packet_flows7.mlir
+++ b/test/create-packet-flows/test_create_packet_flows7.mlir
@@ -12,7 +12,7 @@
 // CHECK:        %[[TILE_1_2:.*]] = aie.tile(1, 2)
 // CHECK:        %{{.*}} = aie.switchbox(%[[TILE_1_2]]) {
 // CHECK:          %[[VAL0:.*]] = aie.amsel<0> (0)
-// CHECK:          %{{.*}} = aie.masterset(South : 0, %[[VAL0]])
+// CHECK:          %{{.*}} = aie.masterset(South : 3, %[[VAL0]])
 // CHECK:          aie.packet_rules(Trace : 0) {
 // CHECK:            aie.rule(31, 1, %[[VAL0]])
 // CHECK:          }
@@ -24,7 +24,7 @@
 // CHECK:        %{{.*}} = aie.switchbox(%[[TILE_0_0]]) {
 // CHECK:          %[[VAL1:.*]] = aie.amsel<0> (0)
 // CHECK:          %{{.*}} = aie.masterset(South : 3, %[[VAL1]]) {keep_pkt_header = true}
-// CHECK:          aie.packet_rules(East : 0) {
+// CHECK:          aie.packet_rules(East : 3) {
 // CHECK:            aie.rule(31, 1, %[[VAL1]])
 // CHECK:          }
 // CHECK:        }
@@ -35,16 +35,16 @@
 // CHECK:        %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:        %{{.*}} = aie.switchbox(%[[TILE_1_0]]) {
 // CHECK:          %[[VAL2:.*]] = aie.amsel<0> (0)
-// CHECK:          %{{.*}} = aie.masterset(West : 0, %[[VAL2]])
-// CHECK:          aie.packet_rules(North : 0) {
+// CHECK:          %{{.*}} = aie.masterset(West : 3, %[[VAL2]])
+// CHECK:          aie.packet_rules(North : 3) {
 // CHECK:            aie.rule(31, 1, %[[VAL2]])
 // CHECK:          }
 // CHECK:        }
 // CHECK:        %[[TILE_1_1:.*]] = aie.tile(1, 1)
 // CHECK:        %{{.*}} = aie.switchbox(%[[TILE_1_1]]) {
 // CHECK:          %[[VAL3:.*]] = aie.amsel<0> (0)
-// CHECK:          %{{.*}} = aie.masterset(South : 0, %[[VAL3]])
-// CHECK:          aie.packet_rules(North : 0) {
+// CHECK:          %{{.*}} = aie.masterset(South : 3, %[[VAL3]])
+// CHECK:          aie.packet_rules(North : 3) {
 // CHECK:            aie.rule(31, 1, %[[VAL3]])
 // CHECK:          }
 // CHECK:        }


### PR DESCRIPTION
## Problem

The router keys its graph on `PathEndPoint = (tile, bundle, channel)`. `Port` carries no direction, and `intraconnect()` pushes the same bundle into both `srcPorts` and `dstPorts`, so **one node stands for both a switchbox port's input side and its output side**.

Dijkstra could therefore chain two crossbar hops through that node and turn a stream around inside a switchbox. Each half is a legal connection; the chaining is not. A concrete bad path:

```
(2,0) DMA0  -> West0
(1,0) East0 -> NOC2      <-- NOC:2 as OUTPUT
(1,0) NOC2  -> West0     <-- NOC:2 as INPUT, same switchbox
(0,0) East0 -> North5
(0,1) South5 -> DMA0
```

`findPaths()` still reports success — this is not a convergence failure, `maxIterations` is never reached. It surfaces downstream as `srcRouted == false`:

```
'aie.packet_flow' op packet flow source (4, 0) DMA0 could not be routed to
destination (0, 2) DMA0; the pathfinder produced an incomplete routing for
this placement.
```

**Why it stayed hidden.** Same-id packet fan-in is what surfaces it: same-id flows may not share a channel, so each extra source is pushed off the cheap one-edge direct entry until the two-edge aliased detour undercuts it. The threshold is congestion-dependent and *not monotonic* — at one geometry four and five sources fail while six route.

## Fix

Search **states** rather than nodes. A state is a node plus the side of the port the stream is on:

```
In  --intra (crossbar)--> Out     (same tile)
Out --inter (wire)    --> In      (neighbour tile)
```

A source starts `In`; a destination is reached `Out`. This is what the rest of the pass already assumes — `findPathToDest()` walks exactly one `src->dst` setting pair per tile, and the shim mux is synthesized from that same single pair.

Crucially this **removes no edge**; it only restricts each edge to the side that can legally use it. That is what keeps distinct-id channel sharing (#3472) intact — an earlier attempt that deleted edges as a proxy for direction broke exactly that.

Route-to-self returns early: the source is stamped on the `In` side, so falling through would trace back from an `Out` state Dijkstra never reached. I could not construct an input where this changes output — wherever a self-route is legal at all, the self-connection makes the `Out` state reachable anyway — so this is hardening, not an observed bug.

## Tests

Two geometries, both of which fail before this change, kept together so a fix that over-fits one shape cannot pass:

- **`same_id_fanin_4way_core_dest.mlir` (new)** — four-way same-id gather into a **core tile**.
- **`same_id_fanin_5way_memtile_dest.mlir`** (renamed from `incomplete_route_edge_merge.mlir`) — five-way gather into a **mem tile**, which has a different topology (no East/West ports; North↔South only on a matching channel). Strengthened to pin the five *distinct* input ports rather than just counting rules.

Both were confirmed to fail without the code change, so they have teeth.

`loc_preservation.mlir` names the tile in its wire check: it bound its FileCheck variable to whichever `aie.wire` came first, and router-synthesized tiles have no source loc. It passes both before and after this change — a fragility fix, not an expectation update.

The remaining test updates are equal-cost routes re-picked because the search space changed. `broadcast.mlir` improves: `total_path_length` 27 → 26.

## Why the existing-test changes are not regressions

Every changed test was checked on four axes. **No test lost an assertion, lost delivery, or got a more expensive route:**

| Test | Delivered before → after | Route cost before → after | CHECK lines before → after |
|---|---|---|---|
| `same_id_fanin_5way_memtile_dest` | **0/5 → 5/5** | errored → 123 | 0 → 19 |
| `broadcast` | 8/8 → 8/8 | **37 → 36** | 29 → 29 |
| `distinct_id_fanin_3way_npu1` | 3/3 → 3/3 | **30 → 27** | 28 → 28 |
| `same_id_fanin_3way_npu1` | 3/3 → 3/3 | **45 → 39** | 25 → 30 |
| `test_congestion_flow_pktflow_cascade_all_in_one` | 65/65 → 65/65 | **245 → 236** | 87 → 87 |
| `same_id_shared_link` | 3/3 → 3/3 | 49 → 49 | 35 → 35 |
| `test_create_packet_flows7` | 1/1 → 1/1 | 13 → 13 | 40 → 40 |
| `loc_preservation` | 1/1 → 1/1 | 3 → 3 | 4 → 4 |

"Delivered" is an independent source→destination reachability check over the emitted switchbox/shim-mux settings, honouring packet-rule masks. "Cost" counts `amsel` + `masterset` + `connect` + `packet_rules`.

**The rewritten assertions still catch the bug each test was written for.** I injected the regression into the router output and confirmed FileCheck rejects it:

| Test | Injected regression | Result |
|---|---|---|
| `same_id_fanin_3way_npu1` | one amsel driving two master ports | **caught** |
| `same_id_shared_link` | one amsel driving two master ports | **caught** |
| `distinct_id_fanin_3way_npu1` | split the shared amsel (undo #3472) | **caught** |
| `same_id_fanin_5way_memtile_dest` | one source arriving on the wrong port | **caught** |

The documented invariants were also re-verified programmatically on the new output: zero amsel fan-out violations in the same-id tests, and three surviving id-sharing points in the distinct-id test (including all three ids on one amsel at the shim).

### The one inverted assertion

`same_id_fanin_5way_memtile_dest.mlir` — formerly `incomplete_route_edge_merge.mlir` — previously asserted `expected-error {{could not be routed to destination}}`. Its comment explained the reasoning: *"The congestion-aware pathfinder does not find a complete assignment for this placement ... The pass must instead fail loudly."*

Making the drop loud instead of silent was right. But the premise — that no complete assignment exists — was a misdiagnosis of this router bug. **This change cannot invent a route:** `buildRoutingGraph()` is untouched, so the node and edge sets are identical; the only edge-related change is the *read* in Dijkstra (`adjacency[s]` → `adjacency[stateNode(s)]`). The search is strictly more constrained, yet the input now routes 5/5. A route that appears under a strictly subtractive change must have existed all along — stock's Dijkstra simply preferred an illegal shortcut and dead-ended on it.

The loud-failure behaviour that test introduced is retained for genuinely unroutable designs: `unreachable_dest_err_test.mlir` still emits `Unable to find a legal routing` and still passes. What was removed is a false positive, not the diagnostic.

The file was renamed because "incomplete" described the bug rather than what is now checked: the routing it pins is complete (five sources, five distinct arrival ports, one merged endpoint). The new name also pairs it with `same_id_fanin_4way_core_dest.mlir` and matches the existing `same_id_fanin_3way_npu1` / `distinct_id_fanin_3way_npu1` convention. The former name is recorded in the file header.

### The remaining changes

`loc_preservation.mlir` is not an expectation update — it passes both before and after. It bound its FileCheck variable to whichever `aie.wire` appeared first, and router-synthesized tiles carry no source loc, so the binding was route-dependent by accident. Naming the tile makes it deterministic.

`test_create_packet_flows7.mlir` and `test_congestion_flow_pktflow_cascade_all_in_one.mlir` are port/channel renumbering only: same assertion count, same or better cost, identical delivery.

## Validation

| | Result |
|---|---|
| `check-aie` | Failure set **byte-identical to before** (24, all `No module named pytest`, **0 routing failures**) |
| Corpus A/B (`create-flows` + `create-packet-flows` + 3 large real designs, 57 inputs) | 2 repaired, **0 broken** |
| Per-flow delivery (source→dest reachability) | 55 unchanged, 2 repaired, **0 degraded** |
| Resource cost (amsel/masterset/connect/rules) | 49 identical, 5 better, 1 input +1 op |
| NPU2 hardware | Two LLM decode designs, both correctness PASS |

The hardware designs previously needed a hand-placed channel-floor attribute to route; with this fix they route without it.


