### PR TITLE
[AIE] Overlay mode-exclusive buffers via an alloc_group attribute [MED]

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1707,16 +1707,12 @@ def AIE_BufferOp
     allocated exactly as before.
   }];
 
-  let arguments = (
-    ins Index:$tile,
-        OptionalAttr<StrAttr>:$sym_name,
-        OptionalAttr<AIEI32Attr>:$address,
-        OptionalAttr<ElementsAttr>:$initial_value,
-        OptionalAttr<AIEI32Attr>:$mem_bank,
-        UnitAttr:$core_data,
-        DefaultValuedAttr<BoolAttr, "true">:$aligned,
-        OptionalAttr<StrAttr>:$alloc_group
-  );
+  let arguments = (ins Index:$tile, OptionalAttr<StrAttr>:$sym_name,
+      OptionalAttr<AIEI32Attr>:$address,
+      OptionalAttr<ElementsAttr>:$initial_value,
+      OptionalAttr<AIEI32Attr>:$mem_bank, UnitAttr:$core_data,
+      DefaultValuedAttr<BoolAttr, "true">:$aligned,
+      OptionalAttr<StrAttr>:$alloc_group);
 
   let results = (outs AnyMemRef:$buffer);
   let assemblyFormat = [{

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -2283,7 +2283,14 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
       // packet selects packet-switched routing. packet_id pins the header;
       // allocation chooses an unused id when it is absent.
       UnitAttr:$packet,
-      OptionalAttr<ConfinedAttr<AIEI8Attr, [IntMinValue<0>]>>:$packet_id);
+      OptionalAttr<ConfinedAttr<AIEI8Attr, [IntMinValue<0>]>>:$packet_id,
+      // Allocation group, propagated onto every buffer this objectFifo lowers
+      // to -- a fifo's depth slots are live together, which is what one group
+      // asserts. Two fifos in DIFFERENT groups are asserted never to be live
+      // at the same time, so the allocator overlays them and they share one
+      // region sized at the larger fifo's total. See aie.buffer's alloc_group
+      // for what is asserted and what is checked.
+      OptionalAttr<StrAttr>:$alloc_group);
 
   let assemblyFormat = [{
     $sym_name
@@ -2516,7 +2523,11 @@ def AIE_ObjectFifoPoolOp
       DefaultValuedAttr<BoolAttr, "false">:$disableSynchronization,
       // If lowered from a high-level ObjectFifo, the name of that fifo.
       // Used to group ops lowered by the same ObjectFifo.
-      OptionalAttr<StrAttr>:$fifoName, InitValuesArrayAttr:$initValues);
+      OptionalAttr<StrAttr>:$fifoName, InitValuesArrayAttr:$initValues,
+      // Allocation group carried down from the objectFifo, stamped onto every
+      // buffer `--aie-objectfifo-allocate` creates here. See aie.buffer's
+      // alloc_group for what it asserts.
+      OptionalAttr<StrAttr>:$allocGroup);
 
   let regions = (region SizedRegion<1>:$segments);
 

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1682,13 +1682,41 @@ def AIE_BufferOp
     `core_data` marks the extent that holds the core's own .data, .rodata and
     .bss, which `aie-assign-buffer-addresses` creates from the core's
     `data_size`. It names no symbol.
+
+    `alloc_group` names a set of buffers that ARE live together. Buffers on the
+    same tile sharing a group get distinct storage, laid out one after another.
+    Buffers in DIFFERENT groups are asserted by the author never to be live at the
+    same time, so the allocator overlays the groups: they share one region, sized
+    at the largest group's total rather than the sum of every group. A group is
+    typically one mode of a mode-selected design, which is what lets several
+    topologies coexist in one design without each paying for the others' L1.
+
+    Sizing follows from that. Two modes of two buffers each cost
+    `max(a1+a2, b1+b2)`, not `max(a1,b1) + max(a2,b2)`: for 100/10 against 10/100
+    that is 110 rather than 200, and the modes need not hold the same number of
+    buffers.
+
+    The assertion is the author's -- the allocator cannot prove two modes never run
+    together. What IS checked (AIEAssignBufferAddresses) is the decidable part: no
+    two buffers from DIFFERENT groups may be referenced from one `aie.core` unless
+    a one-of-N selector (`scf.if`, `scf.index_switch`) separates the references,
+    since otherwise they are simultaneously live by construction. Note this is a
+    property of the selector, not of the enclosing block: objectFifo lowering gives
+    each reference its own `scf.index_switch` case, so a block-scoped check would
+    pass everything. A buffer with no `alloc_group` overlays nothing and is
+    allocated exactly as before.
   }];
 
