### PR TITLE
[ci][test] Fix vitis lit tests broken by lit's internal shell (#3598)

### DIFF
--- a/test/unit_tests/aie2p/00_itsalive/aie.mlir
+++ b/test/unit_tests/aie2p/00_itsalive/aie.mlir
@@ -8,7 +8,7 @@
 // REQUIRES: aiesimulator
 
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s -- %S/test.cpp
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2P ISS
 // CHECK: Hello, world.

--- a/test/unit_tests/chess_compiler_tests/01_precompiled_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/01_precompiled_core_function/aie.mlir
@@ -10,7 +10,7 @@
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %aiecc --get-aiesim --xbridge --xchesscc %s %test_lib_flags -o test.elf -- %S/test.cpp
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/02_precompiled_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/02_precompiled_kernel/aie.mlir
@@ -10,7 +10,7 @@
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags -o test.elf -- %S/test.cpp
 // RUN: xchesscc_wrapper aie +l aie.mlir.prj/main_core_1_3.bcf %S/kernel.cc -o custom_1_3.elf
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/aie.mlir
@@ -10,7 +10,7 @@
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -o test.elf -- %S/test.cpp
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/04_shared_memory/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shared_memory/aie.mlir
@@ -9,7 +9,7 @@
 // REQUIRES: aiesimulator
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %extraAieCcFlags% -o test.elf -- %S/test.cpp
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shared_memory/aie_row.mlir
@@ -9,7 +9,7 @@
 // REQUIRES: aiesimulator
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s %test_lib_flags %extraAieCcFlags% -o test.elf -- %S/test.cpp
 // RUN: %run_on_board ./test.elf
-// RUN: aie_row.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie_row.mlir.prj/aiesim.sh | FileCheck %s
 
 // XFAIL: *
 

--- a/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
@@ -10,7 +10,7 @@
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags -o test.elf -- %S/test.cpp
 // RUN: xchesscc_wrapper aie +l aie.mlir.prj/main_core_7_3.bcf %S/kernel.cc -o custom_7_3.elf
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
@@ -10,7 +10,7 @@
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %aiecc --get-aiesim --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags -o test.elf -- %S/test.cpp
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
@@ -11,7 +11,7 @@
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags -o test.elf -- %S/test.cpp
 // RUN: %run_on_board ./test.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags -o test.elf -- %S/test.cpp
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: test start.
 // CHECK: after core start

--- a/test/unit_tests/chess_compiler_tests_aie2/01_precompiled_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/01_precompiled_core_function/aie.mlir
@@ -9,7 +9,7 @@
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %aiecc -v --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/02_precompiled_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/02_precompiled_kernel/aie.mlir
@@ -9,7 +9,7 @@
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
 // RUN: xchesscc_wrapper aie2 +l aie.mlir.prj/main_core_1_3.bcf %S/kernel.cc -o custom_1_3.elf
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/03_cascade_core_functions/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/03_cascade_core_functions/aie.mlir
@@ -9,7 +9,7 @@
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/03_simple/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/03_simple/aie.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
+// RUN: sh -c './aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie_row.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: aie_row.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie_row.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
@@ -11,7 +11,7 @@
 // RUN: xchesscc_wrapper aie2 +l aie.mlir.prj/main_core_7_3.bcf %S/kernel.cc -o custom_7_3.elf
 
 // FIXME: this hangs
-// UN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// UN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
@@ -11,7 +11,7 @@
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
 
 // FIXME this hangs in simulation
-// RU: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RU: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -10,7 +10,7 @@
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
 
-// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: ./aie.mlir.prj/aiesim.sh | FileCheck %s
 // CHECK: PASS!
 
 // XFAIL: *

--- a/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
+// RUN: sh -c './aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: Core [7, 3] AIE2 locks are: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0

--- a/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: aiesimulator, valid_xchess_license
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge %s %test_lib_flags -- %S/test.cpp
-// RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
+// RUN: sh -c './aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

lit's internal shell only resolves a bare relative path as cwd-relative when it starts with `./`; otherwise it falls back to a PATH search and raises "command not found". Prefix the generated aiesim.sh invocations with `./` so the chess_compiler_tests (and aie2p/00_itsalive) suites keep working now that ShTest() defaults to the internal shell.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
