### PR TITLE
[HRX] Discover pip-installed libhrx without HRX_LIBHRX

### DIFF
--- a/programming_guide/hrx_runtime.md
+++ b/programming_guide/hrx_runtime.md
@@ -41,9 +41,14 @@ values and every HRX environment variable
 
 ## Provisioning `libhrx`
 
-Fetch, checksum-verify, and extract the pinned HRX release (coordinates in
-`utils/hrx-release.env`) with the helper script, then source the environment it
-prints:
+A pip-installed package that ships `libhrx` in the conventional layout
+(`<package>/lib/libhrx.so*` on Linux, `<package>/bin/hrx.dll` on Windows) is
+enough for the Python host. Discovery finds it without importing the package and
+without `HRX_*` variables. CMake does not search site-packages.
+
+For a source/release tree, fetch, checksum-verify, and extract the pinned HRX
+release (coordinates in `utils/hrx-release.env`) with the helper script, then
+source the environment it prints:
 
 ```bash
 source "$(utils/fetch-hrx-release.sh)"

--- a/programming_guide/iron_configuration.md
+++ b/programming_guide/iron_configuration.md
@@ -154,17 +154,16 @@ full step-by-step flow.
 
 ### Library discovery
 
-`libhrx.so` is located by probing standard install locations; these variables
-are high-priority hints (checked in this order), mirroring `FindHRX.cmake`:
+Python locates `libhrx` in this order (filesystem only — no `dlopen`). Explicit
+`HRX_*` hints match `FindHRX.cmake`; CMake does **not** search site-packages.
 
-| Variable | Meaning |
-|----------|---------|
-| `HRX_LIBHRX` | Explicit full path to `libhrx.so`. |
-| `LIBHRX_DIR` | Directory containing `libhrx.so` (e.g. set by `activate_env.sh`). |
+| Source | Meaning |
+|--------|---------|
+| `HRX_LIBHRX` | Explicit full path to `libhrx.so` / `hrx.dll`. |
+| `LIBHRX_DIR` | Directory containing the library (e.g. set by `activate_env.sh`). |
+| pip site-packages | A package that ships `lib/libhrx.so*` or `bin/hrx.dll`. Filesystem only — the package is not imported. |
 | `HRX_DIR` | HRX install prefix (`$HRX_DIR/lib/libhrx.so`, `$HRX_DIR/include/...`). |
-
-If none are set, standard locations (a sibling `hrx` checkout, `$HOME/hrx`,
-`/opt/hrx`, `/usr/local/hrx`, and the loader's `LD_LIBRARY_PATH`) are tried.
+| sibling / `FindHRX` roots | A sibling `hrx` checkout, `$HOME/hrx`, `/opt/hrx`, `/usr/local/hrx`, then the loader's search path. |
 
 ### Runtime behavior
 

--- a/python/utils/hostruntime/hrxruntime/README.md
+++ b/python/utils/hostruntime/hrxruntime/README.md
@@ -157,8 +157,10 @@ cmake … -DAIE_BUILD_HRXXCLBINUTIL=ON     # add to your normal mlir-aie configu
 Auto-detection (`FindHRX.cmake` for C++, `hrxruntime/discovery.py` for Python)
 probes standard locations and a sibling `../hrx-system/build/hrx-install` prefix,
 and prefers the shipped `hrx` CMake package (`find_package(hrx CONFIG)` →
-`hrx::hrx`). If your HRX lives elsewhere, export these **hints** (highest
-priority):
+`hrx::hrx`). Python also locates `libhrx` in a pip-installed package that ships
+it under `<package>/lib` or `<package>/bin` (filesystem only — no import).
+CMake does not search site-packages. If your HRX lives elsewhere, export these
+**hints** (highest priority):
 
 ```bash
 export HRX_DIR=<hrx-install>                  # install prefix w/ include/hrx + lib/libhrx.so
@@ -342,7 +344,7 @@ you ever see all-zero output confirm the transaction bytes reached libhrx intact
 
 | Symptom | Cause / Fix |
 |---|---|
