### PR TITLE
[AIE] Run count checks before mixed-list reads in the ODS verifier [MED]

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -173,11 +173,14 @@ xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
   if (failed(verifyListOfOperandsOrIntegers(
           op, "stride", maxRanks[2], op.getStaticStrides(), op.getStrides())))
     return failure();
-  if (!(op.getMixedOffsets().size() == 1 && maxRanks[0] == 1) && // NOLINT
-      op.getMixedOffsets().size() != op.getMixedSizes().size())
+  // Each getMixed* call rebuilds its list, so read them once.
+  const size_t numMixedOffsets = op.getMixedOffsets().size();
+  const size_t numMixedSizes = op.getMixedSizes().size();
+  if (!(numMixedOffsets == 1 && maxRanks[0] == 1) && // NOLINT
+      numMixedOffsets != numMixedSizes)
     return op->emitError(
                "expected mixed offsets rank to match mixed sizes rank (")
-           << op.getMixedOffsets().size() << " vs " << op.getMixedSizes().size()
+           << numMixedOffsets << " vs " << numMixedSizes
            << ") so the rank of the result type is well-formed.";
   for (int64_t offset : op.getStaticOffsets())
     if (offset < 0 && !ShapedType::isDynamic(offset))

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -160,10 +160,10 @@ LogicalResult
 xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
   std::array<unsigned, 3> maxRanks = op.getArrayAttrMaxRanks();
   // Count checks FIRST, matching mlir::detail::verifyOffsetSizeAndStrideOp.
-  // getMixedOffsets()/getMixedSizes() assert that the number of dynamic operands
-  // equals the number of kDynamic sentinels in the static list, so running the
-  // rank comparison before these validates nothing and aborts on malformed input
-  // instead of diagnosing it.
+  // getMixedOffsets()/getMixedSizes() assert that the number of dynamic
+  // operands equals the number of kDynamic sentinels in the static list, so
+  // running the rank comparison before these validates nothing and aborts on
+  // malformed input instead of diagnosing it.
   if (failed(verifyListOfOperandsOrIntegers(
           op, "offset", maxRanks[0], op.getStaticOffsets(), op.getOffsets())))
     return failure();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -159,12 +159,11 @@ std::string xilinx::AIE::generateUniqueSymbolName(
 LogicalResult
 xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
   std::array<unsigned, 3> maxRanks = op.getArrayAttrMaxRanks();
-  if (!(op.getMixedOffsets().size() == 1 && maxRanks[0] == 1) && // NOLINT
-      op.getMixedOffsets().size() != op.getMixedSizes().size())
-    return op->emitError(
-               "expected mixed offsets rank to match mixed sizes rank (")
-           << op.getMixedOffsets().size() << " vs " << op.getMixedSizes().size()
-           << ") so the rank of the result type is well-formed.";
+  // Count checks FIRST, matching mlir::detail::verifyOffsetSizeAndStrideOp.
+  // getMixedOffsets()/getMixedSizes() assert that the number of dynamic operands
+  // equals the number of kDynamic sentinels in the static list, so running the
+  // rank comparison before these validates nothing and aborts on malformed input
+  // instead of diagnosing it.
   if (failed(verifyListOfOperandsOrIntegers(
           op, "offset", maxRanks[0], op.getStaticOffsets(), op.getOffsets())))
     return failure();
@@ -174,6 +173,12 @@ xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
   if (failed(verifyListOfOperandsOrIntegers(
           op, "stride", maxRanks[2], op.getStaticStrides(), op.getStrides())))
     return failure();
+  if (!(op.getMixedOffsets().size() == 1 && maxRanks[0] == 1) && // NOLINT
+      op.getMixedOffsets().size() != op.getMixedSizes().size())
+    return op->emitError(
+               "expected mixed offsets rank to match mixed sizes rank (")
+           << op.getMixedOffsets().size() << " vs " << op.getMixedSizes().size()
+           << ") so the rank of the result type is well-formed.";
   for (int64_t offset : op.getStaticOffsets())
     if (offset < 0 && !ShapedType::isDynamic(offset))
       return op->emitError("expected offsets to be non-negative, but got ")

--- a/test/dialect/AIEX/bad_npu_nd_mixed_list_counts.mlir
+++ b/test/dialect/AIEX/bad_npu_nd_mixed_list_counts.mlir
@@ -1,0 +1,37 @@
+//===- bad_npu_nd_mixed_list_counts.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A static list whose kDynamic-sentinel count disagrees with its operand list must be
+// DIAGNOSED, not asserted on. getMixedOffsets()/getMixedSizes() assert that the two agree,
+// so any consumer of the mixed lists has to run after the count checks -- which is the order
+// mlir::detail::verifyOffsetSizeAndStrideOp uses.
+//
+// Generic syntax on purpose: no well-formed producer emits this, so it takes hand-written or
+// fuzzed input to reach. Before the reorder this aborted in
+// mlir/lib/Dialect/Utils/StaticValueUtils.cpp (assertions build) rather than reaching any
+// diagnostic at all.
+
+// RUN: aie-opt --split-input-file --verify-diagnostics %s
+
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<16xi32>) {
+      // static_sizes carries one kDynamic sentinel, but the $sizes operand list is empty.
+      // expected-error@+1 {{expected 1 dynamic size values}}
+      "aiex.npu.dma_memcpy_nd"(%arg0) <{
+        operandSegmentSizes = array<i32: 1, 0, 0, 0>,
+        static_offsets = array<i64: 0, 0, 0, 0>,
+        static_sizes = array<i64: -9223372036854775808, 4, 4, 4>,
+        static_strides = array<i64: 0, 0, 0, 1>,
+        metadata = @toMem,
+        id = 1 : i64
+      }> : (memref<16xi32>) -> ()
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @toMem (%tile_0_0, S2MM, 0)
+  }
+}


