### PR TITLE
row_wise_bias_add: add a per-column affine cast to bf16 [LOW]

### DIFF
--- a/programming_examples/basic/row_wise_bias_add/README.md
+++ b/programming_examples/basic/row_wise_bias_add/README.md
@@ -27,3 +27,13 @@ The kernel uses vector intrinsics of size `t` to perform the additions.
 The computation is designed such that the `bias` vector is not unnecessarily reloaded.
 To achieve this, we first load a chunk of `t` elements of `bias`, then produce the results for the first `t` columns of `out` (this is the inner loop).
 The outer loop iterates through chunks of `t` columns, loading the next `t` biases at the beginning of each iteration.
+
+## Row-wise Affine Cast
+
+`--op affine_cast` selects a second design in the same files: a per-column affine transform, `out = bfloat16(in*gamma + beta)`, narrowing the `float32` input to `bfloat16` on the way out.
+`gamma` and `beta` are packed into one `1`&times;`2N` buffer, block-interleaved (`gamma` then `beta` per `n`-wide column block), since an AIE2 tile has only two input DMA channels and `in` already uses one.
+The narrowing cast rounds to nearest even (`aie::rounding_mode::conv_even`), matching a host `float32`-\>`bfloat16` pack bit-for-bit; the AIE default truncates toward zero.
+
+```shell
+python3 row_wise_bias_add.py --op affine_cast --dev npu2
+```

--- a/programming_examples/basic/row_wise_bias_add/kernel.cc
+++ b/programming_examples/basic/row_wise_bias_add/kernel.cc
@@ -48,3 +48,58 @@ void row_wise_bias_add_f32_f32(const float *__restrict in,
   row_wise_bias_add<float, float, DIM_m, DIM_n, t>(in, bias, out);
 }
 }
+
+// Row-wise affine transform with a narrowing output cast: out = in*gamma +
+// beta, gamma/beta per-column (broadcast over rows), narrowed to T_out.
+// gamma and beta are packed into one [2*n] buffer per column-block (gamma
+// then beta) rather than passed as separate inputs -- an AIE2 tile has only
+// two input DMA channels, and `in` already takes one.
+template <typename T_in, typename T_out, int m, int n, int t>
+void row_wise_affine_cast(const T_in *__restrict in, const T_in *__restrict gb,
+                          T_out *__restrict out) {
+  const T_in *__restrict gamma_ptr = gb;
+  const T_in *__restrict beta_ptr = gb + n;
+  const T_in *__restrict in_base_ptr = in;
+  const T_in *__restrict in_ptr = in_base_ptr;
+  T_out *__restrict out_base_ptr = out;
+  T_out *__restrict out_ptr = out_base_ptr;
+  constexpr int n_div_t = n / t;
+
+  // Round-to-nearest-even, matching a host f32->bf16 pack: the AIE default
+  // truncates toward zero, which would drift from the host by up to 1 ULP.
+  const auto saved_rounding = aie::swap_rounding(aie::rounding_mode::conv_even);
+  for (int j = 0; j < n_div_t; j++) {
+    aie::vector<T_in, t> gamma = aie::load_v<t>(gamma_ptr);
+    aie::vector<T_in, t> beta = aie::load_v<t>(beta_ptr);
+    for (int i = 0; i < m; i += 1) {
+      aie::vector<T_in, t> in = aie::load_v<t>(in_ptr);
+      aie::vector<T_in, t> scaled = aie::mul(in, gamma);
+      aie::vector<T_in, t> affine = aie::add(scaled, beta);
+      // aie::vector has no direct to_vector<T_out>(); narrow through an
+      // accfloat accumulator, which does.
+      aie::accum<accfloat, t> acc;
+      acc.from_vector(affine);
+      aie::store_v(out_ptr, acc.template to_vector<T_out>());
+      in_ptr += n;
+      out_ptr += n;
+    }
+    gamma_ptr += t;
+    beta_ptr += t;
+    in_base_ptr += t;
+    in_ptr = in_base_ptr;
+    out_base_ptr += t;
+    out_ptr = out_base_ptr;
+  }
+  aie::set_rounding(saved_rounding);
+}
+
+extern "C" {
+
+void row_wise_affine_cast_f32_bf16(const float *__restrict in,
+                                   const float *__restrict gb,
+                                   bfloat16 *__restrict out) {
+  constexpr int t = 32;
+  static_assert(DIM_n % t == 0);
+  row_wise_affine_cast<float, bfloat16, DIM_m, DIM_n, t>(in, gb, out);
+}
+}

