### PR TITLE
aie_kernels: an argmax kernel, and a stale accumulator in vector_reduce_max [MED]

### DIFF
--- a/aie_kernels/aie2/argmax.cc
+++ b/aie_kernels/aie2/argmax.cc
@@ -1,0 +1,160 @@
+//===- argmax.cc ------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <stdint.h>
+#include <string.h>
+#include <type_traits>
+
+#include "../aie_kernel_utils.h"
+#include <aie_api/aie.hpp>
+
+// Index of the largest element of a tile, as the (partial, combine) pair that
+// aie2/reduce_max.cc already uses for a distributed max: every core runs
+// _argmax_* over its own slice and a tree merges the records with
+// _argmax_combine.
+//
+// A record is 8 bytes, written through an int32 output tile so that one
+// objectFIFO carries value and index together:
+//   out[0]  the winning value -- int32 as itself, bfloat16 widened to float and
+//           bit-cast, so the combine step can compare without the input tile
+//   out[1]  its index, already global: the caller passes the slice's
+//           index_offset, which makes combine order-independent
+//
+// Ties resolve to the lowest index, matching numpy.argmax. A NaN never compares
+// greater, so NaN inputs are skipped rather than returned -- numpy.argmax
+// returns the first NaN instead.
+
+template <typename T>
+using argmax_value_t =
+    std::conditional_t<std::is_same_v<T, int32_t>, int32_t, float>;
+
+template <typename T>
+static inline void _argmax_store(int32_t *restrict out, T value,
+                                 int32_t index) {
+  const argmax_value_t<T> widened = value;
+  memcpy(out, &widened, sizeof(widened));
+  out[1] = index;
+}
+
+// One streaming pass. Lane j only ever sees positions j, j+N, j+2N, ..., and a
+// strict `>` keeps the earliest of equal values within a lane, so the global
+// first-occurrence index is min(offset[j] + j) over the lanes still holding the
+// maximum -- resolved once, after the loop, not per step.
+//
+// The per-lane offsets are int16. That bounds a call at 32767 elements, which
+// no input tile can reach: 32767 bfloat16 is 64 KB, the whole of a core's data
+// memory, and the tail loop below takes any remainder.
+template <typename T, typename V>
+void _argmax_vector(T *restrict in, int32_t *restrict out,
+                    const int32_t input_size, const int32_t index_offset) {
+  event0();
+  constexpr int32_t N = V::size();
+  using Idx = aie::vector<int16_t, N>;
+  assert(input_size <= INT16_MAX);
+
+  alignas(64) int16_t lane_init[N];
+  for (int32_t k = 0; k < N; k++)
+    lane_init[k] = (int16_t)k;
+  const Idx lane = aie::load_v<N>(lane_init);
+
+  V running_max = aie::broadcast<T, N>(std::numeric_limits<T>::lowest());
+  Idx running_off = aie::zeros<int16_t, N>();
+  Idx offset = aie::zeros<int16_t, N>();
+  const Idx step = aie::broadcast<int16_t, N>((int16_t)N);
+
+  int32_t i = 0;
+  AIE_PREPARE_FOR_PIPELINING
+  AIE_LOOP_MIN_ITERATION_COUNT(2)
+  for (; i + N <= input_size; i += N) {
+    V next = aie::load_v<N>(in + i);
+    auto improved = aie::gt(next, running_max);
+    running_max = aie::select(running_max, next, improved);
+    running_off = aie::select(running_off, offset, improved);
+    offset = aie::add(offset, step);
+  }
+
+  T best = aie::reduce_max(running_max);
+  const Idx candidates =
+      aie::select(aie::broadcast<int16_t, N>(INT16_MAX),
+                  aie::add(running_off, lane), aie::eq(running_max, best));
+  int32_t best_index = (int32_t)aie::reduce_min(candidates);
+
+  for (; i < input_size;
+       i++) { // remainder: input_size need not be a multiple of N
+    if (in[i] > best) {
+      best = in[i];
+      best_index = i;
+    }
+  }
+
+  _argmax_store<T>(out, best, index_offset + best_index);
+  event1();
+}
+
+template <typename T>
+void _argmax_scalar(T *restrict in, int32_t *restrict out,
+                    const int32_t input_size, const int32_t index_offset) {
+  event0();
+  T best = std::numeric_limits<T>::lowest();
+  int32_t best_index = 0;
+  for (int32_t i = 0; i < input_size; i++) {
+    if (in[i] > best) { // strict >, so the first of equal values wins
+      best = in[i];
+      best_index = i;
+    }
+  }
+  _argmax_store<T>(out, best, index_offset + best_index);
+  event1();
+}
+
+template <typename TValue>
+void _argmax_combine(int32_t *restrict in1, int32_t *restrict in2,
+                     int32_t *restrict out) {
+  event0();
+  TValue v1, v2;
+  memcpy(&v1, in1, sizeof(v1));
+  memcpy(&v2, in2, sizeof(v2));
+  const bool take2 = (v2 > v1) || (v2 == v1 && in2[1] < in1[1]);
+  out[0] = take2 ? in2[0] : in1[0];
+  out[1] = take2 ? in2[1] : in1[1];
+  event1();
+}
+
+extern "C" {
+
+void argmax_vector_bfloat16(bfloat16 *a_in, int32_t *c_out, int32_t input_size,
+                            int32_t index_offset) {
+  _argmax_vector<bfloat16, aie::vector<bfloat16, 32>>(a_in, c_out, input_size,
+                                                      index_offset);
+}
+
+void argmax_scalar_bfloat16(bfloat16 *a_in, int32_t *c_out, int32_t input_size,
+                            int32_t index_offset) {
+  _argmax_scalar<bfloat16>(a_in, c_out, input_size, index_offset);
+}
+
+void argmax_combine_bfloat16(int32_t *a_in, int32_t *b_in, int32_t *c_out) {
+  _argmax_combine<float>(a_in, b_in, c_out);
+}
+
+void argmax_vector(int32_t *a_in, int32_t *c_out, int32_t input_size,
+                   int32_t index_offset) {
+  _argmax_vector<int32_t, aie::vector<int32_t, 16>>(a_in, c_out, input_size,
+                                                    index_offset);
+}
+
+void argmax_scalar(int32_t *a_in, int32_t *c_out, int32_t input_size,
+                   int32_t index_offset) {
+  _argmax_scalar<int32_t>(a_in, c_out, input_size, index_offset);
+}
+
+void argmax_combine(int32_t *a_in, int32_t *b_in, int32_t *c_out) {
+  _argmax_combine<int32_t>(a_in, b_in, c_out);
+}
+
+} // extern "C"