### PR DESCRIPTION
## Description

`myVerifyOffsetSizeAndStrideOp()` compares `op.getMixedOffsets().size()` against
`op.getMixedSizes().size()` before validating that each list's dynamic-operand count
agrees with its static list's `kDynamic` sentinel count. Both accessors call
`mlir::getMixedValues()`, which asserts
`dynamicValues.size() == count_if(staticValues, isDynamic)`. An `aiex.npu.dma_memcpy_nd`
whose `static_sizes` carries a `kDynamic` sentinel while its `$sizes` operand list is
empty therefore hits that assert during verification instead of reaching a diagnostic:
SIGABRT in an assertions build, an out-of-bounds read in release. It takes hand-written
or fuzzed generic syntax to reach, but a verifier should diagnose malformed IR, not
abort on it.

This moves the three `verifyListOfOperandsOrIntegers` calls ahead of the
mixed-offsets-vs-mixed-sizes rank check — the order
`mlir::detail::verifyOffsetSizeAndStrideOp` already uses upstream, where llvm-project's
`ViewLikeInterface.cpp` validates the same dynamic-operand counts before calling the
mixed accessors. Once the per-list checks have run, each dynamic count matches its
static list's `kDynamic` count, so the mixed accessors cannot assert. The reordering
cannot change any verdict: the checks are independent, side-effect-free, and all
required, so only which failing check reports first can differ.

Covered by `test/dialect/AIEX/bad_npu_nd_mixed_list_counts.mlir`: a generic-syntax
`aiex.npu.dma_memcpy_nd` with `static_sizes = array<i64: kDynamic, 4, 4, 4>` and an
empty `$sizes` list. Built `aie-opt` and ran it both ways — with the fix
`--split-input-file --verify-diagnostics` exits 0; without it the same binary aborts in
`StaticValueUtils.cpp:214` before emitting any diagnostic.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (no Python touched)
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (file not on the enabled list)
