### PR TITLE
ci: take ninja from the pinned lockfile, not a node16 action [LOW]

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -72,9 +72,6 @@ runs:
       with:
         python-version: '3.12'
 
-    - name: Install Ninja
-      uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c # Jan 17
-
     - name: Install cross-compilation toolchain
       shell: bash
       if: ${{ inputs.MATRIX_OS == 'ubuntu-24.04' && inputs.MATRIX_ARCH == 'aarch64' }}


### PR DESCRIPTION
### Problem

`setup_base`'s "Install Ninja" step pins `llvm/actions/install-ninja@6a57890d`, a
`node16` action (its `action.yml` has `runs: using: 'node16'`). node16 is deprecated
on GitHub Actions runners.

### Fix

Drop the step. The same composite action already installs ninja via
`pip install --require-hashes -r python/requirements_dev.lock`, which pins
`ninja==1.11.1.4`, and that pip step runs before either consumer workflow
(`mlirDistro.yml`, `mlirAIEDistro.yml`) invokes cmake or ninja.

### Test

The changed file parses as YAML. `ninja==1.11.1.4` is pinned in
`python/requirements_dev.lock`, and no reference to `install-ninja` remains under
`.github/`.