--- a/programming_examples/basic/README.md
+++ b/programming_examples/basic/README.md
@@ -23,6 +23,7 @@ These programming examples provide a good starting point to illustrate how to bu
 * [Vector Reduce Add](./vector_reduce_add) - Single tile reduction returning the `sum` of a vector.
 * [Vector Reduce Max](./vector_reduce_max) - Single tile reduction returning the `max` of a vector.
 * [Vector Reduce Min](./vector_reduce_min) - Single tile reduction returning the `min` of a vector.
+* [Vector Reduce Argmax](./vector_reduce_argmax) - Multi-core reduction returning the `index` of a vector's maximum.
 * [Vector Exp](./vector_exp) - Element-wise $e^x$ using the AIE look-up table capability.
 * [Vector Exp2f](./vector_exp2f) - Element-wise $2^x$ in f32 via a degree-5 minimax polynomial, a higher-accuracy alternative to the LUT-based `Vector Exp` for softmax-shaped accuracy needs.
 * [Matrix Scalar Add](./matrix_scalar_add) - Single tile adds a scalar constant to every element of a `16x128` matrix (processed in `8x16` tiles).

--- a/programming_examples/basic/vector_reduce_argmax/README.md
+++ b/programming_examples/basic/vector_reduce_argmax/README.md
@@ -1,0 +1,29 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//-->
+
+# Vector Reduce Argmax
+
+The argmax counterpart of [`vector_reduce_max`](../vector_reduce_max): the reduction returns *where* the maximum is, not just its value.
+
+The input streams through a memtile buffer split across 4 cores; each core folds its share into a running record and the records fold pairwise down the column, so core 0 emits one 8-byte `(value, index)` result whatever the input length. Both `bf16` and `i32` are supported.
+
+Ties resolve to the lowest index, matching `numpy.argmax`.
+
+## Source Files Overview
+
+1. `vector_reduce_argmax.py`: IRON design. Each core passes its slice's start as the kernel's `index_offset`, so every record leaves the core carrying a global index and the fold needs no per-core fixup. The first tile of a slice writes the running record outright rather than folding into it: a core-resident buffer keeps its value from the previous run of the same design, so seeding one with an identity record would make the result depend on run order.
+
+1. `argmax.cc`: kernel, pulled from [`aie_kernels/aie2/`](../../../aie_kernels/aie2/). `argmax_vector*` streams the tile once, carrying a per-lane running maximum and the offset at which each lane last improved, and resolves the position after the loop; `argmax_combine*` merges two records. The record is two `int32` slots -- the winning value (`int32` as itself, `bfloat16` widened to `float` and bit-cast) and its index -- so one ObjectFifo carries both.
+
+## Usage
+
+```shell
+python3 vector_reduce_argmax.py --dev npu2
+python3 vector_reduce_argmax.py --dev npu2 -dt i32 -i1s 524288
+```
+
+`in1_size` is in bytes and must be a whole number of 2048-element iterations; see `--help`.

--- a/programming_examples/basic/vector_reduce_argmax/run_strix.lit
+++ b/programming_examples/basic/vector_reduce_argmax/run_strix.lit
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: %run_on_npu2% %python %S/vector_reduce_argmax.py -d npu2
+// RUN: %run_on_npu2% %python %S/vector_reduce_argmax.py -d npu2 -dt i32
+// RUN: %run_on_npu2% %python %S/vector_reduce_argmax.py -d npu2 -i1s 524288

--- a/programming_examples/basic/vector_reduce_argmax/vector_reduce_argmax.py
+++ b/programming_examples/basic/vector_reduce_argmax/vector_reduce_argmax.py
@@ -202,11 +202,19 @@ def _run_and_verify(opts):
 
 def _validate(opts):
     dtype = str_to_dtype(opts.dtype)
-    elems = opts.in1_size // dtype(0).nbytes
-    if elems % N_MEM_ELEMS != 0:
+    nbytes = dtype(0).nbytes
+    if opts.in1_size % nbytes != 0:
+        sys.exit(
+            f"in1_size ({opts.in1_size} bytes) must be a whole number of "
+            f"{opts.dtype} elements"
+        )
+    elems = opts.in1_size // nbytes
+    # The design reads one tile before its loop, so anything short of a full
+    # tile -- zero included -- leaves that read waiting on a fill never sent.
+    if elems == 0 or elems % N_MEM_ELEMS != 0:
         sys.exit(
             f"in1_size ({opts.in1_size} bytes = {elems} {opts.dtype}) must be a "
-            f"whole number of {N_MEM_ELEMS}-element iterations"
+            f"positive whole number of {N_MEM_ELEMS}-element iterations"
         )
 
 