--- a/programming_examples/basic/row_wise_bias_add/row_wise_bias_add.py
+++ b/programming_examples/basic/row_wise_bias_add/row_wise_bias_add.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-"""Row-wise bias add — IRON API design with ``@iron.jit`` compilation.
+"""Row-wise bias add / affine cast — IRON API designs with ``@iron.jit``.
 
 The C++ kernel (``kernel.cc``) adds a per-column bias vector (``1 x N``)
 to every row of an ``M x N`` ``float32`` matrix.  Tiling is ``(m, n)``;
@@ -11,6 +11,12 @@ the kernel is parameterized at compile time on ``DIM_m`` / ``DIM_n``
 (passed via ``ExternalFunction.compile_flags``), so each specialization
 gets its own ``.o`` named with a content hash — no separate Makefile
 ``build/kernel.o`` step.
+
+``--op affine_cast`` selects a second design in the same kernel file:
+a per-column affine transform (``out = in*gamma + beta``) narrowed to
+``bfloat16``. gamma and beta are packed into one ``[2*n]`` buffer per
+column-block (see ``kernel.cc``), since an AIE2 tile has only two input
+DMA channels and ``in`` already takes one.
 
 Two invocation modes:
 
@@ -30,6 +36,7 @@ from aie.iron.kernel import ExternalFunction
 from aie.utils.hostruntime.argparse import add_compile_args, device_from_args
 from aie.utils.hostruntime.cli import run_design_cli
 from aie.utils.verify import assert_pass
+from ml_dtypes import bfloat16
 
 _KERNEL_SRC = str(Path(__file__).parent / "kernel.cc")
 