-| `NPU_RUNTIME=hrx … ImportError: libhrx.so could not be located` | HRX not found. Build it (§2), place it as a sibling `../hrx`, or set `HRX_DIR`/`LIBHRX_DIR` (§4). Verify with the §4 probe. |
+| `NPU_RUNTIME=hrx … ImportError: libhrx.so could not be located` | HRX not found. Build it (§2), pip-install a runtime that ships `libhrx`, place it as a sibling `../hrx`, or set `HRX_DIR`/`LIBHRX_DIR` (§4). Verify with the §4 probe. |
 | C++ configure: `USE_HRX=ON but the HRX runtime was not found` | Same as above (CMake side). Set `HRX_DIR`/`CMAKE_PREFIX_PATH` or co-locate `../hrx-system/build/hrx-install`. |
 | C++ link/load: `undefined symbol: hrx_amdxdna_executable_create` | Your `libhrx.so` predates the `amdxdna-hal-native-rel` API. Refresh HRX from the pinned release (§2) and re-check with `nm -D`. |
 | Output is **all zeros** but no error | The transaction didn't reach libhrx intact (or the xclbin/insts pair is mismatched). Confirm you're on this branch and passing the raw `insts.bin`. |

--- a/python/utils/hostruntime/hrxruntime/_bindings.py
+++ b/python/utils/hostruntime/hrxruntime/_bindings.py
@@ -9,11 +9,12 @@ discovery + ``dlopen``, and the bound ``hrx_*`` entry points. The higher-level
 device/stream/buffer/dispatch orchestration lives in :mod:`.context`
 (:class:`~.context.HRXContext`); the package ``__init__`` re-exports both.
 
-Library discovery order for ``libhrx.so``:
-  1. ``$HRX_LIBHRX``                       (explicit full path to the .so)
-  2. ``$LIBHRX_DIR/libhrx.so``             (set by activate_env.sh)
-  3. ``$HRX_DIR/lib/libhrx.so``            (HRX install prefix)
-  4. plain ``libhrx.so`` via the loader (LD_LIBRARY_PATH)
+Library discovery order for ``libhrx``:
+  1. ``$HRX_LIBHRX``                       (explicit full path)
+  2. ``$LIBHRX_DIR/<libhrx>``              (set by activate_env.sh)
+  3. pip site-packages                     (``<pkg>/lib`` or ``<pkg>/bin``; no import)
+  4. ``$HRX_DIR`` / sibling / ``FindHRX`` roots
+  5. plain ``libhrx.so`` / ``hrx.dll`` via the loader
 
 Importing this module is side-effect-free: it performs no ``dlopen`` and no
 device init. Binding is deferred to :meth:`_HrxLib.ensure`, which the first