--- a/programming_examples/basic/vector_reduce_argmax/vector_reduce_argmax.py
+++ b/programming_examples/basic/vector_reduce_argmax/vector_reduce_argmax.py
@@ -1,0 +1,225 @@
+# vector_reduce_argmax/vector_reduce_argmax.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""Vector reduce-argmax, chained across one column — IRON API + ``@iron.jit``.
+
+The argmax counterpart of ``../vector_reduce_max/single_column_designs``:
+the input streams through a memtile buffer that is split across 4 cores,
+each core folds its share into a running (value, index) record, and the
+records fold pairwise down the column so core 0 emits the single winner.
+The host reads 8 bytes whatever the input length.
+
+Every record leaves a core carrying a GLOBAL index -- the kernel adds the
+``index_offset`` argument, which is the slice's start -- so the fold is
+order-independent and needs no per-core fixup on the host.
+
+Kernels come from the iron kernel library (``iron.kernels.argmax``,
+``iron.kernels.argmax_combine``); both factories share one ``.o``.
+
+Two invocation modes:
+
+  * standalone:   ``python3 vector_reduce_argmax.py``
+  * compile-only: ``... --xclbin-path=PATH --insts-path=PATH``
+"""
+
+import argparse
+import sys
+
+import aie.iron as iron
+import numpy as np
+from aie.iron import (
+    Buffer,
+    CompileTime,
+    In,
+    ObjectFifo,
+    Out,
+    Program,
+    Runtime,
+    Worker,
+    kernels,
+    str_to_dtype,
+)
+from aie.iron.controlflow import range_
+from aie.utils.hostruntime.argparse import add_compile_args, add_trace_arg
+from aie.utils.hostruntime.cli import run_design_cli
+
+N_CORES = 4
+# Elements staged in the memtile per iteration, split N_CORES ways.
+N_MEM_ELEMS = 2048
+# The record the kernel writes: [value bits, index], both int32.
+RECORD_ELEMS = 2
+RECORD_BYTES = RECORD_ELEMS * 4
+
+
+@iron.jit
+def vector_reduce_argmax(
+    a_in: In,
+    c_out: Out,
+    *,
+    in1_size: CompileTime[int] = 65536,
+    out_size: CompileTime[int] = RECORD_BYTES,
+    dtype_str: CompileTime[str] = "bf16",
+    trace_size: CompileTime[int] = 0,
+):
+    if out_size != RECORD_BYTES:
+        raise ValueError(f"Output buffer must be size {RECORD_BYTES} (value + index).")
+
+    dtype = str_to_dtype(dtype_str)
+    in_tensor_size = in1_size // dtype(0).nbytes
+    elems_per_core = N_MEM_ELEMS // N_CORES
+    num_iter = in_tensor_size // N_MEM_ELEMS
+
+    enable_trace = 1 if trace_size > 0 else 0
+
+    in_ty = np.ndarray[(in_tensor_size,), np.dtype[dtype]]
+    mem_ty = np.ndarray[(N_MEM_ELEMS,), np.dtype[dtype]]
+    op_ty = np.ndarray[(elems_per_core,), np.dtype[dtype]]
+    record_ty = np.ndarray[(RECORD_ELEMS,), np.dtype[np.int32]]
+
+    of_in = ObjectFifo(mem_ty, name="of_in")
+    in_fifos = of_in.cons().split(
+        [elems_per_core * i for i in range(N_CORES)],
+        obj_types=[op_ty] * N_CORES,
+        names=[f"memA{i}" for i in range(N_CORES)],
+    )
+    out_fifos = [ObjectFifo(record_ty, name=f"memC{i}") for i in range(N_CORES)]
+
+    argmax = kernels.argmax(tile_size=elems_per_core, dtype=dtype)
+    argmax_combine = kernels.argmax_combine(dtype=dtype)
+
+    zero_record = np.zeros(RECORD_ELEMS, dtype=np.int32)
+    partials = [
+        Buffer(type=record_ty, initial_value=zero_record) for _ in range(N_CORES)
+    ]
+    tmps = [Buffer(type=record_ty, initial_value=zero_record) for _ in range(N_CORES)]
+
+    def reduce_slice(of_in, argmax, argmax_combine, partial, tmp, first_index):
+        # The first iteration writes `partial` outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so seeding one with an identity record would make the
+        # result depend on run order.
+        elem_in = of_in.acquire(1)
+        argmax(elem_in, partial, elems_per_core, first_index)
+        of_in.release(1)
+        next_index = first_index + N_MEM_ELEMS
+        for i in range_(num_iter - 1):
+            elem_in = of_in.acquire(1)
+            argmax(elem_in, tmp, elems_per_core, next_index + i * N_MEM_ELEMS)
+            argmax_combine(partial, tmp, partial)
+            of_in.release(1)
+
+    # End of the chain: nothing to fold in, so this core's own record goes out.
+    def tail_core_body(
+        of_in, of_out, argmax, argmax_combine, partial, tmp, first_index
+    ):
+        reduce_slice(of_in, argmax, argmax_combine, partial, tmp, first_index)
+        elem_out = of_out.acquire(1)
+        elem_out[0] = partial[0]
+        elem_out[1] = partial[1]
+        of_out.release(1)
+
+    def core_body(
+        of_in, of_out, next_in, argmax, argmax_combine, partial, tmp, first_index
+    ):
+        reduce_slice(of_in, argmax, argmax_combine, partial, tmp, first_index)
+        elem_next = next_in.acquire(1)
+        elem_out = of_out.acquire(1)
+        argmax_combine(partial, elem_next, elem_out)
+        next_in.release(1)
+        of_out.release(1)
+
+    workers = []
+    for i in range(N_CORES):
+        common = [argmax, argmax_combine, partials[i], tmps[i], i * elems_per_core]
+        if i == N_CORES - 1:
+            fn_args = [in_fifos[i].cons(), out_fifos[i].prod()] + common
+            body = tail_core_body
+        else:
+            fn_args = [
+                in_fifos[i].cons(),
+                out_fifos[i].prod(),
+                out_fifos[i + 1].cons(),
+            ] + common
+            body = core_body
+        workers.append(Worker(body, fn_args=fn_args, trace=enable_trace))
+
+    def sequence(a, c, in_h, out_h):
+        in_h.fill(a)
+        out_h.drain(c, wait=True)
+
+    rt = Runtime(sequence, [in_ty, record_ty, of_in.prod(), out_fifos[0].cons()])
+    prog = Program(iron.get_current_device(), rt, workers=workers)
+    if trace_size > 0:
+        prog.enable_trace(trace_size)
+
+    return prog.resolve_program()
+
+
+def _make_argparser():
+    p = argparse.ArgumentParser(prog="AIE Vector Reduce Argmax")
+    add_compile_args(p)
+    p.add_argument("-i1s", "--in1_size", type=int, default=65536, help="bytes")
+    p.add_argument(
+        "-os", "--out_size", type=int, default=RECORD_BYTES, help="bytes (always 8)"
+    )
+    p.add_argument("-dt", "--dtype", type=str, default="bf16", choices=["i32", "bf16"])
+    add_trace_arg(p)
+    return p
+
+
+def _compile_kwargs(opts):
+    return dict(
+        in1_size=opts.in1_size,
+        out_size=opts.out_size,
+        dtype_str=opts.dtype,
+        trace_size=opts.trace_size,
+    )
+
+
+def _run_and_verify(opts):
+    dtype = str_to_dtype(opts.dtype)
+    num_elements = opts.in1_size // dtype(0).nbytes
+
+    rng = np.random.default_rng(0)
+    if opts.dtype == "i32":
+        in_np = rng.integers(-100000, 100000, size=(num_elements,), dtype=np.int32)
+    else:
+        in_np = rng.uniform(-1000.0, 1000.0, size=(num_elements,)).astype(dtype)
+    in_t = iron.tensor(in_np, dtype=dtype, device="npu")
+    out_t = iron.zeros(RECORD_ELEMS, dtype=np.int32, device="npu")
+
+    vector_reduce_argmax(in_t, out_t, **_compile_kwargs(opts))
+
+    actual = out_t.numpy()
+    expected = kernels.argmax_ref(in_np)
+    if not np.array_equal(actual, expected):
+        print(f"FAIL: expected record {expected}, got {actual}")
+        sys.exit(1)
+    print("PASS!")
+
+
+def _validate(opts):
+    dtype = str_to_dtype(opts.dtype)
+    elems = opts.in1_size // dtype(0).nbytes
+    if elems % N_MEM_ELEMS != 0:
+        sys.exit(
+            f"in1_size ({opts.in1_size} bytes = {elems} {opts.dtype}) must be a "
+            f"whole number of {N_MEM_ELEMS}-element iterations"
+        )
+
+
+def main():
+    opts = _make_argparser().parse_args()
+    run_design_cli(
+        vector_reduce_argmax,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+        validate=_validate,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/vector_reduce_max/multi_column_designs/col_wise_vector_reduce_max.py
+++ b/programming_examples/basic/vector_reduce_max/multi_column_designs/col_wise_vector_reduce_max.py
@@ -124,7 +124,13 @@ def vector_reduce_max(
         of_out = args[1]
         neighbor_of_in1s = args[2:-4]
 
-        for _ in range_(N_div_n):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in1 = of_in1.acquire(1)
+        reduce_max_vector(elem_in1, c_buffer, tile_size)
+        of_in1.release(1)
+        for _ in range_(N_div_n - 1):
             elem_in1 = of_in1.acquire(1)
             reduce_max_vector(elem_in1, tmp_buffer, tile_size)
             compute_max(c_buffer, tmp_buffer, c_buffer)

--- a/programming_examples/basic/vector_reduce_max/multi_column_designs/row_wise_vector_reduce_max.py
+++ b/programming_examples/basic/vector_reduce_max/multi_column_designs/row_wise_vector_reduce_max.py
@@ -46,7 +46,6 @@ from aie.utils.hostruntime.cli import run_design_cli
 from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
-
 # Per-core tile and core count; the CLI validator and the design share them.
 ELEMS_PER_CORE = 256
 N_CORES = 8

--- a/programming_examples/basic/vector_reduce_max/multi_column_designs/row_wise_vector_reduce_max.py
+++ b/programming_examples/basic/vector_reduce_max/multi_column_designs/row_wise_vector_reduce_max.py
@@ -122,7 +122,13 @@ def vector_reduce_max(
         of_out = args[1]
         in_fifos = args[2:-4]
 
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(nextC_buffer, tmp_buffer, nextC_buffer)

--- a/programming_examples/basic/vector_reduce_max/multi_column_designs/row_wise_vector_reduce_max.py
+++ b/programming_examples/basic/vector_reduce_max/multi_column_designs/row_wise_vector_reduce_max.py
@@ -47,6 +47,11 @@ from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
 
+# Per-core tile and core count; the CLI validator and the design share them.
+ELEMS_PER_CORE = 256
+N_CORES = 8
+
+
 @iron.jit
 def vector_reduce_max(
     a_in: In,
@@ -60,8 +65,8 @@ def vector_reduce_max(
     if out_size != 4:
         raise ValueError("Output buffer must be size 4 (4 bytes = 1 integer).")
 
-    n_cores = 8
-    elems_per_core = 256
+    n_cores = N_CORES
+    elems_per_core = ELEMS_PER_CORE
     n_channels = n_cores
     if n_cores > 8:
         raise ValueError("This design does not support more than 8 cores.")
@@ -238,8 +243,17 @@ def _run_and_verify(opts):
 
 
 def _validate(opts):
-    if opts.in1_size % 64 != 0 or opts.in1_size < 512:
-        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64 and >= 512")
+    if opts.in1_size % 64 != 0:
+        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64")
+    # Each core reads one tile before its loop, so an input shorter than the
+    # whole row leaves those reads waiting on fills that never come.
+    row = ELEMS_PER_CORE * N_CORES
+    elems = opts.in1_size // str_to_dtype(opts.dtype)(0).nbytes
+    if elems < row:
+        sys.exit(
+            f"in1_size ({opts.in1_size} bytes = {elems} {opts.dtype}) must hold at "
+            f"least one {row}-element row"
+        )
 
 
 def main():

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_chained.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_chained.py
@@ -44,6 +44,10 @@ from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
 
+# Elements per memtile tile; the CLI validator and the design share it.
+N_MEM_ELEMS = 2048
+
+
 @iron.jit
 def vector_reduce_max(
     a_in: In,
@@ -58,7 +62,7 @@ def vector_reduce_max(
         raise ValueError("Output buffer must be size 4 (4 bytes = 1 integer).")
 
     n_cores = 4
-    n_mem_elems = 2048
+    n_mem_elems = N_MEM_ELEMS
     elems_per_core = n_mem_elems // n_cores
 
     dtype = str_to_dtype(dtype_str)
@@ -239,8 +243,16 @@ def _run_and_verify(opts):
 
 
 def _validate(opts):
-    if opts.in1_size % 64 != 0 or opts.in1_size < 512:
-        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64 and >= 512")
+    if opts.in1_size % 64 != 0:
+        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64")
+    # The design reads one tile before its loop, so an input shorter than a
+    # tile leaves that read waiting on a fill that never comes.
+    elems = opts.in1_size // str_to_dtype(opts.dtype)(0).nbytes
+    if elems < N_MEM_ELEMS:
+        sys.exit(
+            f"in1_size ({opts.in1_size} bytes = {elems} {opts.dtype}) must hold at "
+            f"least one {N_MEM_ELEMS}-element tile"
+        )
 
 
 def main():

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_chained.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_chained.py
@@ -43,7 +43,6 @@ from aie.utils.hostruntime.cli import run_design_cli
 from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
-
 # Elements per memtile tile; the CLI validator and the design share it.
 N_MEM_ELEMS = 2048
 

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_chained.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_chained.py
@@ -113,7 +113,13 @@ def vector_reduce_max(
         of_in, of_out, reduce_max_vector, compute_max, nextC_buffer, tmp_buffer
     ):
         elem_out = of_out.acquire(1)
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(nextC_buffer, tmp_buffer, nextC_buffer)
@@ -124,7 +130,13 @@ def vector_reduce_max(
     def core_body(
         of_in, of_out, in0, reduce_max_vector, compute_max, nextC_buffer, tmp_buffer
     ):
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(nextC_buffer, tmp_buffer, nextC_buffer)

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_memtile.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_memtile.py
@@ -133,7 +133,13 @@ def vector_reduce_max(
         of_in, of_out, reduce_max_vector, compute_max, nextC_buffer, tmp_buffer
     ):
         elem_out = of_out.acquire(1)
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(tmp_buffer, nextC_buffer, nextC_buffer)
@@ -153,7 +159,13 @@ def vector_reduce_max(
         tmp_buffer,
     ):
         elem_out = elemC_out.acquire(1)
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(tmp_buffer, nextC_buffer, nextC_buffer)

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_memtile.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_memtile.py
@@ -50,6 +50,10 @@ from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
 
+# Elements per memtile tile; the CLI validator and the design share it.
+N_MEM_ELEMS = 2048
+
+
 @iron.jit
 def vector_reduce_max(
     a_in: In,
@@ -64,7 +68,7 @@ def vector_reduce_max(
         raise ValueError("Output buffer must be size 4 (4 bytes = 1 integer).")
 
     n_cores = 4
-    n_mem_elems = 2048
+    n_mem_elems = N_MEM_ELEMS
     elems_per_core = n_mem_elems // n_cores
 
     dtype = str_to_dtype(dtype_str)
@@ -272,8 +276,16 @@ def _run_and_verify(opts):
 
 
 def _validate(opts):
-    if opts.in1_size % 64 != 0 or opts.in1_size < 512:
-        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64 and >= 512")
+    if opts.in1_size % 64 != 0:
+        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64")
+    # The design reads one tile before its loop, so an input shorter than a
+    # tile leaves that read waiting on a fill that never comes.
+    elems = opts.in1_size // str_to_dtype(opts.dtype)(0).nbytes
+    if elems < N_MEM_ELEMS:
+        sys.exit(
+            f"in1_size ({opts.in1_size} bytes = {elems} {opts.dtype}) must hold at "
+            f"least one {N_MEM_ELEMS}-element tile"
+        )
 
 
 def main():

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_memtile.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_memtile.py
@@ -49,7 +49,6 @@ from aie.utils.hostruntime.cli import run_design_cli
 from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
-
 # Elements per memtile tile; the CLI validator and the design share it.
 N_MEM_ELEMS = 2048
 

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_shared.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_shared.py
@@ -43,7 +43,6 @@ from aie.utils.hostruntime.cli import run_design_cli
 from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
-
 # Elements per memtile tile; the CLI validator and the design share it.
 N_MEM_ELEMS = 2048
 

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_shared.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_shared.py
@@ -44,6 +44,10 @@ from aie.utils.verify import assert_pass
 from ml_dtypes import bfloat16
 
 
+# Elements per memtile tile; the CLI validator and the design share it.
+N_MEM_ELEMS = 2048
+
+
 @iron.jit
 def vector_reduce_max(
     a_in: In,
@@ -58,7 +62,7 @@ def vector_reduce_max(
         raise ValueError("Output buffer must be size 4 (4 bytes = 1 integer).")
 
     n_cores = 4
-    n_mem_elems = 2048
+    n_mem_elems = N_MEM_ELEMS
     elems_per_core = n_mem_elems // n_cores
 
     dtype = str_to_dtype(dtype_str)
@@ -250,8 +254,16 @@ def _run_and_verify(opts):
 
 
 def _validate(opts):
-    if opts.in1_size % 64 != 0 or opts.in1_size < 512:
-        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64 and >= 512")
+    if opts.in1_size % 64 != 0:
+        sys.exit(f"in1_size ({opts.in1_size}) must be a multiple of 64")
+    # The design reads one tile before its loop, so an input shorter than a
+    # tile leaves that read waiting on a fill that never comes.
+    elems = opts.in1_size // str_to_dtype(opts.dtype)(0).nbytes
+    if elems < N_MEM_ELEMS:
+        sys.exit(
+            f"in1_size ({opts.in1_size} bytes = {elems} {opts.dtype}) must hold at "
+            f"least one {N_MEM_ELEMS}-element tile"
+        )
 
 
 def main():

--- a/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_shared.py
+++ b/programming_examples/basic/vector_reduce_max/single_column_designs/vector_reduce_max_shared.py
@@ -115,7 +115,13 @@ def vector_reduce_max(
         of_in, of_out, nextC_buffer, tmp_buffer, reduce_max_vector, compute_max
     ):
         elem_out = of_out.acquire(1)
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(nextC_buffer, tmp_buffer, nextC_buffer)
@@ -133,7 +139,13 @@ def vector_reduce_max(
         of_out = args[1]
         in_fifos = args[2:-4]
 
-        for _ in range_(num_iter):
+        # The first tile writes the accumulator outright rather than folding into
+        # it: a core-resident buffer keeps its value from the previous run of the
+        # same design, so a seeded accumulator makes the result depend on run order.
+        elem_in = of_in.acquire(1)
+        reduce_max_vector(elem_in, nextC_buffer, elems_per_core)
+        of_in.release(1)
+        for _ in range_(num_iter - 1):
             elem_in = of_in.acquire(1)
             reduce_max_vector(elem_in, tmp_buffer, elems_per_core)
             compute_max(nextC_buffer, tmp_buffer, nextC_buffer)

--- a/python/iron/kernels/__init__.py
+++ b/python/iron/kernels/__init__.py
@@ -7,7 +7,7 @@
 
 Submodules:
 - `eltwise` — passthrough, scale, add, mul, relu
-- `reduce` — reduce_add, reduce_min, reduce_max, compute_max
+- `reduce` — reduce_add, reduce_min, reduce_max, compute_max, argmax, argmax_combine
 - `vision` — rgba2hue, threshold, bitwise_or, bitwise_and, gray2rgba, rgba2gray, filter2d, add_weighted
 - `activation`: softmax, gelu, silu, swiglu, bf16_exp, exp2f_vec
 - `linalg` — mm, mv, cascade_mm  (mm/mv expose ``.zero`` for the companion zero-fill kernel)
@@ -50,7 +50,15 @@ from .conv import (
 )
 from .eltwise import add, mul, passthrough, relu, scale
 from .linalg import cascade_mm, mm, mv
-from .reduce import compute_max, reduce_add, reduce_max, reduce_min
+from .reduce import (
+    argmax,
+    argmax_combine,
+    argmax_ref,
+    compute_max,
+    reduce_add,
+    reduce_max,
+    reduce_min,
+)
 from .vision import (
     add_weighted,
     bitwise_and,
@@ -71,6 +79,9 @@ __all__ = [
     "reduce_min",
     "reduce_max",
     "compute_max",
+    "argmax",
+    "argmax_combine",
+    "argmax_ref",
     "relu",
     "rgba2hue",
     "threshold",

--- a/python/iron/kernels/reduce.py
+++ b/python/iron/kernels/reduce.py
@@ -267,8 +267,13 @@ def argmax_ref(x, index_offset: int = 0):
     if np.dtype(x.dtype) == np.dtype(np.int32):
         finite, value_dtype = x.astype(np.int64), np.int32
     else:
-        finite = np.nan_to_num(x.astype(np.float64), nan=-np.inf)
         value_dtype = np.float32
+        finite = np.nan_to_num(x.astype(np.float64), nan=-np.inf)
+        if not np.isfinite(finite).any():
+            # Nothing ever compares greater, so the kernel keeps the value its
+            # accumulator started at and the index it started at.
+            lowest = np.asarray(np.finfo(value_dtype).min, dtype=value_dtype)
+            return np.array([lowest.view(np.int32), index_offset], dtype=np.int32)
     index = int(np.argmax(finite))
     value = np.asarray(x[index], dtype=value_dtype)
     return np.array([value.view(np.int32), index + index_offset], dtype=np.int32)

--- a/python/iron/kernels/reduce.py
+++ b/python/iron/kernels/reduce.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-"""Reduction kernel factories: reduce_add, reduce_min, reduce_max, compute_max."""
+"""Reduction kernel factories: reduce_add, reduce_min, reduce_max, compute_max, argmax."""
 
 import numpy as np
 from aie.iron.kernel import ExternalFunction
@@ -15,6 +15,12 @@ from ._common import _default_source_path, _make_extern, _min_dma_aligned_elems
 # output object name so multiple factory calls in the same design share
 # one compile (no duplicate-symbol link errors).
 _REDUCE_MAX_OBJ = "reduce_max.cc.o"
+
+# argmax() and argmax_combine() both live in argmax.cc; same reasoning.
+_ARGMAX_OBJ = "argmax.cc.o"
+
+# The argmax kernel indexes inside a tile with int16 lanes.
+_ARGMAX_MAX_TILE = 32767
 
 
 def _reduce_kernel(
@@ -152,3 +158,117 @@ def compute_max(dtype: type = np.int32) -> ExternalFunction:
         [out_ty, out_ty, out_ty],
         shared_object_file_name=_REDUCE_MAX_OBJ,
     )
+
+
+def _argmax_dtype(factory_name: str, dtype):
+    """Validate an argmax dtype and return the concrete numpy/ml_dtypes type."""
+    if np.dtype(dtype) == np.dtype(bfloat16):
+        return bfloat16
+    if np.dtype(dtype) == np.dtype(np.int32):
+        return np.int32
+    raise ValueError(
+        f"{factory_name}() dtype must be np.int32 or bfloat16, got {dtype}"
+    )
+
+
+def argmax(
+    tile_size: int = 1024, dtype: type = np.int32, vectorized: bool = True
+) -> ExternalFunction:
+    """Reduction kernel: index of the largest element of a tile.
+
+    The partial half of a distributed argmax, in the same shape as
+    [`reduce_max`][iron.kernels.reduce.reduce_max] +
+    [`compute_max`][iron.kernels.reduce.compute_max]: each core runs this over
+    its own slice and a tree merges the records with
+    [`argmax_combine`][iron.kernels.reduce.argmax_combine].
+
+    The kernel writes a 2-element int32 record — ``out[0]`` the winning value
+    (int32 as itself, bfloat16 widened to float and bit-cast), ``out[1]`` its
+    index. The index is global: the kernel adds the ``index_offset`` runtime
+    argument, so the combine step is order-independent.
+    ``argmax_ref()`` builds the same record in numpy.
+
+    Ties resolve to the lowest index, matching ``numpy.argmax``. A NaN never
+    compares greater, so NaN inputs are skipped rather than returned.
+
+    Args:
+        tile_size: Number of elements in the input slice. Any size up to
+            32767 -- the kernel's vector path indexes lanes with int16 and
+            takes the remainder in a scalar tail.
+        dtype: Element data type (``np.int32`` or ``bfloat16``).
+        vectorized: If ``True`` use vectorized path; ``False`` selects scalar.
+
+    Returns:
+        ExternalFunction configured for the argmax kernel; signature is
+        ``(in_ty, out_ty, int32 tile_size, int32 index_offset)``.
+
+    Raises:
+        ValueError: When ``dtype`` is not ``np.int32`` or ``bfloat16``, or
+            ``tile_size`` is not in 1..32767.
+    """
+    actual_dtype = _argmax_dtype("argmax", dtype)
+    if not 0 < tile_size <= _ARGMAX_MAX_TILE:
+        raise ValueError(
+            f"argmax() tile_size must be in 1..{_ARGMAX_MAX_TILE} (the kernel "
+            f"indexes a tile with int16 lanes), got {tile_size}"
+        )
+
+    in_ty = np.ndarray[(tile_size,), np.dtype[actual_dtype]]
+    out_ty = np.ndarray[(2,), np.dtype[np.int32]]
+    func_variant = "vector" if vectorized else "scalar"
+    suffix = "_bfloat16" if np.dtype(actual_dtype) == np.dtype(bfloat16) else ""
+    return _make_extern(
+        f"argmax_{func_variant}{suffix}",
+        _default_source_path("argmax.cc"),
+        [in_ty, out_ty, np.int32, np.int32],
+        shared_object_file_name=_ARGMAX_OBJ,
+    )
+
+
+def argmax_combine(dtype: type = np.int32) -> ExternalFunction:
+    """Pairwise record merge — companion to [`argmax`][iron.kernels.reduce.argmax].
+
+    Takes two of the records described in [`argmax`][iron.kernels.reduce.argmax]
+    and keeps the one with the larger value, or the lower index when the values
+    are equal. Both operands carry global indices, so the merge order does not
+    affect the result.
+
+    Args:
+        dtype: Element data type of the ORIGINAL input (``np.int32`` or
+            ``bfloat16``); it selects how ``out[0]`` is interpreted.
+
+    Returns:
+        ExternalFunction configured for the ``argmax_combine`` kernel;
+        signature is ``(out_ty, out_ty, out_ty)`` where ``out_ty`` is a
+        2-element int32 record.
+
+    Raises:
+        ValueError: When ``dtype`` is not ``np.int32`` or ``bfloat16``.
+    """
+    actual_dtype = _argmax_dtype("argmax_combine", dtype)
+    rec_ty = np.ndarray[(2,), np.dtype[np.int32]]
+    suffix = "_bfloat16" if np.dtype(actual_dtype) == np.dtype(bfloat16) else ""
+    return _make_extern(
+        f"argmax_combine{suffix}",
+        _default_source_path("argmax.cc"),
+        [rec_ty, rec_ty, rec_ty],
+        shared_object_file_name=_ARGMAX_OBJ,
+    )
+
+
+def argmax_ref(x, index_offset: int = 0):
+    """Numpy reference for [`argmax`][iron.kernels.reduce.argmax]: the same record.
+
+    Returns the 2-element int32 record the kernel writes, so a host harness can
+    compare it verbatim instead of re-deriving the packing. NaNs are mapped to
+    -inf first, which is what the kernel's comparisons do to them and where this
+    differs from a plain ``numpy.argmax``.
+    """
+    if np.dtype(x.dtype) == np.dtype(np.int32):
+        finite, value_dtype = x.astype(np.int64), np.int32
+    else:
+        finite = np.nan_to_num(x.astype(np.float64), nan=-np.inf)
+        value_dtype = np.float32
+    index = int(np.argmax(finite))
+    value = np.asarray(x[index], dtype=value_dtype)
+    return np.array([value.view(np.int32), index + index_offset], dtype=np.int32)

--- a/test/python/test_kernels_specs.py
+++ b/test/python/test_kernels_specs.py
@@ -231,6 +231,53 @@ KERNEL_SPECS: list[KernelSpec] = [
             (dict(tile_size=1024, dtype=bfloat16), 1, (2,)),
         ],
     ),
+    KernelSpec(
+        name="argmax",
+        factory=kernels.argmax,
+        kwargs=dict(tile_size=1024, dtype=np.int32),
+        arg_count=4,
+        expected_name="argmax_vector",
+        name_variants=[
+            (dict(tile_size=1024, dtype=np.int32, vectorized=False), "argmax_scalar"),
+            (dict(tile_size=1024, dtype=bfloat16), "argmax_vector_bfloat16"),
+            (
+                dict(tile_size=1000, dtype=bfloat16, vectorized=False),
+                "argmax_scalar_bfloat16",
+            ),
+            # Not a multiple of any vector width: the kernel takes a tail.
+            (dict(tile_size=1000, dtype=bfloat16), "argmax_vector_bfloat16"),
+        ],
+        invalid_kwargs=[
+            (
+                dict(tile_size=1024, dtype=np.float32),
+                "dtype must be np.int32 or bfloat16",
+            ),
+            (dict(tile_size=40000, dtype=bfloat16), "must be in 1..32767"),
+            (dict(tile_size=0, dtype=np.int32), "must be in 1..32767"),
+        ],
+        shape_checks=[
+            (dict(tile_size=2048, dtype=np.int32), 0, (2048,)),
+            # The record is two int32 slots whatever the input dtype.
+            (dict(tile_size=2048, dtype=np.int32), 1, (2,)),
+            (dict(tile_size=1024, dtype=bfloat16), 1, (2,)),
+        ],
+    ),
+    KernelSpec(
+        name="argmax_combine",
+        factory=kernels.argmax_combine,
+        kwargs=dict(dtype=np.int32),
+        arg_count=3,
+        expected_name="argmax_combine",
+        name_variants=[
+            (dict(dtype=bfloat16), "argmax_combine_bfloat16"),
+        ],
+        invalid_kwargs=[
+            (dict(dtype=np.float32), "dtype must be np.int32 or bfloat16"),
+        ],
+        shape_checks=[
+            (dict(dtype=bfloat16), 0, (2,)),
+        ],
+    ),
     # ----- activation -----
     KernelSpec(
         name="relu",


### PR DESCRIPTION
### Problem

Two things, one commit each, independently droppable.

**No argmax.** `aie_kernels/` has a max reduction (`aie2/reduce_max.cc`) but nothing
that returns *where* the maximum is. A caller that needs the position -- a decoder
picking a token from a logits row, any top-1 classifier -- has to read the whole
vector back to the host and scan it there.

**`vector_reduce_max` goes stale.** All five of its designs fold every tile into a
`Buffer` seeded with `initial_value=-inf`. That buffer is written at configure time,
not per run, so the second invocation of an already-compiled design starts from the
first run's maximum. Measured on NPU2, i32, 131072 elements, three inputs in one
process:

| design | run 1 (max 999999) | run 2 (max 7) | run 3 (max 42) |
|---|---|---|---|
| `single_column_designs/vector_reduce_max_chained.py` | 999999 | **999999** | **999999** |
| `single_column_designs/vector_reduce_max_shared.py` | 999999 | **999999** | **999999** |
| `single_column_designs/vector_reduce_max_memtile.py` | 999999 | **999999** | **999999** |
| `multi_column_designs/col_wise_vector_reduce_max.py` | 999999 | **999999** | **999999** |
| `multi_column_designs/row_wise_vector_reduce_max.py` | 999999 | **999999** | **999999** |

Wrong from the second run on, in all five. Each `run.lit` / `run_strix.lit` line
starts a fresh interpreter, which is why CI is green on all of them.

### Fix

**`aie_kernels/aie2/argmax.cc`** (commit 1), in the same (partial, combine) shape
that `reduce_max` + `compute_max` already use for a distributed max:
`argmax_vector*` / `argmax_scalar*` reduce a slice and `argmax_combine*` merges two
results. `int32` and `bfloat16`, matching `reduce_max`'s dtype set, and in the same
directory for the same reason -- it uses no aie2p-specific op.

- **The record.** Value and index travel together as two `int32` slots -- the value
  as itself for `int32`, widened to `float` and bit-cast for `bfloat16` -- so one
  ObjectFifo carries both and the combine step never needs the input tile.
- **Global indices.** The kernel adds an `index_offset` argument, so a core emits
  its slice's global index and the fold is order-independent, with no per-core
  fixup on the host.
- **One pass, and the tie rule falls out of it.** The vector path carries a per-lane
  running maximum and the block offset at which each lane last improved, under a
  strict `>`. Lane j only ever sees positions j, j+N, j+2N, ..., so the earliest of
  equal values survives within a lane, and the global first-occurrence index is
  `min(offset[j] + j)` over the lanes still holding the maximum -- resolved once,
  after the loop. That is `numpy.argmax`'s rule, at one read of the data. Offsets
  are int16, which bounds a call at 32767 elements: 32767 bfloat16 is 64 KB, the
  whole of a core's data memory, and a scalar tail takes any remainder so
  `tile_size` need not divide the vector width. A NaN never compares greater, so
  NaN inputs are skipped rather than returned -- `argmax_ref()` matches the kernel
  there, not numpy.

Plus the `iron.kernels.argmax` / `argmax_combine` / `argmax_ref` factories, their
`test_kernels_specs.py` rows, and `programming_examples/basic/vector_reduce_argmax`:
4 cores folding down one column, the host reading 8 bytes whatever the input length.

**The five `vector_reduce_max` designs** (commit 2) have their first tile write the
accumulator outright instead of folding into it, so nothing depends on the seed.
Three lines per core body.

### Test

`test/python/test_kernels_specs.py` + `test_kernels_memoization.py`: 330 passed.

argmax on NPU2, against `numpy.argmax`, comparing the full record (value bits and
index), 8192 elements per case:

| case | bf16 | i32 |
|---|---|---|
| 25 random seeds | 25/25 | 25/25 |
| max at index 0 / at the end | exact | exact |
| max duplicated 3x / once per core | exact | exact |
| all elements equal | exact | exact |
| strictly ascending / descending | exact | exact |

The scalar tail is covered separately, at per-core slices of 500, 300, 26 and 16
elements (16 is below the 32-lane vector width, so the tail does all of it) --
exact in every case.

All three of the new `run_strix.lit` lines pass, including the 524288-byte case that
streams 128 iterations through the memtile. Vector vs scalar on that design, 262144
bfloat16, whole dispatch, medians of 10: 0.44 ms vs 0.89 ms.

For commit 2: the table above re-run after the fix gives the correct maximum on all
three runs for all five designs, and all eight of their existing `run_strix.lit`
invocations still pass. The fix is free: interleaved before/after on `chained` and
`col_wise`, i32, 131072 elements, gives +1.7% and +2.6% against a p25-p75 spread of
0.25 and 0.43 ms.

### Scope

The kernel is device-verified on NPU2 only; it builds clean for the aie2 target but
has not been run on NPU1.

No `aie_kernels/README.md` row: #3599 is rewriting that file into a per-arch catalog,
and its table is where this entry belongs.

