### PR TITLE
Support larget user-define stack address

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -561,7 +561,26 @@ static bool simpleBankAwareAllocation(TileOp tile) {
     nextAddrInBanks.push_back(bankSize * i);
   if (auto core = tile.getCoreOp()) {
     stacksize = core.getEffectiveStackSize();
-    nextAddrInBanks[0] += stacksize;
+
+    if (stacksize >= maxDataMemorySize) {
+      tile->emitOpError("stack size exceeds local memory size");
+      return false;
+    }
+
+    // The stack occupies the bottom of the tile's memory. When it is larger
+    // than a single bank, spill it across consecutive banks so each bank's
+    // next-free address accounts for the portion of the stack it holds.
+    int remainStacksize = stacksize;
+    for (int bank_idx = 0; bank_idx < numBanks && remainStacksize > 0;
+         bank_idx++) {
+      if (remainStacksize >= bankSize) {
+        nextAddrInBanks[bank_idx] += bankSize;
+        remainStacksize -= bankSize;
+      } else {
+        nextAddrInBanks[bank_idx] += remainStacksize;
+        remainStacksize = 0;
+      }
+    }
   }
   fillBankLimits(numBanks, bankSize, bankLimits);
 

--- a/test/assign-buffer-addresses/bank_aware-alloc-large-stack-address.mlir
+++ b/test/assign-buffer-addresses/bank_aware-alloc-large-stack-address.mlir
@@ -1,6 +1,6 @@
 //===- bank_aware-alloc-large-stack-address.mlir ---------------*- MLIR -*-===//
 //
-// Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//

--- a/test/assign-buffer-addresses/bank_aware-alloc-large-stack-address.mlir
+++ b/test/assign-buffer-addresses/bank_aware-alloc-large-stack-address.mlir
@@ -1,0 +1,23 @@
+//===- bank_aware-alloc-large-stack-address.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-assign-buffer-addresses="alloc-scheme=bank-aware" %s | FileCheck %s
+
+// Pre-allocated buffers placed above a large stack must keep their addresses
+// and still be assigned the bank that covers those addresses.
+// CHECK: %a = aie.buffer(%tile_3_3) {address = 18432 : i32, mem_bank = 1 : i32, sym_name = "a"} : memref<1024xi8>
+// CHECK: %b = aie.buffer(%tile_3_3) {address = 32768 : i32, mem_bank = 2 : i32, sym_name = "b"} : memref<1024xi8>
+module @test {
+  aie.device(npu2) {
+    %0 = aie.tile(3, 3)
+    %b1 = aie.buffer(%0) {  sym_name = "a" } : memref<1024xi8>
+    %b2 = aie.buffer(%0) {  sym_name = "b" } : memref<1024xi8>
+    aie.core(%0) {
+      aie.end
+    }{ stack_size = 18432 : i32 }
+  }
+}

--- a/test/assign-buffer-addresses/basic_alloc-large-stack-address.mlir
+++ b/test/assign-buffer-addresses/basic_alloc-large-stack-address.mlir
@@ -1,6 +1,6 @@
 //===- basic_alloc-large-stack-address.mlir --------------------*- MLIR -*-===//
 //
-// Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//

--- a/test/assign-buffer-addresses/basic_alloc-large-stack-address.mlir
+++ b/test/assign-buffer-addresses/basic_alloc-large-stack-address.mlir
@@ -1,0 +1,23 @@
+//===- basic_alloc-large-stack-address.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s | FileCheck %s
+
+// Pre-allocated buffers placed above a large stack must keep their addresses
+// and still be assigned the bank that covers those addresses.
+// CHECK: %a = aie.buffer(%tile_3_3) {address = 18432 : i32, sym_name = "a"} : memref<1024xi8>
+// CHECK: %b = aie.buffer(%tile_3_3) {address = 19456 : i32, sym_name = "b"} : memref<1024xi8>
+module @test {
+  aie.device(npu2) {
+    %0 = aie.tile(3, 3)
+    %b1 = aie.buffer(%0) {  sym_name = "a" } : memref<1024xi8>
+    %b2 = aie.buffer(%0) {  sym_name = "b" } : memref<1024xi8>
+    aie.core(%0) {
+      aie.end
+    }{ stack_size = 18432 : i32 }
+  }
+}


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

<!-- What does this PR change, and why? Link any related issue with "Fixes #123". -->

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
