### PR TITLE
[aiecc] Add link-time stack-size check for peano-compiled cores [MED]

### DIFF
--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -316,6 +316,10 @@ def compile_cxx_core_function(
             "-Wno-empty-body",
             "-O2",
             "-DNDEBUG",
+            # Per-function frame sizes into .stack_sizes, so aiecc's link-time
+            # stack check covers kernel objects and not just the core code it
+            # compiles itself.
+            "-fstack-size-section",
             # Have the compiler report what it actually read, the way ninja and
             # ccache learn a translation unit's real inputs.
             "-MD",

--- a/test/aiecc/Inputs/big_stack_kernel.c
+++ b/test/aiecc/Inputs/big_stack_kernel.c
@@ -1,0 +1,12 @@
+// Deliberately oversized frame: a 2048-byte local buffer whose address
+// escapes to a global, so the compiler cannot shrink it to just its touched
+// bytes. Stands in for a real kernel (conv accumulator, im2col scratch, ...)
+// whose frame exceeds a core's declared stack_size -- see
+// cpp_stack_size_overflow.mlir.
+volatile char *escape;
+void big_stack_kernel(void) {
+  char big[2048];
+  big[0] = 1;
+  big[2047] = 2;
+  escape = big;
+}

--- a/test/aiecc/cpp_stack_size_overflow.mlir
+++ b/test/aiecc/cpp_stack_size_overflow.mlir
@@ -1,0 +1,66 @@
+//===- cpp_stack_size_overflow.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Link-time stack-size gate: a linked kernel whose compiled frames exceed the
+// core's declared (here, default) stack_size must fail the build instead of
+// linking clean and silently overrunning the objectFIFO buffers the linker
+// places right above the stack. See big_stack_kernel.c: its 2048-byte local
+// buffer cannot be optimized away (the address escapes to a global), so it
+// reliably reports a 2048-byte frame under --stack-size-section.
+
+// REQUIRES: peano
+
+// RUN: clang --target=aie2-none-unknown-elf -O2 -fstack-size-section -c %S/Inputs/big_stack_kernel.c -o big_stack_kernel.o
+// RUN: not aiecc --get-core-elfs %s 2>&1 | FileCheck %s
+
+// CHECK: core (0, 2)'s compiled frames sum to an upper bound of {{[0-9]+}} bytes of stack, more than the 1024 bytes reserved
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+    func.func private @big_stack_kernel() attributes {link_with = "big_stack_kernel.o"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+      %c1_i32 = arith.constant 1 : i32
+
+      %subview_in = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_in = aie.objectfifo.subview.access %subview_in[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+
+      %subview_out = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_out = aie.objectfifo.subview.access %subview_out[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+
+      scf.for %i = %c0 to %c16 step %c1 {
+        %val = memref.load %elem_in[%i] : memref<16xi32>
+        %result = arith.addi %val, %c1_i32 : i32
+        memref.store %result, %elem_out[%i] : memref<16xi32>
+      }
+
+      func.call @big_stack_kernel() : () -> ()
+
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+
+    aie.runtime_sequence(%in : memref<16xi32>, %out : memref<16xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c16 = arith.constant 16 : i64
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_wait {symbol = @of_out}
+    }
+  }
+}

--- a/test/aiecc/cpp_stack_size_overflow_override.mlir
+++ b/test/aiecc/cpp_stack_size_overflow_override.mlir
@@ -1,0 +1,62 @@
+//===- cpp_stack_size_overflow_override.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Same oversized kernel as cpp_stack_size_overflow.mlir, but stack_size is
+// raised to cover it: the link-time stack-size gate must pass.
+
+// REQUIRES: peano
+
+// RUN: clang --target=aie2-none-unknown-elf -O2 -fstack-size-section -c %S/Inputs/big_stack_kernel.c -o big_stack_kernel.o
+// RUN: aiecc --get-core-elfs --verbose %s 2>&1 | FileCheck %s
+
+// CHECK: ({{[0-9]+}}/{{[0-9]+}}) elfs_{0}.elf.stackchecked
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+    func.func private @big_stack_kernel() attributes {link_with = "big_stack_kernel.o"}
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+      %c1_i32 = arith.constant 1 : i32
+
+      %subview_in = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_in = aie.objectfifo.subview.access %subview_in[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+
+      %subview_out = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elem_out = aie.objectfifo.subview.access %subview_out[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+
+      scf.for %i = %c0 to %c16 step %c1 {
+        %val = memref.load %elem_in[%i] : memref<16xi32>
+        %result = arith.addi %val, %c1_i32 : i32
+        memref.store %result, %elem_out[%i] : memref<16xi32>
+      }
+
+      func.call @big_stack_kernel() : () -> ()
+
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    } {stack_size = 4096 : i32}
+
+    aie.runtime_sequence(%in : memref<16xi32>, %out : memref<16xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c16 = arith.constant 16 : i64
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_wait {symbol = @of_out}
+    }
+  }
+}

--- a/tools/aiecc/Actions.h
+++ b/tools/aiecc/Actions.h
@@ -201,6 +201,10 @@ struct ShellCommand {
 
   std::string tool;
   std::vector<Part> parts;
+  // When set, the tool's stdout is written to the output file itself instead
+  // of the hidden diagnostics log -- for tools whose answer IS their stdout
+  // and that take no -o flag (e.g. `llvm-readelf --stack-sizes`).
+  bool captureStdoutToOutput = false;
 
   inline static std::vector<std::string> searchPaths;
   inline static std::map<std::string, std::string> toolPathCache;
@@ -362,6 +366,12 @@ struct ShellCommand {
     return *this;
   }
 
+  // Redirect the tool's stdout to the output file (see captureStdoutToOutput).
+  ShellCommand &captureStdout() {
+    captureStdoutToOutput = true;
+    return *this;
+  }
+
   // Uniform entry: takes any number of input Items (in bundle declaration
   // order) followed by the Item<File> output. Each input/value part consumes
   // the next source in order.
@@ -515,10 +525,13 @@ private:
       llvm::sys::Process::SafelyCloseFileDescriptor(logFd);
       capture = llvm::StringRef(logPath);
     }
+    std::optional<llvm::StringRef> stdoutTarget =
+        captureStdoutToOutput ? std::optional<llvm::StringRef>(outputFile)
+                              : capture;
     std::array<std::optional<llvm::StringRef>, 3> redirects = {
-        std::nullopt, capture, capture};
+        std::nullopt, stdoutTarget, capture};
     llvm::ArrayRef<std::optional<llvm::StringRef>> redirectRef;
