### PR TITLE
[AIEExpandLoadPdi] Keep the empty-PDI reset alternating across dispatches

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Pass/Pass.h"
 
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -79,6 +80,27 @@ static AIE::DeviceOp getOrCreateCtrlPktOverlayCopy(ModuleOp moduleOp,
   return clonedDev;
 }
 
+// The empty device whose PDI load makes the firmware reset the array. `parity`
+// alternates so that two consecutive loads never name the same PDI (see
+// transformLoadPdi).
+static AIE::DeviceOp getOrCreateEmptyDevice(ModuleOp moduleOp,
+                                            AIE::AIEDevice deviceType,
+                                            unsigned parity) {
+  std::string emptyName = "empty_" + std::to_string(parity);
+  if (auto existing = moduleOp.lookupSymbol<AIE::DeviceOp>(emptyName))
+    return existing;
+
+  OpBuilder builder(moduleOp.getContext());
+  builder.setInsertionPointToStart(moduleOp.getBody());
+  auto loc = builder.getUnknownLoc();
+  auto emptyDevice = AIE::DeviceOp::create(builder, loc, deviceType,
+                                           builder.getStringAttr(emptyName));
+  emptyDevice.getRegion().emplaceBlock();
+  builder.setInsertionPointToEnd(&emptyDevice.getRegion().front());
+  AIE::EndOp::create(builder, loc);
+  return emptyDevice;
+}
+
 // Helper to transform a single load_pdi operation
 static LogicalResult transformLoadPdi(NpuLoadPdiOp loadPdiOp, ModuleOp moduleOp,
                                       unsigned index,
@@ -127,21 +149,8 @@ static LogicalResult transformLoadPdi(NpuLoadPdiOp loadPdiOp, ModuleOp moduleOp,
     preloadRef = FlatSymbolRefAttr::get(builder.getContext(), overlayName);
   } else {
     // Empty device PDI (triggers firmware reset)
-    OpBuilder::InsertionGuard guard(builder);
-    builder.setInsertionPointToStart(moduleOp.getBody());
-
-    std::string emptyName = "empty_" + std::to_string(index % 2);
-    AIE::DeviceOp emptyDevice = moduleOp.lookupSymbol<AIE::DeviceOp>(emptyName);
-    if (!emptyDevice) {
-      auto deviceType = referencedDevice.getDevice();
-      auto loc = builder.getUnknownLoc();
-      emptyDevice = AIE::DeviceOp::create(builder, loc, deviceType,
-                                          builder.getStringAttr(emptyName));
-      emptyDevice.getRegion().emplaceBlock();
-      Block *deviceBlock = &emptyDevice.getRegion().front();
-      builder.setInsertionPointToEnd(deviceBlock);
-      AIE::EndOp::create(builder, loc);
-    }
+    AIE::DeviceOp emptyDevice = getOrCreateEmptyDevice(
+        moduleOp, referencedDevice.getDevice(), index % 2);
     preloadRef = FlatSymbolRefAttr::get(emptyDevice.getSymNameAttr());
   }
 
@@ -205,6 +214,28 @@ struct AIEExpandLoadPdiPass
     module.walk(
         [&](NpuLoadPdiOp loadPdiOp) { loadPdiOps.push_back(loadPdiOp); });
 
+    // Per enclosing runtime sequence: how many resets it will emit, plus the
+    // device type to reset. Captured BEFORE transforming, which erases the ops.
+    llvm::MapVector<AIE::RuntimeSequenceOp, std::pair<unsigned, AIE::AIEDevice>>
+        resetsPerSequence;
+    for (auto loadPdiOp : loadPdiOps) {
+      auto deviceRefAttr = loadPdiOp.getDeviceRefAttr();
+      if (!deviceRefAttr)
+        continue;
+      if (loadPdiOp.getExpandMode().value_or(clCtrlPkt
+                                                 ? AIEX::ExpandMode::ctrlpkt
+                                                 : AIEX::ExpandMode::write32) !=
+          AIEX::ExpandMode::write32)
+        continue;
+      auto seq = loadPdiOp->getParentOfType<AIE::RuntimeSequenceOp>();
+      auto dev = module.lookupSymbol<AIE::DeviceOp>(deviceRefAttr);
+      if (!seq || !dev)
+        continue;
+      auto &entry = resetsPerSequence[seq];
+      entry.first++;
+      entry.second = dev.getDevice();
+    }
+
     // Map the legacy bool option to the new ExpandMode enum.
     AIEX::ExpandMode defaultMode =
         clCtrlPkt ? AIEX::ExpandMode::ctrlpkt : AIEX::ExpandMode::write32;
@@ -217,6 +248,38 @@ struct AIEExpandLoadPdiPass
         return;
       }
       idx++;
