### PR TITLE
Run lit tests with lit's internal shell

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 # name: The name of this test suite.
 config.name = "AIE_PROGRAMMING_EXAMPLES"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".lit"]

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -20,7 +20,7 @@ from aie_lit_utils import LitConfigHelper
 # name: The name of this test suite.
 config.name = "AIE_PROGRAMMING_GUIDE"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".lit"]

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -25,7 +25,7 @@ from aie_lit_utils import LitConfigHelper
 # name: The name of this test suite.
 config.name = "AIE_TEST"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".mlir", ".py", ".test"]


### PR DESCRIPTION
lit's ShTest raises a fatal error for execute_external=True as of LLVM 23, and the option disappears in LLVM 24.

No test uses shell features beyond what the internal shell implements, so we can just turn off execute_external.
