### PR TITLE
ci: trigger the distro workflows on their real inputs [MED]

### DIFF
--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     paths:
       - '.github/workflows/mlirAIEDistro.yml'
+      - '.github/actions/setup_base/**'
+      - '.github/actions/setup_ccache/**'
+      - 'utils/mlir_aie_wheels/**'
+      - 'python/requirements_dev.lock'
   workflow_dispatch:
     inputs:
       DEBUG_ENABLED:

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     paths:
       - '.github/workflows/mlirDistro.yml'
+      - '.github/actions/setup_base/**'
+      - '.github/actions/setup_ccache/**'
+      - 'utils/mlir_wheels/**'
+      - 'python/requirements_dev.lock'
   workflow_dispatch:
     inputs:
       DEBUG_ENABLED:


### PR DESCRIPTION
### Problem

`mlirAIEDistro.yml` and `mlirDistro.yml` only trigger on `pull_request` when the
workflow file itself changes, so real changes to what they build from never run them.
Demonstrated on #3561, which changed `.github/actions/setup_base/action.yml` (used by
both workflows via `uses:`) without either Distro workflow running a single check.

### Fix

Add the actually-consumed paths to each workflow's `pull_request.paths`:
`.github/actions/setup_base/**`, `.github/actions/setup_ccache/**`,
`python/requirements_dev.lock`, and `utils/mlir_aie_wheels/**` (mlirAIEDistro.yml) or
`utils/mlir_wheels/**` (mlirDistro.yml).

### Test

Both files parse as YAML. Every added path matches tracked files, and each workflow
references it: the setup_base/setup_ccache action calls, the requirements_dev.lock
install, and the wheel-build scripts under the respective `utils/` tree.
