### PR TITLE
[AIE] Model program memory size

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -258,6 +258,9 @@ public:
   /// Return the size (in bytes) of the local data memory of a core.
   virtual uint32_t getLocalMemorySize() const = 0;
 
+  /// Return the size (in bytes) of a core's program memory.
+  virtual uint32_t getProgramMemorySize() const = 0;
+
   /// Return the default stack reservation (in bytes) for a core, used when a
   /// design does not state one. The linker script places the stack directly
   /// below the objectFIFO buffers with no clearance, so a design whose frames
@@ -541,6 +544,7 @@ public:
   uint32_t getMemNorthBaseAddress() const override { return 0x00030000; }
   uint32_t getMemEastBaseAddress() const override { return 0x00038000; }
   uint32_t getLocalMemorySize() const override { return 0x00008000; }
+  uint32_t getProgramMemorySize() const override { return 0x00004000; }
   uint32_t getAccumulatorCascadeSize() const override { return 384; }
   uint32_t getComputeTileLoadStoreBusWidth() const override { return 128; }
 
@@ -674,6 +678,7 @@ public:
   uint32_t getMemNorthBaseAddress() const override { return 0x00060000; }
   uint32_t getMemEastBaseAddress() const override { return 0x00070000; }
   uint32_t getLocalMemorySize() const override { return 0x00010000; }
+  uint32_t getProgramMemorySize() const override { return 0x00004000; }
   uint32_t getAccumulatorCascadeSize() const override { return 512; }
   uint32_t getComputeTileLoadStoreBusWidth() const override { return 256; }
 

--- a/lib/Targets/AIETargetLdScript.cpp
+++ b/lib/Targets/AIETargetLdScript.cpp
@@ -123,11 +123,9 @@ LogicalResult xilinx::AIE::AIETranslateToLdScript(ModuleOp module,
       int origin =
           targetModel.getMemInternalBaseAddress(srcCoord) + bestGapStart;
       int length = bestGapLen;
-      // The program region has to be the real program memory size. It was
-      // hardcoded to 0x20000 -- eight times the actual 0x4000 -- which let a
-      // core whose .text overflowed link cleanly and then fail much later, in
-      // aie-rt's ELF loader, with a bare "Overflow of program memory" and no
-      // indication of which core.
+      // Was hardcoded to 0x20000 -- eight times the real 0x4000 -- which let
+      // an overflowing core link cleanly and fail much later in aie-rt's ELF
+      // loader instead of here, at the linker, naming the section.
       output << R"THESCRIPT(
 MEMORY
 {

--- a/lib/Targets/AIETargetLdScript.cpp
+++ b/lib/Targets/AIETargetLdScript.cpp
@@ -123,11 +123,17 @@ LogicalResult xilinx::AIE::AIETranslateToLdScript(ModuleOp module,
       int origin =
           targetModel.getMemInternalBaseAddress(srcCoord) + bestGapStart;
       int length = bestGapLen;
+      // The program region has to be the real program memory size. It was
+      // hardcoded to 0x20000 -- eight times the actual 0x4000 -- which let a
+      // core whose .text overflowed link cleanly and then fail much later, in
+      // aie-rt's ELF loader, with a bare "Overflow of program memory" and no
+      // indication of which core.
       output << R"THESCRIPT(
 MEMORY
 {
-   program (RX) : ORIGIN = 0, LENGTH = 0x0020000
 )THESCRIPT";
+      output << "   program (RX) : ORIGIN = 0, LENGTH = 0x"
+             << llvm::utohexstr(targetModel.getProgramMemorySize()) << "\n";
       output << "   data (!RX) : ORIGIN = 0x" << llvm::utohexstr(origin)
              << ", LENGTH = 0x" << llvm::utohexstr(length);
       output << R"THESCRIPT(

--- a/test/CppTests/target_model.cpp
+++ b/test/CppTests/target_model.cpp
@@ -199,7 +199,20 @@ void test() {
   }
 }
 
+// Program memory is 16 KB on every generation, per aie-rt's XAie_CoreMod
+// tables. The same number appears in python/utils/regdb.py's MEMORY_REGIONS --
+// keep them in step.
+void testProgramMemory() {
+  for (auto dev :
+       {AIE::AIEDevice::xcvc1902, AIE::AIEDevice::npu1, AIE::AIEDevice::npu2}) {
+    const auto &tm = AIE::getTargetModel(dev);
+    if (tm.getProgramMemorySize() != 0x4000)
+      throw std::runtime_error("Failed program memory size");
+  }
+}
+
 int main() {
   test();
+  testProgramMemory();
   return 0;
 }

--- a/test/generate-mmap/test_mmap0.mlir
+++ b/test/generate-mmap/test_mmap0.mlir
@@ -73,7 +73,7 @@
 
 // LD44: MEMORY
 // LD44-NEXT: {
-// LD44-NEXT:    program (RX) : ORIGIN = 0, LENGTH = 0x0020000
+// LD44-NEXT:    program (RX) : ORIGIN = 0, LENGTH = 0x4000
 // LD44-NEXT:    data (!RX) : ORIGIN = 0x28450, LENGTH = 0x7BB0
 // LD44-NEXT: }
 // LD44-NEXT: ENTRY(__start)

--- a/test/generate-mmap/test_mmap_data_region_gap.mlir
+++ b/test/generate-mmap/test_mmap_data_region_gap.mlir
@@ -31,7 +31,7 @@
 
 // LD02: MEMORY
 // LD02-NEXT: {
-// LD02-NEXT:    program (RX) : ORIGIN = 0, LENGTH = 0x0020000
+// LD02-NEXT:    program (RX) : ORIGIN = 0, LENGTH = 0x4000
 // LD02-NEXT:    data (!RX) : ORIGIN = 0x74000, LENGTH = 0x4000
 // LD02-NEXT: }
 


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

The generated linker script hardcoded the program region to LENGTH = 0x20000 — 8x the real 16 KB. A core whose .text overflowed linked cleanly and only failed much later, inside aie-rt's ELF loader, with a bare "Overflow of program memory" and no indication of which core.

Add getProgramMemorySize() to AIETargetModel and drive the linker script from it, so an overflow is a linker error naming the section.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