@@ -98,9 +105,85 @@ def row_wise_bias_add(
     return Program(iron.get_current_device(), rt, workers=[worker]).resolve_program()
 
 
+@iron.jit
+def row_wise_affine_cast(
+    inp: In,
+    gb: In,
+    out: Out,
+    *,
+    M: CompileTime[int] = 768,
+    N: CompileTime[int] = 2304,
+    m: CompileTime[int] = 96,
+    n: CompileTime[int] = 32,
+):
+    assert M % m == 0
+    assert N % n == 0
+
+    tensor_ty = np.ndarray[(m * n,), np.dtype[np.float32]]
+    out_tile_ty = np.ndarray[(m * n,), np.dtype[bfloat16]]
+    gb_tile_ty = np.ndarray[(2 * n,), np.dtype[np.float32]]
+    in_ty = np.ndarray[(M * N,), np.dtype[np.float32]]
+    out_ty = np.ndarray[(M * N,), np.dtype[bfloat16]]
+    gb_full_ty = np.ndarray[(2 * N,), np.dtype[np.float32]]
+
+    kernel_func = ExternalFunction(
+        "row_wise_affine_cast_f32_bf16",
+        source_file=_KERNEL_SRC,
+        arg_types=[tensor_ty, gb_tile_ty, out_tile_ty],
+        compile_flags=[f"-DDIM_m={m}", f"-DDIM_n={n}"],
+    )
+
+    in_fifo = ObjectFifo(tensor_ty, name="in_fifo")
+    gb_fifo = ObjectFifo(gb_tile_ty, name="gb_fifo")
+    out_fifo = ObjectFifo(out_tile_ty, name="out_fifo")
+
+    def core_fn(in_fifo, gb_fifo, out_fifo, kernel_func):
+        for _ in range_(N // n):
+            elem_gb = gb_fifo.acquire(1)
+            for _ in range_(M // m):
+                elem_in = in_fifo.acquire(1)
+                elem_out = out_fifo.acquire(1)
+                kernel_func(elem_in, elem_gb, elem_out)
+                out_fifo.release(1)
+                in_fifo.release(1)
+            gb_fifo.release(1)
+
+    worker = Worker(
+        core_fn,
+        fn_args=[in_fifo.cons(), gb_fifo.cons(), out_fifo.prod(), kernel_func],
+    )
+
+    tap = TensorTiler2D.group_tiler(
+        (M, N), (m, n), (M // m, N // n), tile_group_col_major=True
+    )[0]
+    # gamma/beta ride as ONE [1, 2N] array, block-interleaved: for column-block
+    # j, elements [j*2n : j*2n+n) are gamma[jn:(j+1)n) and [j*2n+n : (j+1)*2n)
+    # are beta[jn:(j+1)n) — see _run_and_verify_affine_cast for the host pack.
+    gb_tap = TensorTiler2D.group_tiler((1, 2 * N), (1, 2 * n), (1, N // n))[0]
+
+    def sequence(a, b, c, in_h, gb_h, out_h):
+        in_h.fill(a, tap)
+        gb_h.fill(b, gb_tap)
+        out_h.drain(c, tap, wait=True)
+
+    rt = Runtime(
+        sequence,
+        [in_ty, gb_full_ty, out_ty, in_fifo.prod(), gb_fifo.prod(), out_fifo.cons()],
+    )
+
+    return Program(iron.get_current_device(), rt, workers=[worker]).resolve_program()
+
+
 def _make_argparser():
     p = argparse.ArgumentParser(prog="AIE Row-Wise Bias Add")
     add_compile_args(p)
+    p.add_argument(
+        "--op",
+        choices=["bias_add", "affine_cast"],
+        default="bias_add",
+        help="bias_add: out = in + bias (f32). affine_cast: out = "
+        "bfloat16(in*gamma + beta)",
+    )
     p.add_argument("-M", "--M", type=int, default=768)
     p.add_argument("-N", "--N", type=int, default=2304)
     p.add_argument("-m", "--m", type=int, default=96)
@@ -127,15 +210,50 @@ def _run_and_verify(opts):
     assert_pass(actual, expected, fail_msg="output does not match in + bias (per-row)")
 
 
+def _run_and_verify_affine_cast(opts):
+    rng = np.random.default_rng(0)
+    in_np = rng.uniform(-4.0, 4.0, size=(opts.M, opts.N)).astype(np.float32)
+    gamma_np = rng.uniform(0.5, 2.0, size=(opts.N,)).astype(np.float32)
+    beta_np = rng.uniform(-1.0, 1.0, size=(opts.N,)).astype(np.float32)
+
+    # Block-interleave to match gb_tap's [1, 2N] tiling: column-block j gets
+    # gamma[jn:(j+1)n) then beta[jn:(j+1)n) as one contiguous 2n run.
+    n = opts.n
+    gb_np = np.empty(2 * opts.N, dtype=np.float32)
+    for j in range(opts.N // n):
+        gb_np[2 * j * n : 2 * j * n + n] = gamma_np[j * n : (j + 1) * n]
+        gb_np[2 * j * n + n : 2 * (j + 1) * n] = beta_np[j * n : (j + 1) * n]
+
+    in_t = iron.tensor(in_np, dtype=np.float32, device="npu")
+    gb_t = iron.tensor(gb_np, dtype=np.float32, device="npu")
+    out_t = iron.zeros(opts.M * opts.N, dtype=bfloat16, device="npu")
+
+    row_wise_affine_cast(in_t, gb_t, out_t, **_compile_kwargs(opts))
+
+    # ml_dtypes rounds to nearest even, matching the kernel's conv_even.
+    expected = (in_np * gamma_np[None, :] + beta_np[None, :]).astype(bfloat16)
+    actual = out_t.numpy().reshape(opts.M, opts.N)
+    assert_pass(actual, expected, fail_msg="affine_cast output mismatch")
+
+
 def main():
     opts = _make_argparser().parse_args()
-    run_design_cli(
-        row_wise_bias_add,
-        opts,
-        compile_kwargs=_compile_kwargs,
-        run_and_verify=_run_and_verify,
-        device=device_from_args,
-    )
+    if opts.op == "affine_cast":
+        run_design_cli(
+            row_wise_affine_cast,
+            opts,
+            compile_kwargs=_compile_kwargs,
+            run_and_verify=_run_and_verify_affine_cast,
+            device=device_from_args,
+        )
+    else:
+        run_design_cli(
+            row_wise_bias_add,
+            opts,
+            compile_kwargs=_compile_kwargs,
+            run_and_verify=_run_and_verify,
+            device=device_from_args,
+        )
 
 
 if __name__ == "__main__":

--- a/programming_examples/basic/row_wise_bias_add/run.lit
+++ b/programming_examples/basic/row_wise_bias_add/run.lit
@@ -4,3 +4,4 @@
 // REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: %run_on_npu1% %python %S/row_wise_bias_add.py
+// RUN: %run_on_npu1% %python %S/row_wise_bias_add.py --op affine_cast

--- a/programming_examples/basic/row_wise_bias_add/run_strix.lit
+++ b/programming_examples/basic/row_wise_bias_add/run_strix.lit
@@ -4,3 +4,4 @@
 // REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: %run_on_npu2% %python %S/row_wise_bias_add.py
+// RUN: %run_on_npu2% %python %S/row_wise_bias_add.py --op affine_cast


### PR DESCRIPTION
### Problem

`row_wise_bias_add` only adds a per-column bias in f32. There is no row-wise
op that also scales per column and narrows the output, which a fused
LayerNorm-affine or batchnorm-inference epilogue needs when the next
consumer is a bf16 matmul.

### Fix

Adds `row_wise_affine_cast` next to `row_wise_bias_add` in the same
`kernel.cc` and `row_wise_bias_add.py`: `out = bfloat16(in*gamma + beta)`,
gamma/beta per column, selected with `--op affine_cast`. gamma and beta ride
as one `[2n]` buffer per column-block (gamma then beta) instead of two
separate inputs, since an AIE2 tile has only two input DMA channels and `in`
already takes one. The narrow goes through an `accfloat` accumulator with
`conv_even` rounding, matching a host f32->bf16 pack bit-for-bit; the AIE
default truncates toward zero, the same argument `cast_f32_bf16.cc` makes.
`row_wise_bias_add_f32_f32` is untouched.

### Test

Compiled through `aiecc` to a real xclbin (magic `xclbin2`, 7 AXLF sections:
MEM_TOPOLOGY, AIE_PARTITION, EMBEDDED_METADATA, IP_LAYOUT, CONNECTIVITY,
GROUP_CONNECTIVITY, GROUP_TOPOLOGY) at the default 768x2304 tiling, both
`--dev npu2` and `--dev npu1`. Rebuilding `row_wise_bias_add_f32_f32`
unmodified after the kernel.cc change reproduces the same 9808-byte xclbin,
so the addition does not disturb it. `black`, `ruff check` and `pyright`
pass on the touched Python; `clang-format` 20.1.0 (CI's pin) and 22.1.8
(pre-commit's) both report no diff on `kernel.cc`.

### Known limitations

Compiled only, not device-run.
Added `--op affine_cast` RUN lines to `run.lit` / `run_strix.lit` so CI
exercises it end-to-end (compile, run, `assert_pass` against a numpy
reference) on real devices.
