### PR TITLE
[AIE2PS] Add VE3858 target model

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEAttrs.td
+++ b/include/aie/Dialect/AIE/IR/AIEAttrs.td
@@ -19,132 +19,117 @@ include "mlir/IR/EnumAttr.td"
 // Overridden upstream attributes that return int instead of uint
 //===----------------------------------------------------------------------===//
 
-class AIETypedSignlessIntegerAttrBase<I attrValType, string retType, string descr>
+class AIETypedSignlessIntegerAttrBase<I attrValType, string retType,
+                                      string descr>
     : SignlessIntegerAttrBase<attrValType, descr> {
   let returnType = retType;
   let convertFromStorage = "$_self.getValue().getSExtValue()";
 }
 
-def AIEI8Attr  : AIETypedSignlessIntegerAttrBase<
-    I8,  "int8_t",  "8-bit signless integer attribute">;
-def AIEI16Attr : AIETypedSignlessIntegerAttrBase<
-    I16, "int16_t", "16-bit signless integer attribute">;
-def AIEI32Attr : AIETypedSignlessIntegerAttrBase<
-    I32, "int32_t", "32-bit signless integer attribute">;
-def AIEI64Attr : AIETypedSignlessIntegerAttrBase<
-    I64, "int64_t", "64-bit signless integer attribute">;
+def AIEI8Attr
+    : AIETypedSignlessIntegerAttrBase<I8, "int8_t",
+                                      "8-bit signless integer attribute">;
+def AIEI16Attr
+    : AIETypedSignlessIntegerAttrBase<I16, "int16_t",
+                                      "16-bit signless integer attribute">;
+def AIEI32Attr
+    : AIETypedSignlessIntegerAttrBase<I32, "int32_t",
+                                      "32-bit signless integer attribute">;
+def AIEI64Attr
+    : AIETypedSignlessIntegerAttrBase<I64, "int64_t",
+                                      "64-bit signless integer attribute">;
 
 //===----------------------------------------------------------------------===//
 // AIE attributes.
 //===----------------------------------------------------------------------===//
 
-def CoreWire:   I32EnumAttrCase<"Core", 0>;
-def DMAWire:    I32EnumAttrCase<"DMA", 1>;
-def FIFOWire:   I32EnumAttrCase<"FIFO", 2>;
-def SouthWire:  I32EnumAttrCase<"South", 3>;
-def WestWire:   I32EnumAttrCase<"West", 4>;
-def NorthWire:  I32EnumAttrCase<"North", 5>;
-def EastWire:   I32EnumAttrCase<"East", 6>;
-def PLIOWire:   I32EnumAttrCase<"PLIO", 7>;
-def NOCWire:    I32EnumAttrCase<"NOC", 8>;
-def TraceWire:  I32EnumAttrCase<"Trace", 9>;
-def TileControlWire:  I32EnumAttrCase<"TileControl", 10>;
+def CoreWire : I32EnumAttrCase<"Core", 0>;
+def DMAWire : I32EnumAttrCase<"DMA", 1>;
+def FIFOWire : I32EnumAttrCase<"FIFO", 2>;
+def SouthWire : I32EnumAttrCase<"South", 3>;
+def WestWire : I32EnumAttrCase<"West", 4>;
+def NorthWire : I32EnumAttrCase<"North", 5>;
+def EastWire : I32EnumAttrCase<"East", 6>;
+def PLIOWire : I32EnumAttrCase<"PLIO", 7>;
+def NOCWire : I32EnumAttrCase<"NOC", 8>;
+def TraceWire : I32EnumAttrCase<"Trace", 9>;
+def TileControlWire : I32EnumAttrCase<"TileControl", 10>;
+def Controller32Wire : I32EnumAttrCase<"Controller32", 11>;
 
