### PR TITLE
[AIEX] Keep the runtime BD pool off statically-assigned ids

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -267,6 +267,11 @@ verifyOutOfOrderChannel(mlir::Operation *op, DMAChannelDir dir, bool outOfOrder,
                         llvm::ArrayRef<DMABDOp> bds,
                         bool packetEnabledByContext = false);
 
+// BD ids already assigned within a tile's static DMA program (the
+// aie.dma_bd chain(s) inside one DmaBody-implementing op: aie.mem,
+// aie.memtile_dma, aie.shim_dma).
+llvm::SmallVector<uint32_t> getAssignedBdIds(DmaBody program);
+
 } // namespace xilinx::AIE
 
 namespace llvm {

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -94,6 +94,21 @@ inline BdPool bd_pool_init(uint32_t n) {
   return p;
 }
 
+// Withhold `id` from the pool, for a BD the static allocator already placed on
+// this tile. BD IDs index one table per tile, shared by the statically
+// configured DMAs and by this pool, so an id handed out here that a static BD
+// already owns would silently overwrite that BD's slot. The compiler emits one
+// of these per statically-assigned id on a pooled tile, right after
+// bd_pool_init; a tile carrying no static BDs emits none, leaving the pool and
+// the generated stream exactly as before.
+inline void bd_pool_reserve(BdPool &p, uint32_t id) {
+  for (int i = 0; i < p.head; ++i)
+    if (p.free_ids[i] == id) {
+      p.free_ids[i] = p.free_ids[--p.head];
+      return;
+    }
+}
+
 // Pop a free BD ID into `out`. Returns false if the pool is empty -- the
 // generated builder turns that into a `return std::nullopt`, so a runtime
 // working set that exceeds the tile's BD count yields no stream rather than a

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -94,13 +94,8 @@ inline BdPool bd_pool_init(uint32_t n) {
   return p;
 }
 
-// Withhold `id` from the pool, for a BD the static allocator already placed on
-// this tile. BD IDs index one table per tile, shared by the statically
-// configured DMAs and by this pool, so an id handed out here that a static BD
-// already owns would silently overwrite that BD's slot. The compiler emits one
-// of these per statically-assigned id on a pooled tile, right after
-// bd_pool_init; a tile carrying no static BDs emits none, leaving the pool and
-// the generated stream exactly as before.
+// Withhold `id` from the pool -- a static BD already owns that slot in the
+// tile's shared BD table, and popping it here would silently overwrite it.
 inline void bd_pool_reserve(BdPool &p, uint32_t id) {
   for (int i = 0; i < p.head; ++i)
     if (p.free_ids[i] == id) {

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -96,10 +96,15 @@ inline BdPool bd_pool_init(uint32_t n) {
 
 // Withhold `id` from the pool -- a static BD already owns that slot in the
 // tile's shared BD table, and popping it here would silently overwrite it.
+// `free_ids[0..head)` is kept sorted highest-to-lowest (see bd_pool_init) so
+// pop keeps handing out the lowest remaining id first; shift the tail down
+// instead of swapping in the top, which would scramble that order.
 inline void bd_pool_reserve(BdPool &p, uint32_t id) {
   for (int i = 0; i < p.head; ++i)
     if (p.free_ids[i] == id) {
-      p.free_ids[i] = p.free_ids[--p.head];
+      for (int j = i; j < p.head - 1; ++j)
+        p.free_ids[j] = p.free_ids[j + 1];
+      --p.head;
       return;
     }
 }

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -66,21 +66,12 @@ std::string bdPoolName(uint32_t col, uint32_t row) {
 llvm::SmallVector<uint32_t, 8> staticBdIdsOnTile(AIE::DeviceOp device,
                                                  uint32_t col, uint32_t row) {
   llvm::SmallVector<uint32_t, 8> ids;
-  auto collect = [&](AIE::TileElement elem, Region &region) {
-    auto id = elem.getTileID();
+  for (AIE::DmaBody program : device.getOps<AIE::DmaBody>()) {
+    auto id = program.getTileID();
     if (id.col != static_cast<int>(col) || id.row != static_cast<int>(row))
-      return;
-    region.walk([&](AIE::DMABDOp bd) {
-      if (auto bdId = bd.getBdId())
-        ids.push_back(*bdId);
-    });
-  };
-  for (auto mem : device.getOps<AIE::MemOp>())
-    collect(mem, mem->getRegion(0));
-  for (auto mem : device.getOps<AIE::MemTileDMAOp>())
-    collect(mem, mem->getRegion(0));
-  for (auto mem : device.getOps<AIE::ShimDMAOp>())
-    collect(mem, mem->getRegion(0));
+      continue;
+    llvm::append_range(ids, AIE::getAssignedBdIds(program));
+  }
   llvm::sort(ids);
   ids.erase(llvm::unique(ids), ids.end());
   return ids;

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -60,6 +60,32 @@ std::string bdPoolName(uint32_t col, uint32_t row) {
   return "bd_pool_" + std::to_string(col) + "_" + std::to_string(row);
 }
 
+// BD ids the static allocator has already placed on (col, row), read off the
+// placed aie.mem / aie.memtile_dma / aie.shim_dma chains. Sorted so the emitted
+// stream is deterministic.
+llvm::SmallVector<uint32_t, 8> staticBdIdsOnTile(AIE::DeviceOp device,
+                                                 uint32_t col, uint32_t row) {
+  llvm::SmallVector<uint32_t, 8> ids;
+  auto collect = [&](AIE::TileElement elem, Region &region) {
+    auto id = elem.getTileID();
+    if (id.col != static_cast<int>(col) || id.row != static_cast<int>(row))
+      return;
+    region.walk([&](AIE::DMABDOp bd) {
+      if (auto bdId = bd.getBdId())
+        ids.push_back(*bdId);
+    });
+  };
+  for (auto mem : device.getOps<AIE::MemOp>())
+    collect(mem, mem->getRegion(0));
+  for (auto mem : device.getOps<AIE::MemTileDMAOp>())
+    collect(mem, mem->getRegion(0));
+  for (auto mem : device.getOps<AIE::ShimDMAOp>())
+    collect(mem, mem->getRegion(0));
+  llvm::sort(ids);
+  ids.erase(llvm::unique(ids), ids.end());
+  return ids;
+}
+
 // A uint32_t literal operand (e.g. `42u`) for a txn_append_* argument. Used for
 // the compile-time-resolved address fields (buffer/col/row are folded in).
 Value u32Literal(OpBuilder &b, Location loc, uint32_t val) {
@@ -578,6 +604,16 @@ private:
                                 "aie_runtime::BdPool " + bdPoolName(col, row) +
                                     " = aie_runtime::bd_pool_init(" +
                                     std::to_string(numBDs) + ");");
+      // The pool starts owning every id on the tile, but the BD table is
+      // shared with whatever the static allocator already placed there. Hand
+      // back the ids it took, or a pop would return one that a static BD
+      // already owns and overwrite its slot. Nothing is emitted for a tile
+      // with no static BDs, which is the usual case.
+      for (uint32_t id : staticBdIdsOnTile(deviceOp, col, row))
+        emitc::VerbatimOp::create(fb, loc,
+                                  "aie_runtime::bd_pool_reserve(" +
+                                      bdPoolName(col, row) + ", " +
+                                      std::to_string(id) + ");");
     });
 
     // A rolled loop makes the op count a runtime quantity: declare a __opcount

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -604,11 +604,7 @@ private:
                                 "aie_runtime::BdPool " + bdPoolName(col, row) +
                                     " = aie_runtime::bd_pool_init(" +
                                     std::to_string(numBDs) + ");");
-      // The pool starts owning every id on the tile, but the BD table is
-      // shared with whatever the static allocator already placed there. Hand
-      // back the ids it took, or a pop would return one that a static BD
-      // already owns and overwrite its slot. Nothing is emitted for a tile
-      // with no static BDs, which is the usual case.
+      // Hand back the ids the static allocator already placed on this tile.
       for (uint32_t id : staticBdIdsOnTile(deviceOp, col, row))
         emitc::VerbatimOp::create(fb, loc,
                                   "aie_runtime::bd_pool_reserve(" +

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2987,6 +2987,15 @@ bool xilinx::AIE::isContiguousBDTransfer(llvm::ArrayRef<BDDimLayoutAttr> dims) {
   return true;
 }
 
+llvm::SmallVector<uint32_t> xilinx::AIE::getAssignedBdIds(DmaBody program) {
+  llvm::SmallVector<uint32_t> ids;
+  program.getDmaBody().walk([&](DMABDOp bd) {
+    if (auto id = bd.getBdId())
+      ids.push_back(*id);
+  });
+  return ids;
+}
+
 LogicalResult DMABDOp::verify() {
   // Skip verification of the BDOp outside of mem operations.
   // BDOps may appear elsewhere and subsequent lowerings will place them in the

--- a/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
@@ -59,16 +59,11 @@ struct AIEAssignRuntimeSequenceBDIDsPass
   // doesn't hand the same id to a runtime-sequence task.
   static void seedFromStaticBds(AIE::DeviceOp device, AIE::TileOp tile,
                                 BdIdGenerator &gen) {
-    auto seedRegion = [&](Region &region) {
-      region.walk([&](AIE::DMABDOp bd) {
-        if (auto id = bd.getBdId())
-          if (!gen.bdIdAlreadyAssigned(*id))
-            gen.assignBdId(*id);
-      });
-    };
     for (AIE::DmaBody program : device.getOps<AIE::DmaBody>())
       if (program.getTileID() == tile.getTileID())
-        seedRegion(program.getDmaBody());
+        for (uint32_t id : AIE::getAssignedBdIds(program))
+          if (!gen.bdIdAlreadyAssigned(id))
+            gen.assignBdId(id);
   }
 
   BdIdGenerator &getGeneratorForTile(AIE::TileOp tile) {

--- a/test/Runtime/TxnEncoding/bd_pool_host.cpp
+++ b/test/Runtime/TxnEncoding/bd_pool_host.cpp
@@ -7,10 +7,12 @@
 //
 // Exercises the header-only runtime BD free-list pool in TxnEncoding.h the way
 // generated host C++ consumes it: init a pool sized to a tile's BD count, then
-// pop/push ids. Focus is the exhaustion backstop -- bd_pool_pop returns false
-// when the working set exceeds the tile's BD count, which the generated builder
-// turns into `return std::nullopt`. This is the only path the MLIR/e2e tests
-// verify statically (the write32 emission) but never trigger at runtime.
+// pop/push/reserve ids. Focus is the exhaustion backstop -- bd_pool_pop
+// returns false when the working set exceeds the tile's BD count, which the
+// generated builder turns into `return std::nullopt`; and bd_pool_reserve's
+// lowest-id-first invariant after removing an id from the middle of the pool.
+// These are the only paths the MLIR/e2e tests verify statically (the write32
+// emission) but never trigger at runtime.
 //
 //===----------------------------------------------------------------------===//
 
@@ -68,6 +70,41 @@ int main() {
     while (bd_pool_pop(p, id))
       ++count;
     check(count == kMaxBDsPerTile, "pop count is clamped to kMaxBDsPerTile");
+  }
+
+  // Reserve removes an id from the middle of the pool without disturbing
+  // pop's lowest-first order among the ids left behind.
+  {
+    BdPool p = bd_pool_init(4);
+    bd_pool_reserve(p, 2);
+    uint32_t id = 99;
+    check(bd_pool_pop(p, id) && id == 0, "reserve leaves id 0 as next pop");
+    check(bd_pool_pop(p, id) && id == 1, "reserve leaves id 1 as next pop");
+    check(bd_pool_pop(p, id) && id == 3, "reserved id 2 is skipped");
+    check(!bd_pool_pop(p, id), "pool is empty after the 3 remaining ids");
+  }
+
+  // Reserving the highest id (the bottom of the stack, popped last) must not
+  // reorder the ids that pop lowest-first before it.
+  {
+    BdPool p = bd_pool_init(4);
+    bd_pool_reserve(p, 3);
+    uint32_t id = 99;
+    for (uint32_t expect = 0; expect < 3; ++expect) {
+      check(bd_pool_pop(p, id), "pop within remaining capacity should succeed");
+      check(id == expect, "reserving the top id preserves lowest-first order");
+    }
+    check(!bd_pool_pop(p, id), "pool is empty after the 3 remaining ids");
+  }
+
+  // Reserving an id not present in the pool (already popped, or never valid)
+  // is a no-op -- it must not corrupt the pool or crash.
+  {
+    BdPool p = bd_pool_init(2);
+    bd_pool_reserve(p, 99);
+    uint32_t a = 0, b = 0;
+    check(bd_pool_pop(p, a) && a == 0, "pool unaffected by reserving a missing id");
+    check(bd_pool_pop(p, b) && b == 1, "pool unaffected by reserving a missing id");
   }
 
   if (failures > 0) {

--- a/test/Runtime/TxnEncoding/bd_pool_host.cpp
+++ b/test/Runtime/TxnEncoding/bd_pool_host.cpp
@@ -103,8 +103,10 @@ int main() {
     BdPool p = bd_pool_init(2);
     bd_pool_reserve(p, 99);
     uint32_t a = 0, b = 0;
-    check(bd_pool_pop(p, a) && a == 0, "pool unaffected by reserving a missing id");
-    check(bd_pool_pop(p, b) && b == 1, "pool unaffected by reserving a missing id");
+    check(bd_pool_pop(p, a) && a == 0,
+          "pool unaffected by reserving a missing id");
+    check(bd_pool_pop(p, b) && b == 1,
+          "pool unaffected by reserving a missing id");
   }
 
   if (failures > 0) {

--- a/test/Targets/NPU/aie_npu_to_cpp_bd_pool_static_reserve.mlir
+++ b/test/Targets/NPU/aie_npu_to_cpp_bd_pool_static_reserve.mlir
@@ -45,8 +45,8 @@ aie.device(npu2) {
   aie.shim_dma_allocation @of_in (%tile_0_0, MM2S, 1)
   aie.runtime_sequence @pool(%in: memref<8192xi32>) {
     %bd = aiex.dma_bd_pool_pop(0, 0) : i32
-    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 1) bd_id %bd : i32 {
-      aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 1) {
+      aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1]) bd_id_val %bd : i32
       aie.end
     } {issue_token = true}
     aiex.dma_start_task(%t)

--- a/test/Targets/NPU/aie_npu_to_cpp_bd_pool_static_reserve.mlir
+++ b/test/Targets/NPU/aie_npu_to_cpp_bd_pool_static_reserve.mlir
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// bd_pool_init seeds the free list with every id on the tile, and pop hands
+// out id 0 first. But the BD table is one per tile, shared with whatever the
+// static allocator already placed there -- so on a tile carrying both a
+// static shim BD and this pool, an unreserved pop would hand out the static
+// BD's id and overwrite its slot.
+//
+// Here tile (0, 0) carries a static shim BD at id 0 (MM2S channel 0) and a
+// runtime sequence that draws from the pool for a second stream (MM2S
+// channel 1). The pool must reserve id 0 right after init, so its first pop
+// returns something other than 0.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-dma-tasks-to-npu --aie-dma-to-npu %s \
+// RUN: | aie-translate --aie-npu-to-cpp | FileCheck %s
+
+// CHECK: inline std::optional<std::vector<uint32_t>> generate_txn_
+// CHECK: aie_runtime::BdPool bd_pool_0_0 = aie_runtime::bd_pool_init(16);
+// The static shim BD's id (0) is withheld right after the pool is seeded.
+// CHECK-NEXT: aie_runtime::bd_pool_reserve(bd_pool_0_0, 0);
+// CHECK: uint32_t bd_{{[0-9]+}}; if (!aie_runtime::bd_pool_pop(bd_pool_0_0, bd_{{[0-9]+}})) return std::nullopt;
+
+aie.device(npu2) {
+  %tile_0_0 = aie.tile(0, 0)
+  %sb = aie.external_buffer {sym_name = "sb"} : memref<8xi32>
+
+  // Static shim BD, statically assigned id 0.
+  aie.shim_dma(%tile_0_0) {
+      aie.dma_start(MM2S, 0, ^bd0, ^end)
+    ^bd0:
+      aie.dma_bd(%sb : memref<8xi32> offset = 0 len = 4) {bd_id = 0 : i32}
+      aie.next_bd ^end
+    ^end:
+      aie.end
+  }
+
+  aie.shim_dma_allocation @of_in (%tile_0_0, MM2S, 1)
+  aie.runtime_sequence @pool(%in: memref<8192xi32>) {
+    %bd = aiex.dma_bd_pool_pop(0, 0) : i32
+    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 1) bd_id %bd : i32 {
+      aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%t)
+    aiex.dma_await_task(%t)
+    aiex.dma_bd_pool_push(0, 0) bd_id %bd : i32
+  }
+}


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Same bug class as the per-tile BD-id fix in https://github.com/Xilinx/mlir-aie/pull/3615, for a third holder of ids: bd_pool_init seeds the free list with every id on the tile and hands out id 0 first, ignoring any BD the static allocator already placed there.

Emit a bd_pool_reserve per statically-assigned id right after pool init. A tile with no static BDs (the common case) emits none, so existing output is byte-identical.

Includes a new standalone lit test (a shim tile with a static BD on one channel and a pool-backed runtime sequence on another) — confirmed it fails without the fix.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