--- a/python/utils/hostruntime/hrxruntime/discovery.py
+++ b/python/utils/hostruntime/hrxruntime/discovery.py
@@ -3,17 +3,26 @@
 
 """Filesystem discovery for the HRX runtime (no ctypes / no dlopen).
 
-This module mirrors ``FindHRX.cmake`` for the Python host stack: it locates
-``libhrx.so`` by probing standard install locations, treating the ``HRX_*``
-environment variables only as high-priority *hints*. It deliberately performs no
-``dlopen`` so it can be used as a cheap capability probe before committing to
-the heavier ``hrxruntime`` import that actually loads the library.
+Locates ``libhrx`` for the Python host stack. Performs no ``dlopen`` so it can
+serve as a cheap capability probe before committing to the heavier ctypes
+bindings import.
+
+Python looks for the library in this order (CMake ``FindHRX`` shares the env
+hints and filesystem roots, but does not search site-packages):
+
+1. ``$HRX_LIBHRX`` / ``$LIBHRX_DIR`` -- explicit user overrides.
+2. A pip-installed package in site-packages whose layout is
+   ``<package>/lib/libhrx.so*`` (Linux) or ``<package>/bin/hrx.dll`` (Windows).
+   Filesystem only: no package import.
+3. ``$HRX_DIR``, then the same filesystem roots as ``FindHRX.cmake`` (sibling
+   checkout, ``$HOME/hrx``, ``/opt/hrx``, ``/usr/local/hrx``).
+4. Linux loader fallbacks (``/usr/lib``, ``/usr/local/lib``).
 """
 
 import os
 import platform
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 __all__ = [
     "find_libhrx",
@@ -45,6 +54,16 @@ _HRX_ROOT_CANDIDATES = [
     Path("/opt/hrx"),
     Path("/usr/local/hrx"),
 ]
+
+# pip-installed runtime: any site-packages package with the conventional
+# libhrx layout. No distribution name is hardcoded.
+_SKIP_SITE_DIRS = frozenset({"__pycache__", "bin", "lib", "include"})
+
+# Loader fallbacks after env / wheel / install-prefix. Tests clear this so a
+# host with /usr/lib/libhrx.so cannot leak into discovery unit tests.
+_SYSTEM_LIBS: tuple[str, ...] = (
+    () if _IS_WINDOWS else ("/usr/lib/libhrx.so", "/usr/local/lib/libhrx.so")
+)
 
 
 def _existing(paths: List[Optional[str]]) -> List[str]:
@@ -86,13 +105,93 @@ def find_hrx_dir() -> Optional[str]:
     return None
 
 
+def _pip_roots() -> Tuple[Path, ...]:
+    """Return site-packages directories that may contain a pip-installed libhrx."""
+    try:
+        import site
+    except ImportError:
+        return ()
+    raw: List[str] = []
+    try:
+        raw.extend(site.getsitepackages())
+    except Exception:
+        pass
+    try:
+        user = site.getusersitepackages()
+        if user:
+            raw.append(user)
+    except Exception:
+        pass
+    roots: List[Path] = []
+    seen: set[Path] = set()
+    for item in raw:
+        if not item:
+            continue
+        path = Path(item)
+        key = path.resolve() if path.exists() else path
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(path)
+    return tuple(roots)
+
+
+def _libhrx_in_prefix(root: Path) -> Optional[str]:
+    """Return libhrx under an install-prefix or pip-package layout, or None."""
+    if _IS_WINDOWS:
+        for sub in ("bin", "lib"):
+            for name in _LIBHRX_NAMES:
+                candidate = root / sub / name
+                if candidate.is_file():
+                    return str(candidate)
+        return None
+    lib_dir = root / "lib"
+    direct = lib_dir / "libhrx.so"
+    if direct.is_file():
+        return str(direct)
+    try:
+        matches = sorted(lib_dir.glob("libhrx.so*"))
+    except OSError:
+        return None
+    return str(matches[0]) if matches else None
+
+
+def _wheel_libhrx() -> Optional[str]:
+    """Locate libhrx inside a pip-installed package (any distribution name).
+
+    Walks site-packages one package-directory deep for the conventional layout.
+    No ``import`` and no ``dlopen``.
+    """
+    for site_root in _pip_roots():
+        if not site_root.is_dir():
+            continue
+        try:
+            packages = sorted(
+                p
+                for p in site_root.iterdir()
+                if p.is_dir()
+                and p.name not in _SKIP_SITE_DIRS
+                and not p.name.endswith((".dist-info", ".egg-info"))
+                and not p.name.startswith(".")
+            )
+        except OSError:
+            continue
+        for pkg in packages:
+            found = _libhrx_in_prefix(pkg)
+            if found:
+                return found
+    return None
+
+
 def find_libhrx() -> Optional[str]:
     """Locate the HRX shared library, honoring env hints then standard locations.
 
     On Linux this looks for ``libhrx.so``; on Windows for ``hrx.dll`` /
     ``libhrx.dll`` (which the packaged release ships under ``bin/``, with the
     import lib ``hrx.lib`` under ``lib/``). ``HRX_LIBHRX`` (explicit full path)
-    and ``LIBHRX_DIR`` (a directory to search) are honored on both.
+    and ``LIBHRX_DIR`` (a directory to search) are honored on both. A
+    pip-installed package that ships libhrx in the conventional layout is
+    probed next, then the sibling / ``FindHRX`` roots.
 
     Returns:
         Optional[str]: The path to the first existing HRX shared library found,
@@ -104,6 +203,7 @@ def find_libhrx() -> Optional[str]:
     candidates: List[Optional[str]] = [os.environ.get("HRX_LIBHRX")]
     if libhrx_dir:
         candidates += [os.path.join(libhrx_dir, n) for n in _LIBHRX_NAMES]
+    candidates.append(_wheel_libhrx())
 
     if _IS_WINDOWS:
         if hrx_dir:
@@ -127,7 +227,7 @@ def find_libhrx() -> Optional[str]:
                     hrx_dir, "build", "cmake", "libhrx", "src", "libhrx", "libhrx.so"
                 )
             )
-        candidates += ["/usr/lib/libhrx.so", "/usr/local/lib/libhrx.so"]
+    candidates += list(_SYSTEM_LIBS)
 
     found = _existing(candidates)
     return found[0] if found else None

--- a/test/python/test_hrx_discovery.py
+++ b/test/python/test_hrx_discovery.py
@@ -1,0 +1,111 @@
+# test_hrx_discovery.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# RUN: %pytest %s
+
+"""Discovery of libhrx: env hints, pip layout, then FindHRX roots."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from aie.utils.hostruntime.hrxruntime import discovery
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_hrx(monkeypatch):
+    """Neutralize the host's own HRX so tests see only what they set up."""
+    for var in ("HRX_LIBHRX", "LIBHRX_DIR", "HRX_DIR"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(discovery, "_HRX_ROOT_CANDIDATES", [])
+    monkeypatch.setattr(discovery, "_SYSTEM_LIBS", ())
+    monkeypatch.setattr(discovery, "_pip_roots", lambda: ())
+
+
+def _lib_name() -> str:
+    return discovery._LIBHRX_NAMES[0]
+
+
+def _make_lib(directory: Path, name: str | None = None) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    lib = directory / (name or _lib_name())
+    lib.write_bytes(b"stub")
+    return lib
+
+
+def _make_pip_package(site: Path, name: str = "hrx_wheel") -> Path:
+    """Conventional pip layout: ``<site>/<name>/{lib,bin}/libhrx``."""
+    pkg = site / name
+    sub = "bin" if discovery._IS_WINDOWS else "lib"
+    lib = _make_lib(pkg / sub)
+    (pkg / "__init__.py").write_text("raise RuntimeError('must not import')\n")
+    return lib
+
+
+def test_explicit_lib_path_is_honored(tmp_path, monkeypatch):
+    lib = _make_lib(tmp_path / "opt")
+    monkeypatch.setenv("HRX_LIBHRX", str(lib))
+    assert discovery.find_libhrx() == str(lib)
+    assert discovery.hrx_available() is True
+
+
+def test_libhrx_dir_beats_wheel(tmp_path, monkeypatch):
+    hinted = _make_lib(tmp_path / "hint")
+    site = tmp_path / "site"
+    _make_pip_package(site)
+    monkeypatch.setenv("LIBHRX_DIR", str(tmp_path / "hint"))
+    monkeypatch.setattr(discovery, "_pip_roots", lambda: (site,))
+    assert Path(discovery.find_libhrx()).resolve() == hinted.resolve()
+
+
+def test_wheel_beats_sibling_and_system(tmp_path, monkeypatch):
+    site = tmp_path / "site"
+    wheel = _make_pip_package(site)
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    (sibling / "include" / "hrx").mkdir(parents=True)
+    (sibling / "include" / "hrx" / "hrx_runtime.h").write_text("/* stub */")
+    _make_lib(sibling / "lib")
+    system = _make_lib(tmp_path / "system")
+    monkeypatch.setattr(discovery, "_pip_roots", lambda: (site,))
+    monkeypatch.setattr(discovery, "_HRX_ROOT_CANDIDATES", [sibling])
+    monkeypatch.setattr(discovery, "_SYSTEM_LIBS", (str(system),))
+    assert Path(discovery.find_libhrx()).resolve() == wheel.resolve()
+
+
+def test_system_lib_is_last_resort(tmp_path, monkeypatch):
+    lib = _make_lib(tmp_path / "system")
+    monkeypatch.setattr(discovery, "_SYSTEM_LIBS", (str(lib),))
+    assert discovery.find_libhrx() == str(lib)
+
+
+def test_missing_returns_none():
+    assert discovery.find_libhrx() is None
+    assert discovery.hrx_available() is False
+
+
+def test_pip_package_without_libhrx_falls_through(tmp_path, monkeypatch):
+    site = tmp_path / "site"
+    pkg = site / "unrelated"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    system = _make_lib(tmp_path / "system")
+    monkeypatch.setattr(discovery, "_pip_roots", lambda: (site,))
+    monkeypatch.setattr(discovery, "_SYSTEM_LIBS", (str(system),))
+    assert discovery.find_libhrx() == str(system)
+
+
+def test_wheel_libhrx_is_none_when_not_installed():
+    assert discovery._wheel_libhrx() is None
+
+
+def test_pip_layout_does_not_import_the_package(tmp_path, monkeypatch):
+    site = tmp_path / "site"
+    lib = _make_pip_package(site, name="hrx_wheel")
+    monkeypatch.setattr(discovery, "_pip_roots", lambda: (site,))
+    found = discovery._wheel_libhrx()
+    assert found is not None
+    assert Path(found).resolve() == lib.resolve()
+    assert "hrx_wheel" not in sys.modules


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

<!-- What does this PR change, and why? Link any related issue with "Fixes #123". -->

Python only searched env hints and FindHRX filesystem roots, so a pip runtime was invisible unless HRX_LIBHRX was set. After those hints, look in site-packages for the conventional <package>/lib or <package>/bin layout. No package import, no dlopen, and CMake is unchanged.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
