### PR TITLE
python: recognize Gorgon Point as npu2 [HIGH]

### DIFF
--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -63,7 +63,15 @@ class LitConfigHelper:
     # Maps generation name to list of model strings that may appear in xrt-smi
     NPU_MODELS = {
         "npu1": ["npu1", "Phoenix"],
-        "npu2": ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"],
+        "npu2": [
+            "npu4",
+            "Strix",
+            "npu5",
+            "Strix Halo",
+            "npu6",
+            "Krackan",
+            "Gorgon Point",
+        ],
     }
 
     PATH_ENV_VARS = {"PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"}

--- a/python/utils/hostruntime/xrtruntime/hostruntime.py
+++ b/python/utils/hostruntime/xrtruntime/hostruntime.py
@@ -90,7 +90,15 @@ class XRTHostRuntime(HostRuntime):
     # Maps generation name to list of model strings that may appear in xrt-smi
     NPU_MODELS = {
         "npu1": ["npu1", "Phoenix"],
-        "npu2": ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"],
+        "npu2": [
+            "npu4",
+            "Strix",
+            "npu5",
+            "Strix Halo",
+            "npu6",
+            "Krackan",
+            "Gorgon Point",
+        ],
     }
     _tensor_class = XRTTensor
 

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -62,7 +62,7 @@ export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
 export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 # --- NPU detection (native + WSL) --------------------------------------------
-NPUPAT='NPU Phoenix|NPU Strix|NPU Strix Halo|NPU Krackan|RyzenAI-npu[1456]'
+NPUPAT='NPU Phoenix|NPU Strix|NPU Strix Halo|NPU Krackan|NPU Gorgon Point|RyzenAI-npu[1456]'
 if [ -n "${WSL_DISTRO_NAME-}" ]; then
     # Under WSL the NPU is queried through the Windows xrt-smi.exe.
     XRTSMI="/mnt/c/Windows/System32/AMD/xrt-smi.exe"
@@ -78,7 +78,7 @@ fi
 
 # Check if the current environment is NPU2
 # npu4 => Strix, npu5 => Strix Halo, npu6 => Krackan
-if echo "$NPU" | grep -qiE "NPU Strix|NPU Strix Halo|NPU Krackan|RyzenAI-npu[456]"; then
+if echo "$NPU" | grep -qiE "NPU Strix|NPU Strix Halo|NPU Krackan|NPU Gorgon Point|RyzenAI-npu[456]"; then
     export NPU2=1
 else
     export NPU2=0

--- a/utils/iron_setup.py
+++ b/utils/iron_setup.py
@@ -530,11 +530,11 @@ def resolve_xrt_layout(args: argparse.Namespace, venv: VenvInfo) -> XrtLayout:
 
 # NPU_REGEX recognizes supported devices; NPU2_REGEX selects the Makefile NPU2=1 path.
 NPU_REGEX = re.compile(
-    r"NPU Phoenix|NPU Strix|NPU Strix Halo|NPU Krackan|RyzenAI-npu[1456]",
+    r"NPU Phoenix|NPU Strix|NPU Strix Halo|NPU Krackan|NPU Gorgon Point|RyzenAI-npu[1456]",
     re.IGNORECASE,
 )
 NPU2_REGEX = re.compile(
-    r"NPU Strix|NPU Strix Halo|NPU Krackan|RyzenAI-npu[456]",
+    r"NPU Strix|NPU Strix Halo|NPU Krackan|NPU Gorgon Point|RyzenAI-npu[456]",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
### Problem

Every mlir-aie python device runner (`XRTHostRuntime`, and lit device detection via
`LitConfigHelper`) fails at construction with

```
RuntimeError: Unknown device type: NPU Gorgon Point 1
```

before touching the device. `iron_setup.py` and `env_setup.sh` fail equivalently: their
NPU/NPU2 detection regexes do not match the string either, so `NPU2` never gets set.

It was triggered by a Linux kernel bump (7.1.8 to 7.2.0) and a linux-firmware bump
(20260622 to 20260810), both effective only after reboot. XRT then reported this npu2
part's device name as "NPU Gorgon Point 1" instead of a string already on the
hardcoded marketing-name allowlists these files match against. Same silicon, PCI
0x17f0, 8 columns, aie2p. Only the reported name string changed.

### Fix

Add "Gorgon Point" to the four marketing-name lists that gate on it by substring or
regex match: `XRTHostRuntime.NPU_MODELS`, `LitConfigHelper.NPU_MODELS`,
`iron_setup.py`'s `NPU_REGEX`/`NPU2_REGEX`, and `env_setup.sh`'s `NPUPAT` and its NPU2
check. `hrxruntime/hostruntime.py` keys off PCI id rather than name
(`_STRIX_PCI_IDS` already contains `0x17f0`) and needs no change.

### Test

I have been carrying the equivalent change on this machine since 2026-08-21, and every
python device path works again with it: the lit device legs and the IRON `@iron.jit`
runners all reach the device instead of raising at construction.

In this branch, each changed file was syntax-checked (`ast.parse` for the three python
files, `bash -n` for `env_setup.sh`). The device leg is not reproducible upstream
without a part that reports the new name.