+    }
+
+    // The `index % 2` alternation above keeps two consecutive resets on
+    // different PDIs WITHIN a sequence. But the host re-runs the whole sequence
+    // on every dispatch, so the alternation has to hold across that boundary
+    // too: a sequence with an ODD number of resets ends on the same empty PDI
+    // it starts with, the firmware caches the address and no-ops the next
+    // dispatch's first load, and the configuration that follows lands on a
+    // device that was never reset. That is silent -- the first dispatch is
+    // correct and later ones return non-deterministic garbage.
+    //
+    // Append one more reset so every sequence ends on the opposite parity. The
+    // empty PDI is a few hundred bytes, so the cost is negligible next to the
+    // configuration it guards.
+    for (auto &[seq, info] : resetsPerSequence) {
+      auto [count, deviceType] = info;
+      if (count % 2 == 0)
+        continue;
+      AIE::DeviceOp emptyDevice =
+          getOrCreateEmptyDevice(module, deviceType, count % 2);
+      OpBuilder builder(seq.getContext());
+      Block &body = seq.getBody().front();
+      if (!body.empty() && body.back().hasTrait<OpTrait::IsTerminator>())
+        builder.setInsertionPoint(&body.back());
+      else
+        builder.setInsertionPointToEnd(&body);
+      NpuLoadPdiOp::create(
+          builder, seq.getLoc(),
+          FlatSymbolRefAttr::get(emptyDevice.getSymNameAttr()),
+          /*id=*/nullptr, /*size=*/nullptr, /*address=*/nullptr,
+          /*expand_mode=*/
+          AIEX::ExpandModeAttr::get(seq.getContext(), AIEX::ExpandMode::none));
     }
   }
 };

--- a/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
@@ -214,11 +214,20 @@ struct AIEExpandLoadPdiPass
     module.walk(
         [&](NpuLoadPdiOp loadPdiOp) { loadPdiOps.push_back(loadPdiOp); });
 
