### PR TITLE
Mark the HSA discovery tests unsupported on Windows

### DIFF
--- a/test/python/test_hsa_discovery.py
+++ b/test/python/test_hsa_discovery.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # RUN: %pytest %s
+# ROCm, and hence everything discovered here, exists only on Linux.
+# UNSUPPORTED: system-windows
 
 """Discovery of a ROCm install: explicit root, pip wheel, then system."""
 
@@ -114,47 +116,3 @@ def test_wheel_root_is_none_when_not_installed(monkeypatch):
     """_wheel_root must return None (not raise) when no ROCm wheel is present."""
     monkeypatch.setattr(discovery.importlib.util, "find_spec", lambda name: None)
     assert discovery._wheel_root() is None
-
-
-def _discovery_as_platform(monkeypatch, system):
-    """Re-import discovery privately, as if running on ``system``.
-
-    The platform gate is evaluated at import time, so it can only be exercised
-    by re-executing the module. This loads a throwaway copy under its own name
-    rather than reloading the shared one, so nothing leaks into other tests.
-    """
-    import importlib.util
-    import platform
-
-    monkeypatch.setattr(platform, "system", lambda: system)
-    spec = importlib.util.spec_from_file_location("_disc_probe", discovery.__file__)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def test_unsupported_platform_finds_nothing(tmp_path, monkeypatch):
-    """Off Linux there is no library layout to probe, so discovery declines.
-
-    ROCR's AIE agent is Linux-only. Discovery must report "no ROCm" even with a
-    plausible-looking tree in place, rather than matching a name that platform
-    would never use -- and ``/opt/rocm`` must not be probed there either.
-    """
-    _make_rocm_root(tmp_path / "rocm")
-    monkeypatch.setenv("ROCM_PATH", str(tmp_path / "rocm"))
-    windows = _discovery_as_platform(monkeypatch, "Windows")
-
-    assert windows._LIBHSA_PATTERNS == (), "no library names to probe off Linux"
-    assert windows._SYSTEM_ROOTS == (), "/opt/rocm is POSIX-only"
-    assert windows.find_libhsa() is None
-    assert windows.hsa_available() is False
-
-
-def test_supported_platform_probes_the_linux_layout(tmp_path, monkeypatch):
-    """The same gate must actually admit Linux, or the backend never loads."""
-    lib = _make_rocm_root(tmp_path / "rocm")
-    monkeypatch.setenv("ROCM_PATH", str(tmp_path / "rocm"))
-    linux = _discovery_as_platform(monkeypatch, "Linux")
-
-    assert linux._SYSTEM_ROOTS, "/opt/rocm must still be probed on Linux"
-    assert linux.find_libhsa() == str(lib)


### PR DESCRIPTION
Tests in `test/python/test_hsa_discovery.py` were failing on Windows.

## Why they failed

`discovery.py` answers one question: is there a ROCm install on this machine, and where is its `libhsa-runtime64.so`? It looks in three places, in a fixed priority order: `$ROCM_PATH`, then a pip-installed ROCm, then `/opt/rocm`. The tests check that order. Each one creates a fake ROCm tree in a temp dir, points discovery at it, and asserts that discovery picks the right one.

The module decides at import time which file names to look for:

```python
_LIBHSA_PATTERNS = ("libhsa-runtime64.so", ...) if _IS_LINUX else ()
```

Off Linux that tuple is empty, so `find_libhsa()` returns `None` whatever sits on disk. Seven tests assert that a fabricated tree *is* found, so all seven failed. They have never passed on Windows: the test and the module arrived together in #3452, whose Windows job also reported this failure.

## Fix

ROCR exposes its AIE agent only on Linux, so discovery has no Windows behaviour to pin down. The file now declares:

```
# UNSUPPORTED: system-windows
```

lit's `LLVMConfig` registers `system-windows` from the host platform, so the suite runs on Linux and lit reports it unsupported elsewhere.

An earlier revision of this PR instead kept the tests running everywhere, by re-importing `discovery.py` under a faked `platform.system()`. The author of the test suite confirmed that Windows is out of scope, so that revision is dropped, and so is the `_discovery_as_platform` helper it built on, together with the two tests that called it.

The diff is now 2 added lines and 44 deleted ones. The remaining ten tests are unchanged from main.