-def WireBundle: I32EnumAttr<"WireBundle", "Bundle of wires",
-  [
-    CoreWire, DMAWire, FIFOWire, SouthWire, WestWire, NorthWire,
-    EastWire, PLIOWire, NOCWire, TraceWire, TileControlWire
-  ]> {
-
-  let cppNamespace = "xilinx::AIE";
-}
-
-def CascadeDir: I32EnumAttr<"CascadeDir", "Directions for cascade",
-  [
-    SouthWire, WestWire, NorthWire, EastWire
-  ]> {
+def WireBundle : I32EnumAttr<"WireBundle", "Bundle of wires",
+                             [CoreWire, DMAWire, FIFOWire, SouthWire, WestWire,
+                              NorthWire, EastWire, PLIOWire, NOCWire, TraceWire,
+                              TileControlWire, Controller32Wire]> {
 
   let cppNamespace = "xilinx::AIE";
 }
 
-def LockAction: I32EnumAttr<"LockAction", "lock acquire/release",
-  [
-    I32EnumAttrCase<"Acquire", 0>,
-    I32EnumAttrCase<"AcquireGreaterEqual", 2>,
-    I32EnumAttrCase<"Release", 1>,
-  ]> {
+def CascadeDir : I32EnumAttr<"CascadeDir", "Directions for cascade",
+                             [SouthWire, WestWire, NorthWire, EastWire]> {
 
   let cppNamespace = "xilinx::AIE";
 }
 
-def LockBlocking: I32EnumAttr<"LockBlocking", "lock operation is blocking",
-  [
-    I32EnumAttrCase<"NonBlocking", 0>,
-    I32EnumAttrCase<"Blocking", 1>
-  ]> {
+def LockAction : I32EnumAttr<"LockAction", "lock acquire/release",
+                             [I32EnumAttrCase<"Acquire", 0>,
+                              I32EnumAttrCase<"AcquireGreaterEqual", 2>,
+                              I32EnumAttrCase<"Release", 1>,
+]> {
 
   let cppNamespace = "xilinx::AIE";
 }
 
-def AIEArch: I32EnumAttr<"AIEArch", "AIE Architecture",
-  [
-    I32EnumAttrCase<"AIE1", 1>,
-    I32EnumAttrCase<"AIE2", 2>,
-    I32EnumAttrCase<"AIE2p", 3>,
-  ]> {
+def LockBlocking : I32EnumAttr<"LockBlocking", "lock operation is blocking",
+                               [I32EnumAttrCase<"NonBlocking", 0>,
+                                I32EnumAttrCase<"Blocking", 1>]> {
 
   let cppNamespace = "xilinx::AIE";
 }
 
-def AIETileType: I32EnumAttr<"AIETileType", "Type of AIE Tile",
-  [
-    I32EnumAttrCase<"CoreTile", 0>,
-    I32EnumAttrCase<"MemTile", 1>,
-    I32EnumAttrCase<"ShimNOCTile", 2>,
-    I32EnumAttrCase<"ShimPLTile", 3>,
-  ]> {
+def AIEArch
+    : I32EnumAttr<"AIEArch", "AIE Architecture",
+                  [I32EnumAttrCase<"AIE1", 1>, I32EnumAttrCase<"AIE2", 2>,
+                   I32EnumAttrCase<"AIE2p", 3>, I32EnumAttrCase<"AIE2ps", 4>,
+]> {
 
   let cppNamespace = "xilinx::AIE";
 }
 
-def AIEDevice: I32EnumAttr<"AIEDevice", "AIE Device",
-  [
-    I32EnumAttrCase<"xcvc1902", 1>,
-    I32EnumAttrCase<"xcve2302", 2>,
-    I32EnumAttrCase<"xcve2802", 3>,
-    I32EnumAttrCase<"npu1", 4>,
-    I32EnumAttrCase<"npu1_1col", 5>,
-    I32EnumAttrCase<"npu1_2col", 6>,
-    I32EnumAttrCase<"npu1_3col", 7>,
-    I32EnumAttrCase<"npu2", 8>,
-    I32EnumAttrCase<"npu2_1col", 9>,
-    I32EnumAttrCase<"npu2_2col", 10>,
-    I32EnumAttrCase<"npu2_3col", 11>,
-    I32EnumAttrCase<"npu2_4col", 12>,
-    I32EnumAttrCase<"npu2_5col", 13>,
-    I32EnumAttrCase<"npu2_6col", 14>,
-    I32EnumAttrCase<"npu2_7col", 15>,
-  ]> {
+def AIETileType
+    : I32EnumAttr<
+          "AIETileType", "Type of AIE Tile",
+          [I32EnumAttrCase<"CoreTile", 0>, I32EnumAttrCase<"MemTile", 1>,
+           I32EnumAttrCase<"ShimNOCTile", 2>, I32EnumAttrCase<"ShimPLTile", 3>,
+]> {
 
   let cppNamespace = "xilinx::AIE";
 }
 
-def ObjectFifoPort: I32EnumAttr<"ObjectFifoPort",
-  "Ports of an object FIFO",
-  [
-    I32EnumAttrCase<"Produce", 0>,
-    I32EnumAttrCase<"Consume", 1>
-  ]
-  > {
+def AIEDevice
+    : I32EnumAttr<
+          "AIEDevice", "AIE Device",
+          [I32EnumAttrCase<"xcvc1902", 1>, I32EnumAttrCase<"xcve2302", 2>,
+           I32EnumAttrCase<"xcve2802", 3>, I32EnumAttrCase<"npu1", 4>,
+           I32EnumAttrCase<"npu1_1col", 5>, I32EnumAttrCase<"npu1_2col", 6>,
+           I32EnumAttrCase<"npu1_3col", 7>, I32EnumAttrCase<"npu2", 8>,
+           I32EnumAttrCase<"npu2_1col", 9>, I32EnumAttrCase<"npu2_2col", 10>,
+           I32EnumAttrCase<"npu2_3col", 11>, I32EnumAttrCase<"npu2_4col", 12>,
+           I32EnumAttrCase<"npu2_5col", 13>, I32EnumAttrCase<"npu2_6col", 14>,
+           I32EnumAttrCase<"npu2_7col", 15>, I32EnumAttrCase<"xcve3858", 16>,
+]> {
+
   let cppNamespace = "xilinx::AIE";
 }
 
-def DMAChannelDir: I32EnumAttr<"DMAChannelDir",
-  "DMA Channel direction",
-  [
-    I32EnumAttrCase<"S2MM", 0>,
-    I32EnumAttrCase<"MM2S", 1>
-  ]> {
+def ObjectFifoPort : I32EnumAttr<"ObjectFifoPort", "Ports of an object FIFO",
+                                 [I32EnumAttrCase<"Produce", 0>,
+                                  I32EnumAttrCase<"Consume", 1>]> {
+  let cppNamespace = "xilinx::AIE";
+}
+
+def DMAChannelDir
+    : I32EnumAttr<"DMAChannelDir", "DMA Channel direction",
+                  [I32EnumAttrCase<"S2MM", 0>, I32EnumAttrCase<"MM2S", 1>]> {
   let cppNamespace = "xilinx::AIE";
 }
 

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -63,8 +63,7 @@ public:
     TK_AIE2_NPU1_1Col,
     TK_AIE2_NPU1_2Col,
     TK_AIE2_NPU1_3Col,
-    TK_AIE2_NPU1_4Col, // whole array must be last because of how we
-                       // cast/initialize the VirtualizedNPU1TargetModel class
+    TK_AIE2_NPU1_4Col,
     TK_AIE2_NPU1_Last,
     TK_AIE2_NPU2 = TK_AIE2_NPU1_Last,
     TK_AIE2_NPU2_1Col,
@@ -75,7 +74,9 @@ public:
     TK_AIE2_NPU2_6Col,
     TK_AIE2_NPU2_7Col,
     TK_AIE2_NPU2_Last,
-    TK_AIE2_Last = TK_AIE2_NPU2_Last,
+    TK_AIE2PS_VE3858 = TK_AIE2_NPU2_Last,
+    TK_AIE2PS_Last,
+    TK_AIE2_Last = TK_AIE2PS_Last,
   };
 
   // One-hot encoded list of target model properties.
@@ -83,7 +84,6 @@ public:
     // Device uses semaphore locks.
     UsesSemaphoreLocks = 1U << 0,
     // Device is an NPU-based device.
-    // There are several special cases for handling the NPU at the moment.
     IsNPU = 1U << 1,
     // Device model is virtualized.
     // This is used during CDO code generation to configure aie-rt properly.
@@ -134,6 +134,14 @@ public:
 
   /// Return the number of rows in the device.
   virtual int rows() const = 0;
+
+  /// Number of aie2ps/aie4 microcontrollers (uC) per column
+  virtual uint32_t getNumControllersPerColumn() const { return 0; }
+
+  /// Total number of aie2ps/aie4 microcontrollers (uC) in the device.
+  uint32_t getNumControllers() const {
+    return static_cast<uint32_t>(columns()) * getNumControllersPerColumn();
+  }
 
   /// Return the tile type for the given tile coordinates.
   /// - CoreTile: tiles with a Core, TileDMA, tile memory, and stream
@@ -794,6 +802,76 @@ public:
   getShimBurstEncodingsAndLengths() const override;
 };
 
+// AIE2PS base model
+class AIE2PSTargetModel : public AIE2TargetModel {
+public:
+  AIE2PSTargetModel(TargetModelKind k) : AIE2TargetModel(k) {
+    // AIE2PS is an NPU but uses CERT ELF, not CDO/xclbin.
+    addModelProperty(AIETargetModel::IsNPU);
+  }
+
+  AIEArch getTargetArch() const override { return AIEArch::AIE2ps; }
+
+  uint32_t getNumControllersPerColumn() const override { return 1; }
+
+  // AIE2PS supports 512B burst (same as AIE2P)
+  std::vector<std::pair<uint32_t, uint32_t>>
+  getShimBurstEncodingsAndLengths() const override {
+    return {std::pair(0, 64), std::pair(1, 128), std::pair(2, 256),
+            std::pair(3, 512)};
+  }
+
+  // TODO(aie2ps): AIE2PS changed block floating point from bfp16 to
+  // MX9/MX6/MX4. isSupportedBlockFormat() currently returns false (inherited).
+  // Override with correct MX format strings when ML kernels need it.
+
+  uint64_t getDmaBdAddress(int col, int row, uint32_t bd_id, int channel,
+                           AIE::DMAChannelDir direction) const override;
+  uint32_t getDmaControlAddress(int col, int row, int channel,
+                                AIE::DMAChannelDir direction) const override;
+
+  uint32_t getNumDestSwitchboxConnections(int col, int row,
+                                          WireBundle bundle) const override;
+  uint32_t getNumSourceSwitchboxConnections(int col, int row,
+                                            WireBundle bundle) const override;
+  std::optional<uint32_t> getStreamSwitchPortIndex(int col, int row,
+                                                   WireBundle bundle,
+                                                   uint32_t channel,
+                                                   bool master) const override;
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() >= TK_AIE2PS_VE3858 &&
+           model->getKind() < TK_AIE2PS_Last;
+  }
+};
+
+// VE3858 target model (AIE2PS, xc2ve3858 on VEK385)
+// 36 columns, 7 rows: 1 shim + 2 memtile + 4 core
+class VE3858TargetModel : public AIE2PSTargetModel {
+public:
+  VE3858TargetModel() : AIE2PSTargetModel(TK_AIE2PS_VE3858) {}
+
+  int columns() const override { return 36; }
+  int rows() const override { return 7; }
+
+  // AIE2PS Shim-South tiles (cols 1-23) have both NoC and PL.
+  // Shim-Global (col 0) has NoC only. Modeling all as ShimNOC is a working
+  // approximation for the CERT compilation path.
+  AIETileType getTileType(int col, int row) const override {
+    if (row == 0)
+      return AIETileType::ShimNOCTile;
+    if (row <= 2)
+      return AIETileType::MemTile;
+    return AIETileType::CoreTile;
+  }
+
+  uint32_t getNumMemTileRows() const override { return 2; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() == TK_AIE2PS_VE3858;
+  }
+};
+
 class VC1902TargetModel : public AIE1TargetModel {
   llvm::SmallDenseSet<unsigned, 16> nocColumns = {
       2, 3, 6, 7, 10, 11, 18, 19, 26, 27, 34, 35, 42, 43, 46, 47};
@@ -882,7 +960,6 @@ public:
 class BaseNPU1TargetModel : public AIE2TargetModel {
 public:
   BaseNPU1TargetModel(TargetModelKind k) : AIE2TargetModel(k) {
-    // Device properties initialization
     addModelProperty(AIETargetModel::IsNPU);
   }
 
@@ -932,7 +1009,6 @@ public:
 class BaseNPU2TargetModel : public AIE2TargetModel {
 public:
   BaseNPU2TargetModel(TargetModelKind k) : AIE2TargetModel(k) {
-    // Device properties initialization
     addModelProperty(AIETargetModel::IsNPU);
   }
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -182,6 +182,7 @@ xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
 static VC1902TargetModel VC1902model;
 static VE2302TargetModel VE2302model;
 static VE2802TargetModel VE2802model;
+static VE3858TargetModel VE3858model;
 static VirtualizedNPU1TargetModel NPUmodel1col(1);
 static VirtualizedNPU1TargetModel NPUmodel2col(2);
 static VirtualizedNPU1TargetModel NPUmodel3col(3);
@@ -238,6 +239,8 @@ const AIETargetModel &xilinx::AIE::getTargetModel(AIEDevice device) {
     return NPU2model6col;
   case AIEDevice::npu2_7col:
     return NPU2model7col;
+  case AIEDevice::xcve3858:
+    return VE3858model;
   }
   // No default: label above, so -Wswitch still reports a newly added device.
   // This handles values that are not enumerators at all, which

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -1619,5 +1619,63 @@ bool BaseNPU2TargetModel::isSupportedBlockFormat(
   return static_cast<bool>(supportedTypes.find(format) != supportedTypes.end());
 }
 
+// AIE2PS overrides: shim DMA registers are at different offsets than AIE2.
+// Memtile and core tile DMA addresses are identical to AIE2.
+uint64_t
+AIE2PSTargetModel::getDmaBdAddress(int col, int row, uint32_t bd_id,
+                                   int channel,
+                                   AIE::DMAChannelDir direction) const {
+  if (isShimNOCTile(col, row)) {
+    uint64_t offset = 0x00009000 + bd_id * 0x30;
+    return ((col & 0xff) << getColumnShift()) |
+           ((row & 0xff) << getRowShift()) | offset;
+  }
+  // Memtile and core tile use same addresses as AIE2.
+  return AIE2TargetModel::getDmaBdAddress(col, row, bd_id, channel, direction);
+}
+
+uint32_t
+AIE2PSTargetModel::getDmaControlAddress(int col, int row, int channel,
+                                        AIE::DMAChannelDir direction) const {
+  if (isShimNOCTile(col, row)) {
+    uint32_t offset = 0x00009300 + (channel * 0x8);
+    if (direction == AIE::DMAChannelDir::MM2S)
+      offset += 0x10;
+    return ((col & 0xff) << getColumnShift()) |
+           ((row & 0xff) << getRowShift()) | offset;
+  }
+  // Memtile and core tile use same addresses as AIE2.
+  return AIE2TargetModel::getDmaControlAddress(col, row, channel, direction);
+}
+
+// AIE2PS shim tiles have uC stream switch port for routing TCT to CERT uC.
+uint32_t
+AIE2PSTargetModel::getNumDestSwitchboxConnections(int col, int row,
+                                                  WireBundle bundle) const {
+  if (isShimNOCTile(col, row) && bundle == WireBundle::Controller32)
+    return 1;
+  return AIE2TargetModel::getNumDestSwitchboxConnections(col, row, bundle);
+}
+
+uint32_t
+AIE2PSTargetModel::getNumSourceSwitchboxConnections(int col, int row,
+                                                    WireBundle bundle) const {
+  if (isShimNOCTile(col, row) && bundle == WireBundle::Controller32)
+    return 1;
+  return AIE2TargetModel::getNumSourceSwitchboxConnections(col, row, bundle);
+}
+
+std::optional<uint32_t> AIE2PSTargetModel::getStreamSwitchPortIndex(
+    int col, int row, WireBundle bundle, uint32_t channel, bool master) const {
+  // AIE2PS shim: Controller32 maps to hw master port 22 / slave port 23.
+  if (isShimNOCTile(col, row) && bundle == WireBundle::Controller32) {
+    if (channel > 0)
+      return std::nullopt;
+    return master ? 22 : 23;
+  }
+  return AIE2TargetModel::getStreamSwitchPortIndex(col, row, bundle, channel,
+                                                   master);
+}
+
 } // namespace AIE
 } // namespace xilinx

--- a/test/CppTests/target_model.cpp
+++ b/test/CppTests/target_model.cpp
@@ -12,6 +12,16 @@
 
 using namespace xilinx;
 
+static void checkControllerTopology(AIE::AIEDevice device, uint32_t perColumn,
+                                    uint32_t total) {
+  const auto &model = AIE::getTargetModel(device);
+  if (model.getNumControllersPerColumn() != perColumn ||
+      model.getNumControllers() != total) {
+    throw std::runtime_error("Failed microcontroller topology check for " +
+                             stringifyAIEDevice(device).str());
+  }
+}
+
 void test() {
 
   // AIEDevice::xcvc1902
@@ -41,6 +51,7 @@ void test() {
   if (AIE::getTargetModel(AIE::AIEDevice::xcvc1902).rows() != 9) {
     throw std::runtime_error("Failed xcvc1902 rows");
   }
+  checkControllerTopology(AIE::AIEDevice::xcvc1902, 0, 0);
 
   // AIEDevice::xcve2302
   if (!AIE::getTargetModel(AIE::AIEDevice::xcve2302)
@@ -69,6 +80,7 @@ void test() {
   if (AIE::getTargetModel(AIE::AIEDevice::xcve2302).rows() != 4) {
     throw std::runtime_error("Failed xcve2302 rows");
   }
+  checkControllerTopology(AIE::AIEDevice::xcve2302, 0, 0);
 
   // AIEDevice::xcve2802
   if (!AIE::getTargetModel(AIE::AIEDevice::xcve2802)
@@ -97,6 +109,7 @@ void test() {
   if (AIE::getTargetModel(AIE::AIEDevice::xcve2802).rows() != 11) {
     throw std::runtime_error("Failed xcve2802 rows");
   }
+  checkControllerTopology(AIE::AIEDevice::xcve2802, 0, 0);
 
   // AIEDevice::npu_1col, npu_2col, npu_3col, npu_4col
   llvm::DenseMap<AIE::AIEDevice, int> npu1_devs;
@@ -130,6 +143,7 @@ void test() {
     if (AIE::getTargetModel(dev).rows() != 6) {
       throw std::runtime_error("Failed npu1_ncol rows");
     }
+    checkControllerTopology(dev, 0, 0);
   }
 
   // AIEDevice::npu2
@@ -159,6 +173,7 @@ void test() {
   if (AIE::getTargetModel(AIE::AIEDevice::npu2).rows() != 6) {
     throw std::runtime_error("Failed npu2 rows");
   }
+  checkControllerTopology(AIE::AIEDevice::npu2, 0, 0);
 
   // AIEDevice::npu2_1col, npu2_2col, npu2_3col, npu2_4col, npu2_5col,
   // npu2_6col, npu2_7col
@@ -196,6 +211,127 @@ void test() {
     if (AIE::getTargetModel(dev).rows() != 6) {
       throw std::runtime_error("Failed npu2_ncol rows");
     }
+    checkControllerTopology(dev, 0, 0);
+  }
+
+  // AIEDevice::xcve3858 (AIE2PS)
+  const auto &ve3858 = AIE::getTargetModel(AIE::AIEDevice::xcve3858);
+  if (!ve3858.hasProperty(AIE::AIETargetModel::UsesSemaphoreLocks)) {
+    throw std::runtime_error("Failed xcve3858 property check for "
+                             "'UsesSemaphoreLocks' returns false");
+  }
+  if (!ve3858.hasProperty(AIE::AIETargetModel::UsesMultiDimensionalBDs)) {
+    throw std::runtime_error("Failed xcve3858 property check for "
+                             "'UsesMultiDimensionalBDs' returns false");
+  }
+  if (!ve3858.hasProperty(AIE::AIETargetModel::IsNPU)) {
+    throw std::runtime_error(
+        "Failed xcve3858 property check for 'IsNPU' returns false");
+  }
+  checkControllerTopology(AIE::AIEDevice::xcve3858, 1, 36);
+  // if (ve3858.getUcGroupId(0) != 0 || ve3858.getUcGroupId(35) != 35)
+  //   throw std::runtime_error("Failed xcve3858 uC group-id mapping");
+
+  if (ve3858.hasProperty(AIE::AIETargetModel::IsVirtualized)) {
+    throw std::runtime_error(
+        "Failed xcve3858 property check for 'IsVirtualized' returns true");
+  }
+  if (ve3858.columns() != 36) {
+    throw std::runtime_error("Failed xcve3858 columns");
+  }
+  if (ve3858.rows() != 7) {
+    throw std::runtime_error("Failed xcve3858 rows");
+  }
+  if (ve3858.getTargetArch() != AIE::AIEArch::AIE2ps) {
+    throw std::runtime_error("Failed xcve3858 getTargetArch");
+  }
+  // Tile type checks: row 0 is shim, rows 1-2 are memory, and rows 3-6 are
+  // cores.
+  if (!ve3858.isShimNOCTile(0, 0)) {
+    throw std::runtime_error("Failed xcve3858 isShimNOCTile(0,0)");
+  }
+  if (!ve3858.isMemTile(0, 1) || !ve3858.isMemTile(0, 2)) {
+    throw std::runtime_error("Failed xcve3858 memory-tile layout");
+  }
+  if (!ve3858.isCoreTile(0, 3) || !ve3858.isCoreTile(35, 6)) {
+    throw std::runtime_error("Failed xcve3858 core-tile layout");
+  }
+  // Memory sizes (inherited from AIE2, verified against spec)
+  if (ve3858.getLocalMemorySize() != 0x10000) {
+    throw std::runtime_error("Failed xcve3858 getLocalMemorySize (expected "
+                             "64KB)");
+  }
+  if (ve3858.getMemTileSize() != 0x80000) {
+    throw std::runtime_error("Failed xcve3858 getMemTileSize (expected 512KB)");
+  }
+  // Lock counts (inherited from AIE2, verified against spec)
+  if (ve3858.getNumLocks(0, 0) != 16) {
+    throw std::runtime_error("Failed xcve3858 getNumLocks shim");
+  }
+  if (ve3858.getNumLocks(0, 1) != 64) {
+    throw std::runtime_error("Failed xcve3858 getNumLocks memtile");
+  }
+  if (ve3858.getNumLocks(0, 3) != 16) {
+    throw std::runtime_error("Failed xcve3858 getNumLocks core");
+  }
+  // BD counts (inherited from AIE2, verified against spec)
+  if (ve3858.getNumBDs(0, 0) != 16) {
+    throw std::runtime_error("Failed xcve3858 getNumBDs shim");
+  }
+  if (ve3858.getNumBDs(0, 1) != 48) {
+    throw std::runtime_error("Failed xcve3858 getNumBDs memtile");
+  }
+  if (ve3858.getNumBDs(0, 3) != 16) {
+    throw std::runtime_error("Failed xcve3858 getNumBDs core");
+  }
+  // Burst encodings: AIE2PS supports 512B (4 encodings, not 3)
+  auto bursts = ve3858.getShimBurstEncodingsAndLengths();
+  if (bursts.size() != 4) {
+    throw std::runtime_error("Failed xcve3858 burst encoding count "
+                             "(expected 4, got " +
+                             std::to_string(bursts.size()) + ")");
+  }
+  if (bursts[3].second != 512) {
+    throw std::runtime_error("Failed xcve3858 burst[3] should be 512B");
+  }
+
+  // AIE2PS-specific shim DMA register layout.
+  if (ve3858.getDmaBdAddress(2, 0, 3, 0, AIE::DMAChannelDir::S2MM) !=
+      ((uint64_t{2} << 25) | 0x9090)) {
+    throw std::runtime_error("Failed xcve3858 shim DMA BD address");
+  }
+  if (ve3858.getDmaControlAddress(2, 0, 1, AIE::DMAChannelDir::S2MM) !=
+      ((uint32_t{2} << 25) | 0x9308)) {
+    throw std::runtime_error("Failed xcve3858 shim S2MM control address");
+  }
+  if (ve3858.getDmaControlAddress(2, 0, 1, AIE::DMAChannelDir::MM2S) !=
+      ((uint32_t{2} << 25) | 0x9318)) {
+    throw std::runtime_error("Failed xcve3858 shim MM2S control address");
+  }
+
+  auto controllerMaster = ve3858.getStreamSwitchPortIndex(
+      0, 0, AIE::WireBundle::Controller32, 0, true);
+  auto controllerSlave = ve3858.getStreamSwitchPortIndex(
+      0, 0, AIE::WireBundle::Controller32, 0, false);
+  if (controllerMaster != 22 || controllerSlave != 23)
+    throw std::runtime_error("Failed xcve3858 controller port mapping");
+  if (ve3858.getNumDestSwitchboxConnections(
+          0, 0, AIE::WireBundle::Controller32) != 1 ||
+      ve3858.getNumSourceSwitchboxConnections(
+          0, 0, AIE::WireBundle::Controller32) != 1 ||
+      ve3858.getNumDestShimMuxConnections(0, 0,
+                                          AIE::WireBundle::Controller32) != 0 ||
+      ve3858.getNumSourceShimMuxConnections(0, 0,
+                                            AIE::WireBundle::Controller32) != 0)
+    throw std::runtime_error("Failed xcve3858 controller port connectivity");
+
+  if (ve3858.getStreamSwitchPortIndex(0, 0, AIE::WireBundle::Controller32, 1,
+                                      true))
+    throw std::runtime_error("Failed xcve3858 controller channel bounds");
+
+  // Cascade size
+  if (ve3858.getAccumulatorCascadeSize() != 512) {
+    throw std::runtime_error("Failed xcve3858 getAccumulatorCascadeSize");
   }
 }
 

--- a/test/CppTests/target_model_rtti.cpp
+++ b/test/CppTests/target_model_rtti.cpp
@@ -65,6 +65,28 @@ void test() {
     throw std::runtime_error("Failed xcve2802 !isa<>");
   }
 
+  // AIEDevice::xcve3858 (AIE2PS provisional)
+  if (!llvm::isa<AIE::VE3858TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve3858))) {
+    throw std::runtime_error("Failed xcve3858 isa<VE3858TargetModel>");
+  }
+  if (!llvm::isa<AIE::AIE2PSTargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve3858))) {
+    throw std::runtime_error("Failed xcve3858 isa<AIE2PSTargetModel>");
+  }
+  if (!llvm::isa<AIE::AIETargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve3858))) {
+    throw std::runtime_error("Failed xcve3858 isa<AIETargetModel>");
+  }
+  if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
+                AIE::VE2302TargetModel, AIE::VE2802TargetModel,
+                AIE::BaseNPU1TargetModel, AIE::BaseNPU2TargetModel,
+                AIE::VirtualizedNPU1TargetModel, AIE::NPU2TargetModel,
+                AIE::VirtualizedNPU2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve3858))) {
+    throw std::runtime_error("Failed xcve3858 !isa<>");
+  }
+
   // AIEDevice::npu1, AIEDevice::npu_1col, npu_2col, npu_3col, npu_4col
   llvm::SmallVector<AIE::AIEDevice> npu1_devs = {
       AIE::AIEDevice::npu1_1col, AIE::AIEDevice::npu1_2col,


### PR DESCRIPTION
## Description

Add the AIE2PS target-model family and a concrete VE3858 (`xcve3858`) device model.

- Model the 36-column, 7-row VE3858 array and its per-column CERT microcontrollers.
- Add the AIE2PS architecture/device enums and controller stream-switch bundle.
- Model AIE2PS shim DMA register addresses, 512-byte bursts, and controller port connectivity.
- Add controller-topology helpers shared by the CERT runtime stack.
- Extend target-model and RTTI C++ coverage for VE3858.

PR #3557 is stacked on this target-model foundation. The main purpose of this is to enable testing of multi-controller CERT programs. Hardware/board support is not enabled by this PR.