-    // Per enclosing runtime sequence: how many resets it will emit, plus the
-    // device type to reset. Captured BEFORE transforming, which erases the ops.
-    llvm::MapVector<AIE::RuntimeSequenceOp, std::pair<unsigned, AIE::AIEDevice>>
-        resetsPerSequence;
-    for (auto loadPdiOp : loadPdiOps) {
+    // Per enclosing runtime sequence: the parity of its FIRST and LAST reset,
+    // plus the device type to reset. `transformLoadPdi` picks the empty device
+    // as `index % 2` over the module-wide op order, and that order includes
+    // ops this pass skips, so a sequence's first reset is not necessarily
+    // `@empty_0` and its parity cannot be recovered from a count. Captured
+    // BEFORE transforming, which erases the ops.
+    struct ResetParity {
+      unsigned firstParity = 0;
+      unsigned lastParity = 0;
+      bool seen = false;
+      AIE::AIEDevice device = {};
+    };
+    llvm::MapVector<AIE::RuntimeSequenceOp, ResetParity> resetsPerSequence;
+    for (auto [index, loadPdiOp] : llvm::enumerate(loadPdiOps)) {
       auto deviceRefAttr = loadPdiOp.getDeviceRefAttr();
       if (!deviceRefAttr)
         continue;
@@ -232,8 +241,12 @@ struct AIEExpandLoadPdiPass
       if (!seq || !dev)
         continue;
       auto &entry = resetsPerSequence[seq];
-      entry.first++;
-      entry.second = dev.getDevice();
+      if (!entry.seen) {
+        entry.firstParity = index % 2;
+        entry.seen = true;
+      }
+      entry.lastParity = index % 2;
+      entry.device = dev.getDevice();
     }
 
     // Map the legacy bool option to the new ExpandMode enum.
@@ -253,21 +266,21 @@ struct AIEExpandLoadPdiPass
     // The `index % 2` alternation above keeps two consecutive resets on
     // different PDIs WITHIN a sequence. But the host re-runs the whole sequence
     // on every dispatch, so the alternation has to hold across that boundary
-    // too: a sequence with an ODD number of resets ends on the same empty PDI
-    // it starts with, the firmware caches the address and no-ops the next
-    // dispatch's first load, and the configuration that follows lands on a
-    // device that was never reset. That is silent -- the first dispatch is
-    // correct and later ones return non-deterministic garbage.
+    // too: when a sequence's last reset lands on the same empty PDI as its
+    // first, the firmware caches the address and no-ops the next dispatch's
+    // first load, and the configuration that follows lands on a device that was
+    // never reset. That is silent -- the first dispatch is correct and later
+    // ones return non-deterministic garbage.
     //
-    // Append one more reset so every sequence ends on the opposite parity. The
-    // empty PDI is a few hundred bytes, so the cost is negligible next to the
-    // configuration it guards.
+    // Append one more reset, of the parity opposite the last one, so the
+    // sequence ends somewhere its own start will not repeat. The empty PDI is a
+    // few hundred bytes, so the cost is negligible next to the configuration it
+    // guards.
     for (auto &[seq, info] : resetsPerSequence) {
-      auto [count, deviceType] = info;
-      if (count % 2 == 0)
+      if (!info.seen || info.firstParity != info.lastParity)
         continue;
       AIE::DeviceOp emptyDevice =
-          getOrCreateEmptyDevice(module, deviceType, count % 2);
+          getOrCreateEmptyDevice(module, info.device, 1 - info.lastParity);
       OpBuilder builder(seq.getContext());
       Block &body = seq.getBody().front();
       if (!body.empty() && body.back().hasTrait<OpTrait::IsTerminator>())

--- a/test/Passes/expand-load-pdi/odd_reset_count_parity.mlir
+++ b/test/Passes/expand-load-pdi/odd_reset_count_parity.mlir
@@ -1,0 +1,54 @@
+//===- odd_reset_count_parity.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-expand-load-pdi --split-input-file %s | FileCheck %s
+
+// The empty-device reset alternates empty_0/empty_1 so that two consecutive
+// loads never name the same PDI -- the firmware caches the address and turns a
+// repeated load into a no-op. The host re-runs the whole runtime sequence on
+// every dispatch, so that alternation has to hold across the dispatch boundary
+// too. A sequence with an ODD number of resets would end on the same empty PDI
+// it starts with, so the next dispatch's reset silently does nothing and the
+// configuration that follows lands on a device that was never reset. One extra
+// reset of the opposite parity is appended to keep the sequence even.
+
+// ONE reset -> starts on empty_0, so a trailing empty_1 is appended.
+module {
+  aie.device(npu2_1col) @dev_a {
+    aie.end
+  }
+
+  aie.device(npu2_1col) @main {
+    // CHECK-LABEL: aie.runtime_sequence(%arg0: memref<1xi32>)
+    aie.runtime_sequence (%arg0: memref<1xi32>) {
+      // CHECK: aiex.npu.load_pdi {device_ref = @empty_0
+      // CHECK: aiex.npu.load_pdi {device_ref = @empty_1
+      // CHECK-NOT: aiex.npu.load_pdi
+      aiex.npu.load_pdi { device_ref = @dev_a }
+    }
+  }
+}
+
+// -----
+
+// TWO resets already end on the opposite parity, so nothing is appended.
+module {
+  aie.device(npu2_1col) @dev_a {
+    aie.end
+  }
+
+  aie.device(npu2_1col) @main {
+    // CHECK-LABEL: aie.runtime_sequence(%arg0: memref<1xi32>)
+    aie.runtime_sequence (%arg0: memref<1xi32>) {
+      // CHECK: aiex.npu.load_pdi {device_ref = @empty_0
+      // CHECK: aiex.npu.load_pdi {device_ref = @empty_1
+      // CHECK-NOT: aiex.npu.load_pdi
+      aiex.npu.load_pdi { device_ref = @dev_a }
+      aiex.npu.load_pdi { device_ref = @dev_a }
+    }
+  }
+}

--- a/test/Passes/expand-load-pdi/odd_reset_count_parity.mlir
+++ b/test/Passes/expand-load-pdi/odd_reset_count_parity.mlir
@@ -52,3 +52,28 @@ module {
     }
   }
 }