-  let arguments = (ins Index:$tile, OptionalAttr<StrAttr>:$sym_name,
-      OptionalAttr<AIEI32Attr>:$address,
-      OptionalAttr<ElementsAttr>:$initial_value,
-      OptionalAttr<AIEI32Attr>:$mem_bank, UnitAttr:$core_data,
-      DefaultValuedAttr<BoolAttr, "true">:$aligned);
+  let arguments = (
+    ins Index:$tile,
+        OptionalAttr<StrAttr>:$sym_name,
+        OptionalAttr<AIEI32Attr>:$address,
+        OptionalAttr<ElementsAttr>:$initial_value,
+        OptionalAttr<AIEI32Attr>:$mem_bank,
+        UnitAttr:$core_data,
+        DefaultValuedAttr<BoolAttr, "true">:$aligned,
+        OptionalAttr<StrAttr>:$alloc_group
+  );
 
   let results = (outs AnyMemRef:$buffer);
   let assemblyFormat = [{

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -198,6 +198,7 @@ static bool checkAndPrintBufferOverlap(ArrayRef<BufferOp> sortedBuffers,
     // group, or two ungrouped buffers would compare equal as absent and exempt
     // every ordinary overlap.
     BufferOp blocker;
+    int64_t blockerAddr = 0;
     int64_t blockerEnd = 0;
     for (size_t j = 0; j < i; ++j) {
       auto other = sortedBuffers[j];
@@ -212,6 +213,7 @@ static bool checkAndPrintBufferOverlap(ArrayRef<BufferOp> sortedBuffers,
       assert(otherAddrOpt.has_value() && "buffer must have address assigned");
       int64_t end = *otherAddrOpt + other.getAllocationSize();
       if (end > blockerEnd) {
+        blockerAddr = *otherAddrOpt;
         blockerEnd = end;
         blocker = other;
       }
@@ -220,7 +222,7 @@ static bool checkAndPrintBufferOverlap(ArrayRef<BufferOp> sortedBuffers,
       cur.emitOpError("")
           << bufferLabel(cur) << " at address 0x" << llvm::utohexstr(curAddr)
           << " overlaps with " << bufferLabel(blocker) << " at address 0x"
-          << llvm::utohexstr(blocker.getAddress().value())
+          << llvm::utohexstr(blockerAddr)
           << " (size: " << blocker.getAllocationSize() << " bytes)";
       return false;
     }
@@ -327,9 +329,9 @@ static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers) {
       extent += member.getAllocationSize();
     u.size = std::max(u.size, extent);
   }
-  std::stable_sort(
-      units.begin(), units.end(),
-      [](const AllocUnit &a, const AllocUnit &b) { return a.size > b.size; });
+  llvm::stable_sort(units, [](const AllocUnit &a, const AllocUnit &b) {
+    return a.size > b.size;
+  });
   return units;
 }
 
@@ -503,10 +505,12 @@ static bool basicAllocation(TileOp tile) {
                                                   maxVecAlignBits));
     if (unit.aligned)
       address = getAlignedAddress(address, unitAlignBits);
-    while (current_alloc != allocated_buffers.end() &&
-           address + unit.size > current_alloc->getAddress().value()) {
-      address = current_alloc->getAddress().value() +
-                current_alloc->getAllocationSize();
+    while (current_alloc != allocated_buffers.end()) {
+      auto allocAddr = current_alloc->getAddress();
+      assert(allocAddr.has_value() && "buffer must have address assigned");
+      if (address + unit.size <= *allocAddr)
+        break;
+      address = *allocAddr + current_alloc->getAllocationSize();
       if (unit.aligned)
         address = getAlignedAddress(address, unitAlignBits);
       current_alloc++;
@@ -1326,7 +1330,13 @@ struct AIEAssignBufferAddressesPass
         tileAllocationScheme = clAllocScheme;
       }
 
-      if (tileAllocationScheme == "basic-sequential") {
+      // Only basic-sequential implements overlays, so a tile carrying one
+      // takes that path rather than trying bank-aware first and silently
+      // dropping them.
+      bool needsBasic = tileAllocationScheme == "basic-sequential" ||
+                        (tileAllocationScheme != "bank-aware" &&
+                         tileHasAllocGroup(device, tile));
+      if (needsBasic) {
         if (!basicAllocation(tile)) {
           emitAllocationFailure(tile, "basic-sequential");
           return signalPassFailure();
@@ -1340,13 +1350,6 @@ struct AIEAssignBufferAddressesPass
         }
         if (simpleBankAwareAllocation(tile) != BankAwareResult::Success) {
           emitAllocationFailure(tile, "bank-aware");
-          return signalPassFailure();
-        }
-      } else if (tileHasAllocGroup(device, tile)) {
-        // Only basic-sequential implements overlays, so do not try bank-aware
-        // first and silently drop them.
-        if (!basicAllocation(tile)) {
-          tile.emitOpError("Basic sequential allocation failed.");
           return signalPassFailure();
         }
       } else {

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -289,14 +289,38 @@ struct AllocUnit {
   // largest group's total, not the sum of every group. An ungrouped buffer is a
   // unit holding one group of one member, which is the pre-existing behaviour.
   SmallVector<SmallVector<BufferOp>> groups;
-  int64_t size = 0;     // max over groups of that group's summed extent
+  int64_t size = 0;     // max over groups of that group's padded extent
   bool aligned = false; // any member aligned => align the shared base
 };
 } // namespace
 
+// Simulate laying `group` out sequentially from a base of 0, applying each
+// member's own alignment exactly as the real placement loop in
+// basicAllocation does, and return the resulting extent (including any
+// inter-member padding). Valid at any base that is itself aligned to the
+// unit's `unitAlignBits` (the max required alignment over its members, see
+// its use in basicAllocation): every member's required alignment then
+// divides the base's, so the padding pattern -- and hence the extent -- does
+// not depend on the base's actual value.
+static int64_t groupExtent(ArrayRef<BufferOp> group,
+                           uint32_t tileAlignBitWidth,
+                           uint32_t maxVecAlignBitWidth) {
+  int64_t offset = 0;
+  for (auto buffer : group) {
+    if (buffer.getAligned())
+      offset = getAlignedAddress(
+          offset,
+          getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBitWidth));
+    offset += buffer.getAllocationSize();
+  }
+  return offset;
+}
+
 // Group this tile's unallocated buffers into allocation units, preserving the
 // pass's existing largest-first order across units.
-static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers) {
+static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers,
+                                              uint32_t tileAlignBitWidth,
+                                              uint32_t maxVecAlignBitWidth) {
   SmallVector<AllocUnit> units;
   // Every alloc_group on this tile overlays every other, so they share ONE
   // unit. groupIndex maps a group name to its slot within that unit's group
@@ -323,10 +347,10 @@ static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers) {
       u.groups.push_back({});
     u.groups[it->second].push_back(buffer);
     u.aligned |= buffer.getAligned();
-    // A group's extent is its members' sum; the unit's is the largest such sum.
-    int64_t extent = 0;
-    for (auto member : u.groups[it->second])
-      extent += member.getAllocationSize();
+    // A group's extent is its members' padded layout; the unit's is the
+    // largest such extent.
+    int64_t extent = groupExtent(u.groups[it->second], tileAlignBitWidth,
+                                 maxVecAlignBitWidth);
     u.size = std::max(u.size, extent);
   }
   llvm::stable_sort(units, [](const AllocUnit &a, const AllocUnit &b) {
@@ -492,7 +516,8 @@ static bool basicAllocation(TileOp tile) {
   // final placement. A misaligned candidate otherwise passes the fit test, and
   // getAlignedAddress then bumps it into a pre-allocated buffer.
   auto *current_alloc = allocated_buffers.begin();
-  for (const AllocUnit &unit : buildAllocUnits(buffers)) {
+  for (const AllocUnit &unit :
+       buildAllocUnits(buffers, tileAlignBitWidth, maxVecAlignBitWidth)) {
     // Every group starts at the unit's base, so the base has to satisfy the
     // strictest requirement any member has -- a per-buffer figure since
     // getRequiredAlignBits keys on the buffer's own size.
@@ -518,7 +543,14 @@ static bool basicAllocation(TileOp tile) {
 
     // Groups overlay: each starts at the unit's base. Members within a group do
     // not, so they follow one another. The unit advances by the largest group's
-    // total, which is what makes N modes cost max(sum) rather than sum(max).
+    // real end, which is what makes N modes cost max(sum) rather than sum(max).
+    //
+    // That real end is tracked here rather than trusted from unit.size: a
+    // group's alignment padding depends on each member's own required
+    // alignment, and while unit.size (via groupExtent) predicts it correctly,
+    // advancing by what was actually placed can't be wrong even if the two
+    // ever diverge.
+    int64_t unitEnd = address;
     for (const auto &group : unit.groups) {
       int64_t offset = address;
       for (auto buffer : group) {
@@ -530,8 +562,9 @@ static bool basicAllocation(TileOp tile) {
         buffer.setAddress(offset);
         offset += buffer.getAllocationSize();
       }
+      unitEnd = std::max(unitEnd, offset);
     }
-    address += unit.size;
+    address = unitEnd;
   }
 
   sortBuffersByAddress(allBuffers_on_tile);

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -534,13 +534,16 @@ static bool basicAllocation(TileOp tile) {
 
   // High-water mark across all buffers, including pre-allocated buffers above
   // the allocation cursor, so checkAndPrintOverflow reads a correct bound.
+  //
+  // Every buffer, not just the last: the vector is sorted by start address, and
+  // buffers in different alloc_groups are allowed to overlap, so the greatest
+  // start address is no longer also the greatest end address.
   int64_t highWater = address;
-  if (!allBuffers_on_tile.empty()) {
-    auto &last = allBuffers_on_tile.back();
-    auto lastAddrOpt = last.getAddress();
-    assert(lastAddrOpt.has_value() && "buffer must have address assigned");
+  for (auto buffer : allBuffers_on_tile) {
+    auto addrOpt = buffer.getAddress();
+    assert(addrOpt.has_value() && "buffer must have address assigned");
     highWater =
-        std::max<int64_t>(highWater, *lastAddrOpt + last.getAllocationSize());
+        std::max<int64_t>(highWater, *addrOpt + buffer.getAllocationSize());
   }
 
   if (!checkAndPrintOverlapStackframe(stacksize, allBuffers_on_tile) ||

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -219,11 +219,12 @@ static bool checkAndPrintBufferOverlap(ArrayRef<BufferOp> sortedBuffers,
       }
     }
     if (blocker && curAddr < blockerEnd) {
-      cur.emitOpError("")
-          << bufferLabel(cur) << " at address 0x" << llvm::utohexstr(curAddr)
-          << " overlaps with " << bufferLabel(blocker) << " at address 0x"
-          << llvm::utohexstr(blockerAddr)
-          << " (size: " << blocker.getAllocationSize() << " bytes)";
+      cur.emitOpError("") << bufferLabel(cur) << " at address 0x"
+                          << llvm::utohexstr(curAddr) << " overlaps with "
+                          << bufferLabel(blocker) << " at address 0x"
+                          << llvm::utohexstr(blockerAddr)
+                          << " (size: " << blocker.getAllocationSize()
+                          << " bytes)";
       return false;
     }
   }
@@ -302,15 +303,14 @@ struct AllocUnit {
 // its use in basicAllocation): every member's required alignment then
 // divides the base's, so the padding pattern -- and hence the extent -- does
 // not depend on the base's actual value.
-static int64_t groupExtent(ArrayRef<BufferOp> group,
-                           uint32_t tileAlignBitWidth,
-                           uint32_t maxVecAlignBitWidth) {
+static int64_t groupExtent(ArrayRef<BufferOp> group, uint32_t tileAlignBitWidth,
+                           uint32_t maxVecAlignBits) {
   int64_t offset = 0;
   for (auto buffer : group) {
     if (buffer.getAligned())
       offset = getAlignedAddress(
           offset,
-          getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBitWidth));
+          getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBits));
     offset += buffer.getAllocationSize();
   }
   return offset;
@@ -320,7 +320,7 @@ static int64_t groupExtent(ArrayRef<BufferOp> group,
 // pass's existing largest-first order across units.
 static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers,
                                               uint32_t tileAlignBitWidth,
-                                              uint32_t maxVecAlignBitWidth) {
+                                              uint32_t maxVecAlignBits) {
   SmallVector<AllocUnit> units;
   // Every alloc_group on this tile overlays every other, so they share ONE
   // unit. groupIndex maps a group name to its slot within that unit's group
@@ -349,8 +349,8 @@ static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers,
     u.aligned |= buffer.getAligned();
     // A group's extent is its members' padded layout; the unit's is the
     // largest such extent.
-    int64_t extent = groupExtent(u.groups[it->second], tileAlignBitWidth,
-                                 maxVecAlignBitWidth);
+    int64_t extent =
+        groupExtent(u.groups[it->second], tileAlignBitWidth, maxVecAlignBits);
     u.size = std::max(u.size, extent);
   }
   llvm::stable_sort(units, [](const AllocUnit &a, const AllocUnit &b) {
@@ -517,7 +517,7 @@ static bool basicAllocation(TileOp tile) {
   // getAlignedAddress then bumps it into a pre-allocated buffer.
   auto *current_alloc = allocated_buffers.begin();
   for (const AllocUnit &unit :
-       buildAllocUnits(buffers, tileAlignBitWidth, maxVecAlignBitWidth)) {
+       buildAllocUnits(buffers, tileAlignBitWidth, maxVecAlignBits)) {
     // Every group starts at the unit's base, so the base has to satisfy the
     // strictest requirement any member has -- a per-buffer figure since
     // getRequiredAlignBits keys on the buffer's own size.
@@ -526,8 +526,8 @@ static bool basicAllocation(TileOp tile) {
       for (auto buffer : group)
         if (buffer.getAligned())
           unitAlignBits = std::max(
-              unitAlignBits, getRequiredAlignBits(buffer, tileAlignBitWidth,
-                                                  maxVecAlignBits));
+              unitAlignBits,
+              getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBits));
     if (unit.aligned)
       address = getAlignedAddress(address, unitAlignBits);
     while (current_alloc != allocated_buffers.end()) {
@@ -557,8 +557,8 @@ static bool basicAllocation(TileOp tile) {
         assert(!buffer.getAddress());
         if (buffer.getAligned())
           offset = getAlignedAddress(
-              offset, getRequiredAlignBits(buffer, tileAlignBitWidth,
-                                           maxVecAlignBits));
+              offset,
+              getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBits));
         buffer.setAddress(offset);
         offset += buffer.getAllocationSize();
       }

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -11,7 +11,10 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
 
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Attributes.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/StringMap.h"
 
 #include "llvm/ADT/BitVector.h"
 
@@ -156,8 +159,8 @@ static uint32_t getRequiredAlignBits(BufferOp buffer, uint32_t busAlignBits,
 static bool checkAndPrintBufferOverlap(ArrayRef<BufferOp> sortedBuffers,
                                        uint32_t tileAlignBitWidth,
                                        uint32_t maxVecAlignBits) {
-  BufferOp prev = nullptr;
-  for (auto cur : sortedBuffers) {
+  for (size_t i = 0; i < sortedBuffers.size(); ++i) {
+    auto cur = sortedBuffers[i];
     auto curAddrOpt = cur.getAddress();
     assert(curAddrOpt.has_value() && "buffer must have address assigned");
     int64_t curAddr = *curAddrOpt;
@@ -184,40 +187,41 @@ static bool checkAndPrintBufferOverlap(ArrayRef<BufferOp> sortedBuffers,
       continue;
     }
 
-    if (prev) {
-      auto prevAddrOpt = prev.getAddress();
-      assert(prevAddrOpt.has_value() && "buffer must have address assigned");
-      int64_t prevAddr = *prevAddrOpt;
-      int64_t prevEnd = prevAddr + prev.getAllocationSize();
-      if (curAddr < prevEnd) {
-        cur.emitOpError("")
-            << bufferLabel(cur) << " at address 0x" << llvm::utohexstr(curAddr)
-            << " overlaps with " << bufferLabel(prev) << " at address 0x"
-            << llvm::utohexstr(prevAddr)
-            << " (size: " << prev.getAllocationSize() << " bytes)";
-        return false;
+    // Track the furthest end among the earlier buffers `cur` must stay clear
+    // of, rather than comparing against sortedBuffers[i - 1] alone: an exempt
+    // pair can sit between two buffers that do overlap, hiding it from an
+    // adjacent-only check.
+    //
+    // Buffers in DIFFERENT alloc_groups are overlaid on purpose, so a shared
+    // address between them is not a defect; two members of the SAME group are
+    // laid out sequentially and must not overlap. Both sides have to name a
+    // group, or two ungrouped buffers would compare equal as absent and exempt
+    // every ordinary overlap.
+    BufferOp blocker;
+    int64_t blockerEnd = 0;
+    for (size_t j = 0; j < i; ++j) {
+      auto other = sortedBuffers[j];
+      if (other.getAllocationSize() == 0) {
+        continue;
+      }
+      if (auto curGroup = cur.getAllocGroup())
+        if (auto otherGroup = other.getAllocGroup())
+          if (*curGroup != *otherGroup)
+            continue;
+      auto otherAddrOpt = other.getAddress();
+      assert(otherAddrOpt.has_value() && "buffer must have address assigned");
+      int64_t end = *otherAddrOpt + other.getAllocationSize();
+      if (end > blockerEnd) {
+        blockerEnd = end;
+        blocker = other;
       }
     }
-    prev = cur;
-  }
-  return true;
-}
-
-static bool checkAndPrintOverlapStackframe(int64_t stacksize,
-                                           ArrayRef<BufferOp> buffers) {
-  for (auto buf : buffers) {
-    // A zero-sized buffer covers no bytes, so it cannot overlap the stack.
-    if (buf.getAllocationSize() == 0) {
-      continue;
-    }
-    auto bufAddrOpt = buf.getAddress();
-    assert(bufAddrOpt.has_value() && "buffer must have address assigned");
-    int64_t bufAddr = *bufAddrOpt;
-    if (bufAddr < stacksize) {
-      buf.emitOpError("") << bufferLabel(buf) << " at address 0x"
-                          << llvm::utohexstr(bufAddr)
-                          << " overlaps with stack (size: " << stacksize
-                          << " bytes)";
+    if (blocker && curAddr < blockerEnd) {
+      cur.emitOpError("")
+          << bufferLabel(cur) << " at address 0x" << llvm::utohexstr(curAddr)
+          << " overlaps with " << bufferLabel(blocker) << " at address 0x"
+          << llvm::utohexstr(blocker.getAddress().value())
+          << " (size: " << blocker.getAllocationSize() << " bytes)";
       return false;
     }
   }
@@ -269,6 +273,151 @@ static bool checkAndPrintOverflow(TileOp tile, int64_t address,
     return false;
   }
   return true;
+}
+
+// An allocation unit is either one ordinary buffer or every `alloc_group`
+// on the tile, overlaid.
+// Members of a group are asserted never to be live simultaneously, so they
+// overlay: the unit costs its LARGEST member, not the sum. See AIE_BufferOp's
+// description for what is asserted and what is checked.
+namespace {
+struct AllocUnit {
+  // Each entry is one alloc_group, laid out sequentially from the unit's base.
+  // Entries overlay: they all start at the same base, so the unit costs the
+  // largest group's total, not the sum of every group. An ungrouped buffer is a
+  // unit holding one group of one member, which is the pre-existing behaviour.
+  SmallVector<SmallVector<BufferOp>> groups;
+  int64_t size = 0;     // max over groups of that group's summed extent
+  bool aligned = false; // any member aligned => align the shared base
+};
+} // namespace
+
+// Group this tile's unallocated buffers into allocation units, preserving the
+// pass's existing largest-first order across units.
+static SmallVector<AllocUnit> buildAllocUnits(ArrayRef<BufferOp> buffers) {
+  SmallVector<AllocUnit> units;
+  // Every alloc_group on this tile overlays every other, so they share ONE
+  // unit. groupIndex maps a group name to its slot within that unit's group
+  // list.
+  llvm::MapVector<StringRef, unsigned> groupIndex;
+  std::optional<unsigned> overlayUnit;
+  for (auto buffer : buffers) {
+    auto group = buffer.getAllocGroup();
+    if (!group) {
+      AllocUnit u;
+      u.groups.push_back({buffer});
+      u.size = buffer.getAllocationSize();
+      u.aligned = buffer.getAligned();
+      units.push_back(std::move(u));
+      continue;
+    }
+    if (!overlayUnit) {
+      overlayUnit = units.size();
+      units.push_back(AllocUnit{});
+    }
+    AllocUnit &u = units[*overlayUnit];
+    auto [it, inserted] = groupIndex.try_emplace(*group, u.groups.size());
+    if (inserted)
+      u.groups.push_back({});
+    u.groups[it->second].push_back(buffer);
+    u.aligned |= buffer.getAligned();
+    // A group's extent is its members' sum; the unit's is the largest such sum.
+    int64_t extent = 0;
+    for (auto member : u.groups[it->second])
+      extent += member.getAllocationSize();
+    u.size = std::max(u.size, extent);
+  }
+  std::stable_sort(
+      units.begin(), units.end(),
+      [](const AllocUnit &a, const AllocUnit &b) { return a.size > b.size; });
+  return units;
+}
+
+// The decidable half of the alloc_group assertion: two buffers from different
+// groups that one core references without a selector between them are
+// simultaneously live by construction, so they can never be overlaid whatever
+// the author intended. Catching this here turns a silent memory-aliasing bug
+// into a compile error.
+// Does any buffer on this tile ask for an overlay?
+static bool tileHasAllocGroup(DeviceOp device, TileOp tile) {
+  bool found = false;
+  device.walk([&](BufferOp buffer) {
+    if (buffer.getTileOp() == tile && buffer.getAllocGroup())
+      found = true;
+  });
+  return found;
+}
+
+// Whether two ops sit in branches of one branching op that selects exactly one
+// of them -- the only ground on which two references inside one core body may
+// be called mutually exclusive. Decided at the INNERMOST COMMON ANCESTOR: two
+// ops in different regions of one scf.if / scf.index_switch are exclusive;
+// anything else (different ops, an scf.while whose regions both run, plain
+// sequence) is not.
+//
+// Scoping this at the block rather than the ancestor does not work: the
+// objectFifo lowering hands every buffer reference its own scf.index_switch
+// case, so on a lowered design no two buffers ever share a block and a
+// block-scoped check silently passes everything.
+static bool inExclusiveBranches(Operation *a, Operation *b) {
+  llvm::DenseMap<Operation *, Region *> aChain;
+  for (Region *r = a->getParentRegion(); r; r = r->getParentRegion())
+    if (Operation *parent = r->getParentOp())
+      aChain[parent] = r;
+    else
+      break;
+
+  for (Region *r = b->getParentRegion(); r; r = r->getParentRegion()) {
+    Operation *parent = r->getParentOp();
+    if (!parent)
+      break;
+    auto it = aChain.find(parent);
+    if (it == aChain.end())
+      continue;
+    // Innermost common ancestor. Only a one-of-N selector makes its regions
+    // exclusive; scf.for/scf.while run theirs unconditionally.
+    if (!isa<scf::IfOp, scf::IndexSwitchOp>(parent))
+      return false;
+    return it->second != r;
+  }
+  return false;
+}
+
+static bool checkAllocGroups(DeviceOp device) {
+  bool ok = true;
+  // Collect every reference to a grouped buffer from inside a core. Two
+  // references conflict when they name DIFFERENT groups, since different groups
+  // are the ones the allocator overlays; same-group members get distinct
+  // storage and may be live together, which is the point of the group.
+  device.walk([&](CoreOp core) {
+    SmallVector<std::tuple<BufferOp, Operation *, StringRef>> refs;
+    core.walk([&](Operation *op) {
+      for (Value operand : op->getOperands())
+        if (auto buffer = dyn_cast_or_null<BufferOp>(operand.getDefiningOp()))
+          if (auto group = buffer.getAllocGroup())
+            refs.emplace_back(buffer, op, *group);
+    });
+
+    for (size_t i = 0; i < refs.size(); ++i)
+      for (size_t j = i + 1; j < refs.size(); ++j) {
+        auto [bufI, opI, groupI] = refs[i];
+        auto [bufJ, opJ, groupJ] = refs[j];
+        if (groupI == groupJ)
+          continue;
+        if (inExclusiveBranches(opI, opJ))
+          continue;
+        ok = false;
+        bufJ.emitOpError()
+            << "is in alloc_group '" << groupJ
+            << "' while this aie.core also references a buffer in alloc_group '"
+            << groupI
+            << "', and no selector separates the two references, so they are "
+               "simultaneously live and cannot be overlaid";
+        bufI.emitRemark() << "member of alloc_group '" << groupI << "'";
+        return;
+      }
+  });
+  return ok;
 }
 
 static bool basicAllocation(TileOp tile) {
@@ -341,26 +490,44 @@ static bool basicAllocation(TileOp tile) {
   // final placement. A misaligned candidate otherwise passes the fit test, and
   // getAlignedAddress then bumps it into a pre-allocated buffer.
   auto *current_alloc = allocated_buffers.begin();
-  for (auto buffer : buffers) {
-    assert(!buffer.getAddress());
-    uint32_t reqAlignBits =
-        getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBits);
-    if (buffer.getAligned()) {
-      address = getAlignedAddress(address, reqAlignBits);
-    }
+  for (const AllocUnit &unit : buildAllocUnits(buffers)) {
+    // Every group starts at the unit's base, so the base has to satisfy the
+    // strictest requirement any member has -- a per-buffer figure since
+    // getRequiredAlignBits keys on the buffer's own size.
+    uint32_t unitAlignBits = tileAlignBitWidth;
+    for (const auto &group : unit.groups)
+      for (auto buffer : group)
+        if (buffer.getAligned())
+          unitAlignBits = std::max(
+              unitAlignBits, getRequiredAlignBits(buffer, tileAlignBitWidth,
+                                                  maxVecAlignBits));
+    if (unit.aligned)
+      address = getAlignedAddress(address, unitAlignBits);
     while (current_alloc != allocated_buffers.end() &&
-           address + buffer.getAllocationSize() >
-               current_alloc->getAddress().value()) {
+           address + unit.size > current_alloc->getAddress().value()) {
       address = current_alloc->getAddress().value() +
                 current_alloc->getAllocationSize();
-      if (buffer.getAligned()) {
-        address = getAlignedAddress(address, reqAlignBits);
-      }
+      if (unit.aligned)
+        address = getAlignedAddress(address, unitAlignBits);
       current_alloc++;
     }
 
-    buffer.setAddress(address);
-    address += buffer.getAllocationSize();
+    // Groups overlay: each starts at the unit's base. Members within a group do
+    // not, so they follow one another. The unit advances by the largest group's
+    // total, which is what makes N modes cost max(sum) rather than sum(max).
+    for (const auto &group : unit.groups) {
+      int64_t offset = address;
+      for (auto buffer : group) {
+        assert(!buffer.getAddress());
+        if (buffer.getAligned())
+          offset = getAlignedAddress(
+              offset, getRequiredAlignBits(buffer, tileAlignBitWidth,
+                                           maxVecAlignBits));
+        buffer.setAddress(offset);
+        offset += buffer.getAllocationSize();
+      }
+    }
+    address += unit.size;
   }
 
   sortBuffersByAddress(allBuffers_on_tile);
@@ -1143,6 +1310,12 @@ struct AIEAssignBufferAddressesPass
     DeviceOp device = getOperation();
     materializeCoreDataBuffers(device);
 
+    // alloc_group overlays buffers, so validate the part of its contract that
+    // is decidable before any address is handed out.
+    if (!checkAllocGroups(device))
+      return signalPassFailure();
+
+    // Select allocation scheme per tile
     for (auto tile : device.getOps<TileOp>()) {
       auto tileAllocationScheme = tile.getAllocationScheme();
 
@@ -1156,8 +1329,21 @@ struct AIEAssignBufferAddressesPass
           return signalPassFailure();
         }
       } else if (tileAllocationScheme == "bank-aware") {
+        if (tileHasAllocGroup(device, tile)) {
+          tile.emitOpError(
+              "bank-aware allocation does not implement alloc_group "
+              "overlays; use basic-sequential on this tile");
+          return signalPassFailure();
+        }
         if (simpleBankAwareAllocation(tile) != BankAwareResult::Success) {
           emitAllocationFailure(tile, "bank-aware");
+          return signalPassFailure();
+        }
+      } else if (tileHasAllocGroup(device, tile)) {
+        // Only basic-sequential implements overlays, so do not try bank-aware
+        // first and silently drop them.
+        if (!basicAllocation(tile)) {
+          tile.emitOpError("Basic sequential allocation failed.");
           return signalPassFailure();
         }
       } else {

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoAllocate.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoAllocate.cpp
@@ -136,7 +136,8 @@ struct AIEObjectFifoAllocatePass
       lastPlaced[placement] = BufferOp::create(
           builder, pool.getLoc(), pool.getElemType(), placement,
           builder.getStringAttr(name), /*address=*/nullptr, init,
-          /*mem_bank=*/nullptr, /*aligned=*/nullptr);
+          /*mem_bank=*/nullptr, /*aligned=*/nullptr,
+          /*alloc_group=*/nullptr);
       names.push_back(FlatSymbolRefAttr::get(builder.getContext(), name));
     }
     pool.setBuffersAttr(builder.getArrayAttr(names));

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoAllocate.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoAllocate.cpp
@@ -137,7 +137,10 @@ struct AIEObjectFifoAllocatePass
           builder, pool.getLoc(), pool.getElemType(), placement,
           builder.getStringAttr(name), /*address=*/nullptr, init,
           /*mem_bank=*/nullptr, /*aligned=*/nullptr,
-          /*alloc_group=*/nullptr);
+          // Every slot of one pool is live at once -- that is what depth
+          // means -- so they all take the pool's group and are laid out one
+          // after another; a pool in a different group overlays them.
+          pool.getAllocGroupAttr());
       names.push_back(FlatSymbolRefAttr::get(builder.getContext(), name));
     }
     pool.setBuffersAttr(builder.getArrayAttr(names));

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoSplit.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoSplit.cpp
@@ -213,7 +213,8 @@ struct AIEObjectFifoSplitPass
         repeatCount ? builder.getI32IntegerAttr(*repeatCount) : IntegerAttr(),
         from.getDisableSynchronization(),
         builder.getStringAttr(from.name().getValue()),
-        holdsInitialContents ? from.getInitValuesAttr() : ArrayAttr());
+        holdsInitialContents ? from.getInitValuesAttr() : ArrayAttr(),
+        from.getAllocGroupAttr());
     createSegments(pool, loc, extents);
     return pool;
   }
@@ -314,7 +315,7 @@ struct AIEObjectFifoSplitPass
         /*locks=*/ArrayAttr(), /*repeatCount=*/IntegerAttr(),
         fifo.getDisableSynchronization(),
         builder.getStringAttr(fifo.name().getValue()),
-        /*initValues=*/ArrayAttr());
+        /*initValues=*/ArrayAttr(), fifo.getAllocGroupAttr());
     createSegments(pool, fifo.getLoc(), {{0, elemType.getNumElements()}});
     return PoolRef{pool, {0}};
   }

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -130,7 +130,8 @@ struct AIECreateCoresPass
           BufferOp buf = BufferOp::create(
               builder, callOp.getLoc(), t, tile, /*sym_name*/ nullptr,
               /*address*/ nullptr, /*initial_value*/ nullptr,
-              /*mem_bank*/ nullptr, /*aligned*/ nullptr);
+              /*mem_bank*/ nullptr, /*aligned*/ nullptr,
+              /*alloc_group*/ nullptr);
           buffers[callOperands[i]] = buf;
           operand.replaceAllUsesWith(buf.getResult());
         }

--- a/lib/Dialect/AIEX/Transforms/AIELowerScratchpadParameters.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerScratchpadParameters.cpp
@@ -124,7 +124,8 @@ struct AIELowerScratchpadParametersPass
       auto buf =
           BufferOp::create(builder, readOp.getLoc(), bufType, tile,
                            builder.getStringAttr(bufName), /*address=*/nullptr,
-                           /*initial_value=*/nullptr, /*mem_bank=*/nullptr);
+                           /*initial_value=*/nullptr, /*mem_bank=*/nullptr,
+                           /*aligned=*/nullptr, /*alloc_group=*/nullptr);
       seen[key] = buf;
 
       readOp.setBufferAttr(

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -713,6 +713,9 @@ class object_fifo(ObjectFifoCreateOp):
         self.attributes["aie_stream"] = int_stream_end
         self.attributes["aie_stream_port"] = int_stream_port
 
+    def set_alloc_group(self, group):
+        self.attributes["alloc_group"] = StringAttr.get(group)
+
     def set_prod_dma_channel(self, channel):
         self.attributes["prod_dma_channel"] = IntegerAttr.get(T.i32(), channel)
 

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -90,6 +90,7 @@ class ObjectFifo(Resolvable):
         aie_stream: tuple[int, int] | None = None,
         packet: bool = False,
         packet_id: int | None = None,
+        alloc_group: str | None = None,
     ):
         """Construct an ObjectFifo.
 
@@ -156,6 +157,14 @@ class ObjectFifo(Resolvable):
                 designs that route on the id (e.g. a MemTile dispatching to one of several
                 cores). Requires ``packet``; when absent, allocation picks an id no other
                 flow is using. Defaults to None.
+            alloc_group (str | None, optional): Allocation group name, stamped onto the
+                underlying ``aie.objectfifo`` op and propagated onto every buffer it lowers
+                to. A fifo's own depth slots are live together, which is what one group
+                asserts, so they all share it. Fifos in DIFFERENT groups are asserted by the
+                author never to be live at the same time, so the allocator overlays them: the
+                groups share one region sized at the largest group's total. That is what lets
+                a second mode-selected topology coexist without paying full L1. Only
+                ``basic-sequential`` allocation implements the overlay. Defaults to None.
 
         Raises:
             ValueError: If ``depth`` is provided and is less than 1.
@@ -192,6 +201,7 @@ class ObjectFifo(Resolvable):
         self._aie_stream: tuple[int, int] | None = aie_stream
         self._packet: bool = packet
         self._packet_id: int | None = packet_id
+        self._alloc_group: str | None = alloc_group
 
     @property
     def depth(self) -> int | None:
@@ -484,6 +494,9 @@ class ObjectFifo(Resolvable):
 
             if self._aie_stream is not None:
                 op.set_aie_stream(*self._aie_stream)
+
+            if self._alloc_group is not None:
+                op.set_alloc_group(self._alloc_group)
 
             # Pin DMA channels requested on the handles. The producer channel
             # and one channel per consumer (-1 = auto-assign that consumer) are

--- a/test/assign-buffer-addresses/alloc_group_alignment_padding.mlir
+++ b/test/assign-buffer-addresses/alloc_group_alignment_padding.mlir
@@ -1,0 +1,31 @@
+//===- alloc_group_alignment_padding.mlir -----------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// A unit's size must reflect the alignment padding placement actually inserts
+// between a group's members, not just their summed sizes. Group "a" holds
+// "a2" (80 B, needs 64B vector alignment) then "a1" (64 B, also needs 64B
+// alignment, placed second because it is smaller): a1 lands at 128, not 80,
+// since 80 is not 64-aligned. So group "a" really spans 192 B while the naive
+// sum of its members is only 144 B. Group "b" ("b1", 16 B) is smaller either
+// way and doesn't change which group drives the unit's size.
+//
+// The unit must advance the cursor to 192 (the real end), not 144 (the naive
+// sum): with the bug, "other" lands at 160, inside a1's [128,192) range, and
+// the allocator reports a false overlap instead of succeeding.
+
+// RUN: aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s | FileCheck %s
+// CHECK: aie.buffer({{.*}}) {address = 0 : i32, alloc_group = "a", sym_name = "a2"} : memref<20xi32>
+// CHECK: aie.buffer({{.*}}) {address = 128 : i32, alloc_group = "a", sym_name = "a1"} : memref<16xi32>
+// CHECK: aie.buffer({{.*}}) {address = 0 : i32, alloc_group = "b", sym_name = "b1"} : memref<4xi32>
+// CHECK: aie.buffer({{.*}}) {address = 192 : i32, sym_name = "other"} : memref<2xi32>
+module @test_alloc_group_alignment_padding {
+  aie.device(npu2) {
+    %0 = aie.tile(0, 2)
+    %a2 = aie.buffer(%0) { sym_name = "a2", alloc_group = "a" } : memref<20xi32>
+    %a1 = aie.buffer(%0) { sym_name = "a1", alloc_group = "a" } : memref<16xi32>
+    %b1 = aie.buffer(%0) { sym_name = "b1", alloc_group = "b" } : memref<4xi32>
+    %other = aie.buffer(%0) { sym_name = "other" } : memref<2xi32>
+  }
+}

--- a/test/assign-buffer-addresses/alloc_group_alignment_padding.mlir
+++ b/test/assign-buffer-addresses/alloc_group_alignment_padding.mlir
@@ -1,5 +1,7 @@
 //===- alloc_group_alignment_padding.mlir -----------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/assign-buffer-addresses/alloc_group_max_of_sums.mlir
+++ b/test/assign-buffer-addresses/alloc_group_max_of_sums.mlir
@@ -1,0 +1,50 @@
+//===- alloc_group_max_of_sums.mlir ----------------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// A group is a MODE, so N modes cost max(sum of each mode), not sum(max of each
+// pairing). Mode "a" holds 2048 B + 256 B, mode "b" holds 256 B + 2048 B. Both
+// total 2304 B, so the shared region is 2304 B and "other" follows at
+// 1024 + 2304 = 3328.
+//
+// Pairing the buffers across modes instead -- the only thing a mutual-exclusion
+// attribute could express -- would give max(2048,256) + max(256,2048) = 4096 B
+// and put "other" at 5120. It would also require the two modes to hold the same
+// number of buffers, which grouping by mode does not.
+
+// RUN: aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s | FileCheck %s
+// Within a group members follow the pass's existing largest-first order, so each
+// group places its 2048 B member at the base and its 256 B member above it. The
+// two groups overlay, which is why a2 and b1 share 3072.
+
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, alloc_group = "a", sym_name = "a1"} : memref<512xi32>
+// CHECK: aie.buffer({{.*}}) {address = 3072 : i32, alloc_group = "a", sym_name = "a2"} : memref<64xi32>
+// CHECK: aie.buffer({{.*}}) {address = 3072 : i32, alloc_group = "b", sym_name = "b1"} : memref<64xi32>
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, alloc_group = "b", sym_name = "b2"} : memref<512xi32>
+// CHECK: aie.buffer({{.*}}) {address = 3328 : i32, sym_name = "other"} : memref<128xi32>
+module @test_alloc_group_max_of_sums {
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %a1 = aie.buffer(%0) { sym_name = "a1", alloc_group = "a" } : memref<512xi32>
+    %a2 = aie.buffer(%0) { sym_name = "a2", alloc_group = "a" } : memref<64xi32>
+    %b1 = aie.buffer(%0) { sym_name = "b1", alloc_group = "b" } : memref<64xi32>
+    %b2 = aie.buffer(%0) { sym_name = "b2", alloc_group = "b" } : memref<512xi32>
+    %other = aie.buffer(%0) { sym_name = "other" } : memref<128xi32>
+    %rtp = aie.buffer(%0) { sym_name = "rtp" } : memref<1xi32>
+    aie.core(%0) {
+      %c0 = arith.constant 0 : index
+      %c0_i32 = arith.constant 0 : i32
+      %sel = memref.load %rtp[%c0] : memref<1xi32>
+      %is_a = arith.cmpi eq, %sel, %c0_i32 : i32
+      scf.if %is_a {
+        %v = memref.load %a1[%c0] : memref<512xi32>
+        %u = memref.load %a2[%c0] : memref<64xi32>
+      } else {
+        %w = memref.load %b1[%c0] : memref<64xi32>
+        %x = memref.load %b2[%c0] : memref<512xi32>
+      }
+      aie.end
+    }
+  }
+}

--- a/test/assign-buffer-addresses/alloc_group_max_of_sums.mlir
+++ b/test/assign-buffer-addresses/alloc_group_max_of_sums.mlir
@@ -1,5 +1,7 @@
 //===- alloc_group_max_of_sums.mlir ----------------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/assign-buffer-addresses/alloc_group_nested_error.mlir
+++ b/test/assign-buffer-addresses/alloc_group_nested_error.mlir
@@ -1,0 +1,23 @@
+//===- alloc_group_nested_error.mlir ---------------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// An exempt pair must not hide a real overlap behind it. `in` sits inside `big`
+// and is exempt from it (different groups, so they overlay on purpose); `past`
+// starts exactly where `in` ends, so checking only the previous buffer in
+// address order would clear `past` while it still overlaps `big`. The check
+// compares against the furthest end seen.
+
+// RUN: not aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s 2>&1 | FileCheck %s
+// CHECK: error: 'aie.buffer' op buffer '"past"' at address 0x1100 overlaps with '"big"' at address 0x1000 (size: 4096 bytes)
+
+module @nested_overlap_not_hidden {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    aie.core(%t) { aie.end }
+    %big  = aie.buffer(%t) { sym_name = "big",  address = 4096 : i32, alloc_group = "a" } : memref<1024xi32>
+    %in   = aie.buffer(%t) { sym_name = "in",   address = 4096 : i32, alloc_group = "b" } : memref<64xi32>
+    %past = aie.buffer(%t) { sym_name = "past", address = 4352 : i32 } : memref<64xi32>
+  }
+}

--- a/test/assign-buffer-addresses/alloc_group_nested_error.mlir
+++ b/test/assign-buffer-addresses/alloc_group_nested_error.mlir
@@ -1,5 +1,7 @@
 //===- alloc_group_nested_error.mlir ---------------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/assign-buffer-addresses/basic_alloc_alloc_group.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_alloc_group.mlir
@@ -1,0 +1,26 @@
+//===- basic_alloc_alloc_group.mlir ----------------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// Buffers in DIFFERENT alloc_groups are overlaid: the two groups share one
+// region sized at the larger group's total, so the next ungrouped buffer starts
+// right after it. Here "big" is 2048 B in group "a" and "small" is 256 B in
+// group "b"; both land at 1024, and "other" lands at 1024 + 2048 = 3072.
+// Without the groups it would be at 3328.
+
+// RUN: aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s | FileCheck %s
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, alloc_group = "a", sym_name = "big"} : memref<512xi32>
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, alloc_group = "b", sym_name = "small"} : memref<64xi32>
+// CHECK: aie.buffer({{.*}}) {address = 3072 : i32, sym_name = "other"} : memref<128xi32>
+module @test_alloc_group {
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %big = aie.buffer(%0) { sym_name = "big", alloc_group = "a" } : memref<512xi32>
+    %small = aie.buffer(%0) { sym_name = "small", alloc_group = "b" } : memref<64xi32>
+    %other = aie.buffer(%0) { sym_name = "other" } : memref<128xi32>
+    aie.core(%0) {
+      aie.end
+    }
+  }
+}

--- a/test/assign-buffer-addresses/basic_alloc_alloc_group.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_alloc_group.mlir
@@ -1,5 +1,7 @@
 //===- basic_alloc_alloc_group.mlir ----------------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/assign-buffer-addresses/basic_alloc_alloc_group_error.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_alloc_group_error.mlir
@@ -1,0 +1,25 @@
+//===- basic_alloc_alloc_group_error.mlir ----------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// Two buffers from DIFFERENT alloc_groups referenced by the SAME core with no
+// selector between them are simultaneously live by construction, so overlaying
+// them would alias live data. That half of the contract is decidable, and is
+// rejected.
+
+// RUN: not aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s 2>&1 | FileCheck %s
+// CHECK: error: {{.*}}is in alloc_group 'b' while this aie.core also references a buffer in alloc_group 'a'
+module @test_alloc_group_same_core {
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %big = aie.buffer(%0) { sym_name = "big", alloc_group = "a" } : memref<512xi32>
+    %small = aie.buffer(%0) { sym_name = "small", alloc_group = "b" } : memref<64xi32>
+    aie.core(%0) {
+      %c0 = arith.constant 0 : index
+      %v = memref.load %big[%c0] : memref<512xi32>
+      %w = memref.load %small[%c0] : memref<64xi32>
+      aie.end
+    }
+  }
+}

--- a/test/assign-buffer-addresses/basic_alloc_alloc_group_error.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_alloc_group_error.mlir
@@ -1,5 +1,7 @@
 //===- basic_alloc_alloc_group_error.mlir ----------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/assign-buffer-addresses/basic_alloc_alloc_group_modes.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_alloc_group_modes.mlir
@@ -1,0 +1,41 @@
+//===- basic_alloc_alloc_group_modes.mlir ----------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// The case alloc_group exists to serve: one core carrying two mode bodies, with
+// a runtime selector picking one per dispatch. The two buffers are in different
+// groups and are referenced from different branches of one scf.if, so they are
+// never live together and the overlay is accepted -- both land at 1024 and
+// "other" follows the larger.
+//
+// Contrast basic_alloc_alloc_group_error.mlir, where nothing separates the two
+// references and the same annotation is rejected.
+
+// RUN: aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s | FileCheck %s
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, alloc_group = "a", sym_name = "big"} : memref<512xi32>
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, alloc_group = "b", sym_name = "small"} : memref<64xi32>
+// CHECK: aie.buffer({{.*}}) {address = 3072 : i32, sym_name = "other"} : memref<128xi32>
+module @test_alloc_group_modes {
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %big = aie.buffer(%0) { sym_name = "big", alloc_group = "a" } : memref<512xi32>
+    %small = aie.buffer(%0) { sym_name = "small", alloc_group = "b" } : memref<64xi32>
+    %other = aie.buffer(%0) { sym_name = "other" } : memref<128xi32>
+    %rtp = aie.buffer(%0) { sym_name = "rtp" } : memref<1xi32>
+    aie.core(%0) {
+      %c0 = arith.constant 0 : index
+      %c0_i32 = arith.constant 0 : i32
+      %sel = memref.load %rtp[%c0] : memref<1xi32>
+      %is_a = arith.cmpi eq, %sel, %c0_i32 : i32
+      scf.if %is_a {
+        %v = memref.load %big[%c0] : memref<512xi32>
+        memref.store %v, %other[%c0] : memref<128xi32>
+      } else {
+        %w = memref.load %small[%c0] : memref<64xi32>
+        memref.store %w, %other[%c0] : memref<128xi32>
+      }
+      aie.end
+    }
+  }
+}

--- a/test/assign-buffer-addresses/basic_alloc_alloc_group_modes.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_alloc_group_modes.mlir
@@ -1,5 +1,7 @@
 //===- basic_alloc_alloc_group_modes.mlir ----------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/objectFifo-allocate/alloc_group_propagation.mlir
+++ b/test/objectFifo-allocate/alloc_group_propagation.mlir
@@ -1,0 +1,32 @@
+//===- alloc_group_propagation.mlir ----------------------------*- MLIR -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+// An objectFifo's alloc_group reaches every buffer it lowers to, unmodified. A
+// fifo's own depth slots are live together -- that is what depth means -- which
+// is exactly what one group asserts, so they all carry the same name and stay
+// distinct. Two fifos that never run together take DIFFERENT groups and overlay.
+//
+// The group rides the pool, not the fifo: split gives a shim-fed fifo a
+// separate consumer-side pool, and that is the one whose buffers land in core
+// L1. Without the pool carrying it, the overlay would apply to the producer
+// half only.
+
+// RUN: aie-opt --aie-objectfifo-split --aie-objectfifo-allocate %s | FileCheck %s
+// CHECK-DAG: aie.buffer({{.*}}) {alloc_group = "a", sym_name = "mode_a_cons_buff_0"}
+// CHECK-DAG: aie.buffer({{.*}}) {alloc_group = "a", sym_name = "mode_a_cons_buff_1"}
+// CHECK-DAG: aie.buffer({{.*}}) {alloc_group = "b", sym_name = "mode_b_cons_buff_0"}
+// CHECK-DAG: aie.buffer({{.*}}) {alloc_group = "b", sym_name = "mode_b_cons_buff_1"}
+// CHECK-DAG: aie.buffer({{.*}}) {sym_name = "plain_cons_buff_0"}
+module @alloc_group_propagation {
+  aie.device(npu2) {
+    %shim = aie.tile(0, 0)
+    %shim1 = aie.tile(1, 0)
+    %core = aie.tile(0, 2)
+    %core2 = aie.tile(0, 3)
+    aie.objectfifo @mode_a (%shim, { %core }, 2 : i32) {alloc_group = "a"} : !aie.objectfifo<memref<512xi32>>
+    aie.objectfifo @mode_b (%shim, { %core }, 2 : i32) {alloc_group = "b"} : !aie.objectfifo<memref<64xi32>>
+    aie.objectfifo @plain  (%shim1, { %core2 }, 2 : i32) : !aie.objectfifo<memref<64xi32>>
+  }
+}

--- a/test/objectFifo-allocate/alloc_group_propagation.mlir
+++ b/test/objectFifo-allocate/alloc_group_propagation.mlir
@@ -1,5 +1,7 @@
 //===- alloc_group_propagation.mlir ----------------------------*- MLIR -*-===//
 //
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/python/objectfifo_alloc_group.py
+++ b/test/python/objectfifo_alloc_group.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+# The IRON ObjectFifo constructor plumbs alloc_group onto aie.objectfifo, so
+# two fifos naming different groups may be overlaid by the allocator.
+
+import numpy as np
+
+from aie.iron import ObjectFifo, Program, Runtime, Worker
+from aie.iron.controlflow import range_
+from aie.iron.device import NPU2
+
+line_type = np.ndarray[(256,), np.dtype[np.uint8]]
+
+of_a = ObjectFifo(line_type, name="mode_a", alloc_group="a")
+of_b = ObjectFifo(line_type, name="mode_b", alloc_group="b")
+of_out = ObjectFifo(line_type, name="out")
+
+
+def core_fn(of_a, of_b, of_out):
+    for _ in range_(2):
+        elem_out = of_out.acquire(1)
+        elem_a = of_a.acquire(1)
+        for i in range_(256):
+            elem_out[i] = elem_a[i]
+        of_a.release(1)
+        of_out.release(1)
+
+        elem_out = of_out.acquire(1)
+        elem_b = of_b.acquire(1)
+        for i in range_(256):
+            elem_out[i] = elem_b[i]
+        of_b.release(1)
+        of_out.release(1)
+
+
+worker = Worker(core_fn, [of_a.cons(), of_b.cons(), of_out.prod()])
+
+
+def sequence(a_in, b_in, c_out, a_h, b_h, out_h):
+    a_h.fill(a_in)
+    b_h.fill(b_in)
+    out_h.drain(c_out, wait=True)
+
+
+rt = Runtime(
+    sequence,
+    [line_type, line_type, line_type, of_a.prod(), of_b.prod(), of_out.cons()],
+)
+
+# CHECK-DAG: aie.objectfifo @mode_a{{.*}}alloc_group = "a"
+# CHECK-DAG: aie.objectfifo @mode_b{{.*}}alloc_group = "b"
+print(Program(NPU2(), rt, workers=[worker]).resolve_program())


### PR DESCRIPTION
## Description

An overlay design pays L1 for every mode at once. Buffers that belong to different modes
are never live together, but the allocator has no way to know that, so it sums them and a
mode-selected design carries the cost of the topologies it is not running.

This adds an `alloc_group` attribute on `aie.buffer`. Buffers on the same tile sharing a
group get distinct storage laid out one after another; buffers in *different* groups are
asserted by the author never to be live at the same time, so the allocator overlays the
groups into one region sized at the largest group's total rather than the sum of every
group. Two modes of two buffers each cost `max(a1+a2, b1+b2)`, not
`max(a1,b1) + max(a2,b2)` — for 100/10 against 10/100 that is 110 rather than 200 — and
the modes need not hold the same number of buffers. A buffer with no `alloc_group`
overlays nothing and is allocated exactly as before.

The assertion is the author's; the allocator cannot prove two modes never run together.
What *is* checked is the decidable part: no two buffers from different groups may be
referenced from one `aie.core` unless a one-of-N selector (`scf.if`,
`scf.index_switch`) separates the references, since otherwise they are simultaneously
live by construction. That is a property of the selector, not of the enclosing block —
objectFifo lowering gives each reference its own `scf.index_switch` case, so a
block-scoped check would pass everything.

Two consequences fall out of overlaying. The overlap verifier can no longer compare each
buffer against its immediate predecessor in address order, because an exempt pair can sit
between two buffers that really do overlap and hide it; it now tracks the furthest end
among the earlier buffers each one must stay clear of. For the same reason the tile's
high-water mark is taken as the maximum end across every buffer rather than from the
last one by start address. Bank-aware allocation does not implement overlays and rejects
a tile that uses the attribute, pointing at basic-sequential.

Covered by seven lit tests under `test/assign-buffer-addresses/` and
`test/objectFifo-allocate/`: max-of-sums sizing, alignment padding, the nested-selector
error, the propagation path, and the IRON constructor path
(`test/python/objectfifo_alloc_group.py` builds `ObjectFifo(..., alloc_group=...)` and
checks the emitted attribute).

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