-    if (capture)
+    if (capture || captureStdoutToOutput)
       redirectRef = redirects;
     int rc = llvm::sys::ExecuteAndWait(cmd[0], argv, std::nullopt, redirectRef,
                                        0, 0, &errMsg);

--- a/tools/aiecc/Utils.h
+++ b/tools/aiecc/Utils.h
@@ -25,6 +25,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
+#include <optional>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -186,6 +188,48 @@ inline std::vector<std::string> parseBcfIncludeFiles(llvm::StringRef bcf) {
     }
   }
   return files;
+}
+
+// Parse `llvm-readelf --stack-sizes`'s report into an upper bound on the
+// program's stack usage: the sum of every function's frame. Without the call
+// graph, a caller's frame could be sitting under any of the others, so the
+// sum is the only sound bound. Expected shape:
+//
+//   Stack Sizes:
+//        Size     Functions
+//          64     core_0_5, main
+//          32     some_func
+//
+// Returns nullopt on a shape this parser does not recognize: a loud build
+// failure beats a silent under-report.
+inline std::optional<uint32_t>
+parseStackSizesUpperBound(llvm::StringRef report) {
+  llvm::SmallVector<llvm::StringRef> lines;
+  report.split(lines, '\n');
+  size_t i = 0;
+  for (; i < lines.size() && lines[i].trim().empty(); ++i) {
+  }
+  if (i >= lines.size() || !lines[i].trim().starts_with("Stack Sizes:"))
+    return std::nullopt;
+  // The banner is followed by a "Size Functions" header. Check it rather than
+  // skipping two lines blind, so a report shaped otherwise is unparsable
+  // rather than short by its first row.
+  if (++i >= lines.size() || !lines[i].trim().starts_with("Size"))
+    return std::nullopt;
+  ++i;
+  uint64_t total = 0;
+  for (; i < lines.size(); ++i) {
+    llvm::StringRef line = lines[i].trim();
+    if (line.empty())
+      continue;
+    unsigned long long size;
+    if (line.split(' ').first.getAsInteger(10, size))
+      return std::nullopt;
+    total += size;
+  }
+  if (total > std::numeric_limits<uint32_t>::max())
+    return std::nullopt; // implausible; unparsable rather than silently wrapped
+  return static_cast<uint32_t>(total);
 }
 
 // Discover the aietools (Vitis AIE / Chess) install directory. Search order:

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -275,6 +275,9 @@ buildObjectSubgraph(EdgeWithTypedOutput<ModRef> &lowered,
       .value("--march=")
       .arg("--function-sections")
       .arg("--filetype=obj")
+      // Per-function frame size into a `.stack_sizes` section, so the link-time
+      // stack-size gate below (see peanoElfsChecked) has something to read.
+      .arg("--stack-size-section")
       .output("-o");
   EdgeWithTypedOutput<Directory> &peanoObject =
       bundle(opted.out, arches.out)
@@ -898,11 +901,83 @@ buildMainGraph(mlir::MLIRContext &context, Graph &g,
                   .output("-o"))
           .threadSafe();
 
+  // Link-time stack-size gate (peano only), mirroring iree-amd-aie's
+  // XCLBinGen.cpp getMaxStackSizeFromExecutable. CoreOp::verify() only rejects
+  // a stack_size that alone exceeds local memory; it cannot see whether the
+  // compiled code fits the reservation, and the linker places the stack
+  // directly below this tile's buffers with no clearance, so an overrun
+  // corrupts them silently instead of faulting.
+  auto &stackSizeReports =
+      peanoElfs
+          .map<File>("stacksizes_{0}.txt", ShellCommand{"llvm-readelf"}
+                                               .arg("--stack-sizes")
+                                               .input()
+                                               .captureStdout())
+          .threadSafe();
+  EdgeWithTypedOutput<Directory> &peanoElfsChecked =
+      bundle(stackSizeReports.out, peanoElfs.out, perCore.out)
+          .map<Directory>(
+              "elfs_{0}.elf.stackchecked",
+              [](const Item<File> &report, const Item<Directory> &elf,
+                 const Item<OpInModule<CoreOp>> &coreItem,
+                 Item<Directory> &out) -> mlir::LogicalResult {
+                CoreOp core = coreItem.get().op;
+                auto tile = mlir::cast<TileOp>(core.getTile().getDefiningOp());
+                // Under -n the readelf above only printed its command line, so
+                // there is no report to gate on.
+                if (dryRun) {
+                  out.value = elf.get();
+                  out.filePath = elf.filePath;
+                  return mlir::success();
+                }
+                auto buf = llvm::MemoryBuffer::getFile(report.asFile());
+                if (!buf) {
+                  llvm::errs() << "aiecc: could not read stack-size report '"
+                               << report.asFile()
+                               << "': " << buf.getError().message() << "\n";
+                  return mlir::failure();
+                }
+                std::optional<uint32_t> upperBound =
+                    parseStackSizesUpperBound((*buf)->getBuffer());
+                if (!upperBound) {
+                  llvm::errs() << "aiecc: could not parse llvm-readelf "
+                                  "--stack-sizes output for core ("
+                               << tile.getCol() << ", " << tile.getRow()
+                               << ") from '" << report.asFile() << "'\n";
+                  return mlir::failure();
+                }
+                uint32_t reserved = core.getEffectiveStackSize();
+                if (*upperBound > reserved) {
+                  llvm::errs()
+                      << "aiecc: core (" << tile.getCol() << ", "
+                      << tile.getRow()
+                      << ")'s compiled frames sum to an upper bound of "
+                      << *upperBound << " bytes of stack, more than the "
+                      << reserved
+                      << " bytes reserved (stack_size on the aie.core, or "
+                         "the target's default if unset). The linker places "
+                         "the stack directly below this tile's buffers with "
+                         "no clearance, so this overrun corrupts them "
+                         "silently instead of faulting. Raise stack_size on "
+                         "the core.\n";
+                  return mlir::failure();
+                }
+                out.value = elf.get();
+                out.filePath = elf.filePath;
+                return mlir::success();
+              })
+          .threadSafe();
+  // No new artifact -- this re-exposes peanoElfs's own ELF under a gate, same
+  // as preBakedElfs re-exposing an externally-built one (see its
+  // producesFiles=false above). Without this the engine's duplicate-output
+  // check trips: two edges, both producesFiles=true, claiming the same path.
+  peanoElfsChecked.producesFiles = false;
+
   // Fresh per-core ELFs (Chess/xbridge or Peano). Cores that already carry an
   // `elf_file` attribute are handled separately by `preBakedElfs` and merged
   // into `physicalWithElfs`.
   EdgeWithTypedOutput<Directory> &compiledElfs =
-      xbridge ? chessElfs : peanoElfs;
+      xbridge ? chessElfs : peanoElfsChecked;
 
   // --- Per-device configuration artifacts ---------------------------------
 


### PR DESCRIPTION
## Problem

`CoreOp::verify()` (added in #3496) only rejects a `stack_size` that alone exceeds local memory. It has no way to see whether the compiled CODE fits the reservation. The linker places the stack directly below this tile's objectFIFO buffers with zero clearance (`AIETargetLdScript.cpp`), so a frame that overruns a correct, small `stack_size` corrupts those buffers silently instead of faulting: no crash, deterministic, surviving tiles bit-exact. Upstream has hit this three times on real kernels (#2275, #2280, #2345), each just re-guessing the constant.

The fix is already half-built and unused. The ld script has emitted a `.stack_sizes` output section since #2417 (`AIETargetLdScript.cpp:167`), but nothing ever populates or reads it: `llc` is never passed `--stack-size-section`, so the section has been empty the whole time.

## Fix

Wire the existing plumbing up to an actual link-time gate, on the peano path:

1. `llc` gets `--stack-size-section`, so each function's frame size lands in `.stack_sizes` (the ld script already collects it into the linked ELF).
2. `ShellCommand` gains `captureStdout()`: `llvm-readelf --stack-sizes` has no `-o` flag, its answer is its stdout.
3. `compile_cxx_core_function` passes `-fstack-size-section` on its Peano branch, so the kernel objects the JIT builds carry their frames too. Without this the gate sees only the core code aiecc itself compiles, which is not where the big frames are.
4. A new edge runs `llvm-readelf --stack-sizes` on the linked ELF and sums every function's frame into an upper bound (same conservative choice, for the same reason, as iree-amd-aie's own `getMaxStackSize`, `XCLBinGen.cpp:126`: without the call graph, a caller's frame could sit under any of the others). It compares that bound against `CoreOp::getEffectiveStackSize()` and fails the build with the tile and both numbers if the code does not fit.

This mirrors iree-amd-aie's `getMaxStackSizeFromExecutable` (`XCLBinGen.cpp:697`). Chess/xbridge cores are unchecked, as they are there (`if (useChess)` skips the whole peano branch); cores carrying an `elf_file` attribute are unchecked here because aiecc does not compile them at all.

## Test

Two new lit tests plus `test/aiecc/Inputs/big_stack_kernel.c`: a 2048-byte local buffer whose address escapes to a global, so the compiler cannot shrink it away, linked into a core via `link_with`.

- `cpp_stack_size_overflow.mlir`: default `stack_size` (1024), expects `not aiecc` to fail with the new diagnostic.
- `cpp_stack_size_overflow_override.mlir`: same kernel, `stack_size = 4096`, expects a clean build.

Both pass under lit. Across the rest of the in-tree suite 58 cores went through the gate and none tripped: their frame sums are 0, 32, 64 or 128 bytes against the 1024-byte default.

The failure this closes is real: with the check removed, the same design links to a valid, loadable 2212-byte ELF whose `.stack_sizes` reports 2080 bytes (32 + 2048) against the 1024 reserved.

Also confirmed, since it was previously untested: `.stack_sizes` survives this driver's own `-Wl,--orphan-handling=error` -- non-allocatable sections with an explicit but region-less SECTIONS rule (`.comment`, `.symtab`, ...) are not orphans.

## Scope

A frame is visible to the gate only if it carries a `.stack_sizes` entry, which is why item 3 exists. Measured on a design linking `aie_kernels/aie2p/layer_norm.cc`: before that change the core reported 128 bytes, the kernel's own frame invisible; after it the kernel's frame is counted. A `link_with` object built by a hand-rolled compile line rather than by `compile_cxx_core_function` is still opt-in, and Chess is unaffected. `--gc-sections` runs before the check, so the bound is over the functions that survive into the ELF, not over the object.

No in-tree design is rejected by this check. That was not true when this was first written: `programming_examples/ml/norm` at `-o layer_f32` overran the 1024-byte default, which is what `run_strix.lit` had been timing out on, and the fix was pending in #3467. #3467 has since merged -- it sets `stack_size=2048` on that Worker and rewrites `layer_norm.cc`, and the frame it produces is now 320 bytes, so the design clears the default with room to spare and clears its explicit reservation by 6x.

Re-measured against the Peano this repo's CI actually pins (`llvm-aie==21.0.0.2026080301+c9c5ecb7`, `utils/peano-requirements.txt`), the kernels behind every design #3467 added:

| kernel | functions (frame bytes) | design's `stack_size` |
|---|---|---|
| `aie2p/layer_norm.cc` | `layer_norm` 512, `layer_norm_f32` 320, `layer_norm_affine_cast` 320 | 2048 (explicit) |
| `aie2p/exp2f_vec.cc` | `exp2f_vec_f32` 128, static helper 256 | 1024 (default) |
| `aie2p/cast_f32_bf16.cc` | `cast_f32_bf16_row` 0 | 1024 (default) |
| `aie2p/dwconv1d.cc` | `dwconv1d_bf16` 0 | 1024 (default) |

Identical byte-for-byte under the divergent Peano this was developed against, so the margins here are not an artifact of one toolchain pin.