+
+// -----
+
+// The empty device is chosen by the load_pdi's MODULE-WIDE index, and that
+// index counts ops this pass skips. Here an `expand_mode = none` load takes
+// index 0, so the one reset this sequence does emit starts on empty_1 -- and
+// the appended reset has to be empty_0, not empty_1, or it reloads the address
+// the firmware already has cached and changes nothing.
+module {
+  aie.device(npu2_1col) @dev_a {
+    aie.end
+  }
+
+  aie.device(npu2_1col) @main {
+    // CHECK-LABEL: aie.runtime_sequence(%arg0: memref<1xi32>)
+    aie.runtime_sequence (%arg0: memref<1xi32>) {
+      // CHECK: aiex.npu.load_pdi {device_ref = @dev_a, expand_mode = 0
+      // CHECK: aiex.npu.load_pdi {device_ref = @empty_1
+      // CHECK: aiex.npu.load_pdi {device_ref = @empty_0
+      // CHECK-NOT: aiex.npu.load_pdi
+      aiex.npu.load_pdi { device_ref = @dev_a, expand_mode = 0 : i32 }
+      aiex.npu.load_pdi { device_ref = @dev_a }
+    }
+  }
+}


### PR DESCRIPTION
`AIEExpandLoadPdi` replaces each `load_pdi @device` with a load of an EMPTY
device PDI, which makes the firmware reset the array, followed by explicit
write32/blockwrite configuration.

The firmware caches the PDI address, so loading the same PDI twice in a row is
a no-op. The pass already knows this — it is why the ctrl-pkt path keeps both
`ctrl_pkt_overlay` and `ctrl_pkt_overlay_copy` — and handles it by picking
`empty_ + (index % 2)`.

But `index` is the module-wide `load_pdi` index, so the alternation only holds
*within* a sequence. The host re-runs the whole runtime sequence on every
dispatch, so it has to hold across that boundary too. A sequence with an **odd**
number of resets ends on the same empty PDI it started with, so the next
dispatch's reset is swallowed and the configuration that follows lands on a
device still holding the previous run's lock and DMA state.

This appends one reset of the opposite parity to any sequence that would
otherwise end where it began.

## Impact

A single-launch ELF has exactly one reset, so it is always broken from the
second dispatch on. Multi-launch ELFs have several and mostly end on the other
parity, which is why this went unnoticed: in the mlir-air SmolVLA vision
encoder the three fused multi-launch ELFs were bit-identical across repeat
dispatches while the single-launch connector GEMM returned cosine 0.9999 on its
first call and ~0.61 on every call after it, in the same process.

Failure signature: non-deterministic between dispatches, uniform across all
32 C tiles, correct magnitude, and not explained by any missing or duplicated
data — a synchronisation race, not mis-programmed BDs. `xclbin` repeats
correctly on the identical design; only the ELF path does not.

## Testing

Parity was predicted before it was measured, 4/4:

| launches | resets | predicted | observed |
|---|---|---|---|
| 1 | 1 | BREAK | BREAK |
| 2 | 2 | OK    | OK    |
| 3 | 3 | BREAK | BREAK |
| 4 | 4 | OK    | OK    |

After the fix every parity and every shape in the repro suite repeats
correctly, and the mlir-air consumer is uniform across images
(0.999753 / 0.999752 / 0.999763, was 0.999753 / 0.9939 / 0.9939).

New lit test `test/Passes/expand-load-pdi/odd_reset_count_parity.mlir` covers
both directions: one reset gets a trailing `empty_1`, two resets get nothing
appended.

Perf is unchanged — the empty PDI is a few hundred bytes (6676.8 vs 6837.7 us
on a SmolVLA ViT layer, inside noise).