### PR TITLE
[programming_examples] transposes: add dyn, a runtime-shape strategy [LOW]

### DIFF
--- a/programming_examples/basic/transposes/Makefile
+++ b/programming_examples/basic/transposes/Makefile
@@ -5,7 +5,7 @@
 #
 ##===----------------------------------------------------------------------===##
 #
-# Four-way transpose demo (dma, dma_packet, shuffle, combined).  Pick
+# Five-way transpose demo (dma, dma_packet, shuffle, combined, dyn).  Pick
 # one via STRATEGY=...; per-strategy defaults for M / K / dtype-bytes
 # live in transposes.py's _DEFAULTS so `make run` Just Works for any
 # strategy.
@@ -42,6 +42,11 @@ ifeq (${STRATEGY},combined)
   K ?= 128
   DTYPE_BYTES ?= 4
   COMBINED_ARGS ?= -m 32 -n 32 --ss 8
+endif
+ifeq (${STRATEGY},dyn)
+  M ?= 48
+  K ?= 37
+  DTYPE_BYTES ?= 2
 endif
 
 aie_py_src = ${targetname}.py

--- a/programming_examples/basic/transposes/README.md
+++ b/programming_examples/basic/transposes/README.md
@@ -5,9 +5,9 @@
 //
 //===----------------------------------------------------------------------===//-->
 
-# Transposes — four ways
+# Transposes — five ways
 
-A single [`@iron.jit`](./transposes.py) design exposing four distinct on-device transpose mechanisms.  All four produce the same end result: a full `M × K → K × M` transpose.  Only the on-device mechanism differs — pick one via `--strategy`.
+A single [`@iron.jit`](./transposes.py) design exposing five distinct on-device transpose mechanisms.  All five produce the same end result: a full `M × K → K × M` transpose.  Only the on-device mechanism differs — pick one via `--strategy`.
 
 | `--strategy`  | mechanism                                                     | dtypes      | size constraints                               |
 | ------------- | ------------------------------------------------------------- | ----------- | ---------------------------------------------- |
@@ -15,10 +15,12 @@ A single [`@iron.jit`](./transposes.py) design exposing four distinct on-device 
 | `dma_packet`  | same as `dma` but lowered with `--packet-sw-objFifos`         | int32/uint32 only<sup>1</sup>      | any                                            |
 | `shuffle`     | per-tile VSHUFFLE (hand-coded `transpose_16x16` kernel)       | uint8 only<sup>2</sup>             | M = K = 16 only                                |
 | `combined`    | hybrid: shim DMA outer reshuffle + VSHUFFLE inner sub-tile    | i8 / i16 / i32 (`--dtype-bytes`)   | `m \| M`, `n \| K`, `s \| m`, `s \| n`<sup>3</sup> |
+| `dyn`         | scalar transpose on a compute core (`transpose_dyn.cc`)      | i8 / i16 / i32 (`--dtype-bytes`)   | `M`, `K` fit one core's L1<sup>4</sup>          |
 
 <sup>1</sup> Shim DMA stride-1 must be ≥ 4 bytes, so 1- and 2-byte elements would lower to `aie.dma_bd` with stride < 4 bytes and be rejected.
 <sup>2</sup> The `shuffle_16x16.cc` kernel is hand-written for `uint8 16x16`; supporting other dtypes / sizes would require new kernels.
 <sup>3</sup> Plus an empirical lower bound — `s = 8` needs `m, n ≥ 32` for the underlying `transpose_8x8` VECTOR_SIZE arithmetic to do the right block interleave.
+<sup>4</sup> `mb`/`nb` are ordinary `int32` kernel arguments, not `-DDIM_m`/`-DDIM_n` macros, so `dyn` has no divisibility or minimum-size constraint the way `combined`/`shuffle` do; the whole `M x K` tile is moved and transposed in one core call, so it has to fit in the core's 64 KB L1 alongside the objectFIFO's ping-pong buffers.
 
 Each `@iron.jit` function in [`transposes.py`](./transposes.py) raises `ValueError` if asked for a combo outside its support envelope.
 
@@ -31,6 +33,7 @@ python3 transposes.py -d npu2 -s dma          # int32 64x64
 python3 transposes.py -d npu2 -s dma_packet   # int32 64x32
 python3 transposes.py -d npu2 -s shuffle      # uint8 16x16
 python3 transposes.py -d npu2 -s combined     # int32 128x128, m=n=32, s=8
+python3 transposes.py -d npu2 -s dyn          # bf16 48x37 (deliberately not a power of 2)
 ```
 
 Pick `--dtype-bytes 1|2|4`, `-M`, `-K`, plus `-m`/`-n`/`--ss` for `combined`.  Strategies that can't satisfy the request fail fast with a clear `ValueError`.
@@ -138,3 +141,17 @@ individually, then interleave the result two elements at a time.
 After this kernel, the `m × n` tile is completely transposed. The
 output transfer then writes the tiles back into their correct position
 in the transposed output `M × K` matrix.
+
+## `dyn` strategy: `--strategy dyn`
+
+`combined` and `shuffle` both bake their tile shape into the compiled
+kernel object (`-DDIM_m`/`-DDIM_n`, or a hand-written `16x16` body), so
+a new `(M, K)` needs a new compiled kernel, and only shapes satisfying
+`m | M`, `n | K`, `s | m`, `s | n` are reachable at all. `dyn` moves the
+whole `M x K` tile into one core's L1 in a single DMA and transposes it
+with a plain nested loop, taking `mb`/`nb` as ordinary `int32` arguments
+(`aie_kernels/transpose_dyn.cc`) rather than macros. The same compiled
+object then serves any `M`/`K`/element width, including sizes `combined`
+cannot express, such as this design's own default `48 x 37`. The cost is
+one element per cycle instead of a `VSHUFFLE`-per-tile, and the tile has
+to fit L1 rather than being DMA-tiled the way `combined` tiles it.

--- a/programming_examples/basic/transposes/aie_kernels/transpose_dyn.cc
+++ b/programming_examples/basic/transposes/aie_kernels/transpose_dyn.cc
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Scalar transpose with mb, nb as ordinary int32 arguments instead of the
+// -DDIM_m/-DDIM_n macros transpose_4x4/transpose_8x8 need, so one compiled
+// object serves any (mb, nb), with no divisibility or minimum-size
+// constraint, at one element per cycle instead of a VSHUFFLE per tile.
+
+#include <cstdint>
+
+#if !defined(DTYPE_i8) && !defined(DTYPE_i16) && !defined(DTYPE_i32)
+#error Please specify data type at kernel compile time using e.g., -DDTYPE_i8 or -DDTYPE_i16 or -DDTYPE_i32.
+#endif
+
+#if defined(DTYPE_i8)
+#define DTYPE uint8_t
+#endif
+#if defined(DTYPE_i16)
+#define DTYPE uint16_t
+#endif
+#if defined(DTYPE_i32)
+#define DTYPE uint32_t
+#endif
+
+extern "C" {
+
+void transpose_dyn(DTYPE *__restrict__ in_ptr, DTYPE *__restrict__ out_ptr,
+                   int32_t mb, int32_t nb) {
+  for (int32_t i = 0; i < mb; i++) {
+    const DTYPE *in_row = in_ptr + i * nb;
+    for (int32_t j = 0; j < nb; j++) {
+      out_ptr[j * mb + i] = in_row[j];
+    }
+  }
+}
+}

--- a/programming_examples/basic/transposes/run_jit.lit
+++ b/programming_examples/basic/transposes/run_jit.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// Exercises all four strategies via the standalone Python JIT path —
+// Exercises all five strategies via the standalone Python JIT path —
 // each one JITs, runs on the NPU, and verifies in Python.  No C++
 // testbench involved.
 //
@@ -11,4 +11,5 @@
 // RUN: %run_on_npu2% %python %S/transposes.py -d npu2 -s dma_packet | FileCheck %s
 // RUN: %run_on_npu2% %python %S/transposes.py -d npu2 -s shuffle | FileCheck %s
 // RUN: %run_on_npu2% %python %S/transposes.py -d npu2 -s combined | FileCheck %s
+// RUN: %run_on_npu2% %python %S/transposes.py -d npu2 -s dyn | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/basic/transposes/transposes.py
+++ b/programming_examples/basic/transposes/transposes.py
@@ -3,9 +3,9 @@
 # Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-"""Four transpose strategies on a single AIE column, ``@iron.jit``-compiled.
+"""Five transpose strategies on a single AIE column, ``@iron.jit``-compiled.
 
-All four strategies produce the same end result: a full ``M x N`` →
+All five strategies produce the same end result: a full ``M x N`` →
 ``N x M`` transpose.  Only the on-device mechanism differs, and each
 mechanism has its own (dtype, size) support envelope:
 
@@ -28,6 +28,15 @@ mechanism has its own (dtype, size) support envelope:
                       inner ``s x s`` sub-tile.  Supports
                       ``i8`` / ``i16`` / ``i32`` and any sizes with
                       ``m | M``, ``n | N``, ``s | m``, ``s | n``.
+  * ``dyn``         — scalar transpose on a compute core
+                      (``aie_kernels/transpose_dyn.cc``). ``mb``/``nb``
+                      are ordinary ``int32`` kernel arguments rather than
+                      the ``-DDIM_m``/``-DDIM_n`` macros ``combined`` and
+                      ``shuffle`` need, so one compiled object serves any
+                      ``M``/``K``/``i8``/``i16``/``i32`` combination with
+                      no divisibility or minimum-size constraint. One
+                      element per cycle, and the whole ``M x K`` tile must
+                      fit one core's L1.
 
 Each strategy raises ``ValueError`` if asked for a combo outside its
 support envelope.
@@ -53,6 +62,7 @@ from aie.utils.verify import assert_pass
 _KERNELS_DIR = Path(__file__).parent / "aie_kernels"
 _SHUFFLE_SRC = str(_KERNELS_DIR / "shuffle_16x16.cc")
 _COMBINED_SRC = str(_KERNELS_DIR / "transpose.cc")
+_DYN_SRC = str(_KERNELS_DIR / "transpose_dyn.cc")
 
 _BYTES_TO_DTYPE = {1: np.uint8, 2: np.uint16, 4: np.uint32}
 _COMBINED_DTYPE_MACRO = {1: "DTYPE_i8", 2: "DTYPE_i16", 4: "DTYPE_i32"}
@@ -277,6 +287,56 @@ def _transpose_combined(
 
 
 # ---------------------------------------------------------------------------
+# Strategy 5: scalar transpose, mb/nb as runtime kernel args (no macros).
+# ---------------------------------------------------------------------------
+
+
+@iron.jit
+def _transpose_dyn(
+    A: In,
+    C: Out,
+    *,
+    M: CompileTime[int] = 64,
+    K: CompileTime[int] = 64,
+    dtype_bytes: CompileTime[int] = 4,
+):
+    dtype = _BYTES_TO_DTYPE[dtype_bytes]
+    tensor_ty = np.ndarray[(M, K), np.dtype[dtype]]
+
+    kernel_func = ExternalFunction(
+        "transpose_dyn",
+        source_file=_DYN_SRC,
+        arg_types=[tensor_ty, tensor_ty, np.int32, np.int32],
+        compile_flags=[f"-D{_COMBINED_DTYPE_MACRO[dtype_bytes]}"],
+    )
+
+    in_fifo = ObjectFifo(tensor_ty, name="in_fifo")
+    out_fifo = ObjectFifo(tensor_ty, name="out_fifo")
+
+    def core_fn(in_fifo, out_fifo, kernel_func):
+        elem_in = in_fifo.acquire(1)
+        elem_out = out_fifo.acquire(1)
+        # M, K are Python ints closed over from the @iron.jit trace here,
+        # same as this file's other strategies; nothing about the kernel
+        # signature requires that (see transpose_dyn.cc).
+        kernel_func(elem_in, elem_out, M, K)
+        out_fifo.release(1)
+        in_fifo.release(1)
+
+    worker = Worker(core_fn, fn_args=[in_fifo.cons(), out_fifo.prod(), kernel_func])
+
+    def sequence(a, c, in_h, out_h):
+        in_h.fill(a)
+        out_h.drain(c, wait=True)
+
+    rt = Runtime(
+        sequence,
+        [tensor_ty, tensor_ty, in_fifo.prod(), out_fifo.cons()],
+    )
+    return Program(iron.get_current_device(), rt, workers=[worker]).resolve_program()
+
+
+# ---------------------------------------------------------------------------
 # Strategy dispatch
 # ---------------------------------------------------------------------------
 
@@ -286,6 +346,7 @@ _STRATEGIES = {
     "dma_packet": _transpose_dma_packet,
     "shuffle": _transpose_shuffle,
     "combined": _transpose_combined,
+    "dyn": _transpose_dyn,
 }
 
 
@@ -302,6 +363,9 @@ _DEFAULTS = {
     # outer tile equals the sub-tile size, producing the wrong block
     # interleave.  Original combined_transpose Makefile shipped m=64,n=32.
     "combined": dict(M=128, K=128, dtype_bytes=4, m=32, n=32, s=8),
+    # dyn: an odd, non-power-of-2, mutually-prime (M, K) at bf16 width,
+    # which combined/shuffle cannot express at all, to make the point.
+    "dyn": dict(M=48, K=37, dtype_bytes=2),
 }
 
 

--- a/programming_examples/basic/transposes/transposes.py
+++ b/programming_examples/basic/transposes/transposes.py
@@ -327,7 +327,7 @@ def _transpose_dyn(
     kernel_func = ExternalFunction(
         "transpose_dyn",
         source_file=_DYN_SRC,
-        arg_types=[tensor_ty, tensor_ty, np.int32, np.int32],
+        arg_types=[tensor_ty, tensor_ty, np.dtype(np.int32), np.dtype(np.int32)],
         compile_flags=[f"-D{_COMBINED_DTYPE_MACRO[dtype_bytes]}"],
     )
 

--- a/programming_examples/basic/transposes/transposes.py
+++ b/programming_examples/basic/transposes/transposes.py
@@ -5,8 +5,8 @@
 #
 """Five transpose strategies on a single AIE column, ``@iron.jit``-compiled.
 
-All five strategies produce the same end result: a full ``M x N`` →
-``N x M`` transpose.  Only the on-device mechanism differs, and each
+All five strategies produce the same end result: a full ``M x K`` →
+``K x M`` transpose.  Only the on-device mechanism differs, and each
 mechanism has its own (dtype, size) support envelope:
 
   * ``dma``         — pure shim-DMA stride; no compute core.
@@ -65,6 +65,11 @@ _COMBINED_SRC = str(_KERNELS_DIR / "transpose.cc")
 _DYN_SRC = str(_KERNELS_DIR / "transpose_dyn.cc")
 
 _BYTES_TO_DTYPE = {1: np.uint8, 2: np.uint16, 4: np.uint32}
+
+# Core data memory on both npu1 and npu2 (AIETargetModel::getLocalMemorySize),
+# and the ObjectFifo constructor's default depth.
+_CORE_L1_BYTES = 64 * 1024
+_FIFO_DEPTH = 2
 _COMBINED_DTYPE_MACRO = {1: "DTYPE_i8", 2: "DTYPE_i16", 4: "DTYPE_i32"}
 
 
@@ -300,6 +305,22 @@ def _transpose_dyn(
     K: CompileTime[int] = 64,
     dtype_bytes: CompileTime[int] = 4,
 ):
+    if dtype_bytes not in _BYTES_TO_DTYPE:
+        raise ValueError(
+            f"--strategy=dyn supports {sorted(_BYTES_TO_DTYPE)}-byte elements; "
+            f"got dtype_bytes={dtype_bytes}."
+        )
+    # dyn moves the whole tile into L1 in one DMA, so both fifos' buffers have
+    # to sit there at once: 2 fifos x depth 2 x the tile.  Checked here because
+    # overflowing it otherwise surfaces as a placement failure from aiecc.
+    tile_bytes = M * K * dtype_bytes
+    l1_bytes = 2 * _FIFO_DEPTH * tile_bytes
+    if l1_bytes > _CORE_L1_BYTES:
+        raise ValueError(
+            f"--strategy=dyn needs {l1_bytes} B of L1 for a {M}x{K} tile of "
+            f"{dtype_bytes}-byte elements (2 fifos x depth {_FIFO_DEPTH}), "
+            f"over the core's {_CORE_L1_BYTES} B."
+        )
     dtype = _BYTES_TO_DTYPE[dtype_bytes]
     tensor_ty = np.ndarray[(M, K), np.dtype[dtype]]
 


### PR DESCRIPTION
## Description

`programming_examples/basic/transposes` has four strategies and all four bake shape into
the compiled kernel object. `combined`/`shuffle` take `M`/`K`/`m`/`n` as `-DDIM_m`/`-DDIM_n`
macros, so a new shape needs a new compiled kernel, and only shapes satisfying `m | M`,
`n | K`, `s | m`, `s | n` are reachable at all (`shuffle` is narrower still, fixed at
`uint8 16x16`). `dma`/`dma_packet` have no size constraint but only work at 4-byte
elements, since shim DMA stride-1 must be >= 4 bytes. I hit this from a caller whose tile
shape is a run-length not known until inference time and not a multiple of anything in
particular, where recompiling per shape is not an option.

This adds `dyn`, a fifth strategy. `aie_kernels/transpose_dyn.cc` takes `mb`/`nb` as
ordinary `int32` arguments instead of macros, so one compiled kernel object serves any
`(M, K)` and any of `i8`/`i16`/`i32`, with no divisibility or minimum-size constraint. The
whole `M x K` tile moves through one core in a single DMA and is transposed with a plain
nested loop instead of a `VSHUFFLE`, so it is slower than `combined` and bounded by one
core's L1 rather than being DMA-tiled the way `combined` tiles it. `transposes.py`,
`Makefile`, `README.md` and `run_jit.lit` gain `dyn` alongside the other four, reusing the
same `_run_and_verify` (`numpy` `.T` reference) and `test.cpp` harness already here, so it
needs no new test infrastructure.

Compiled through `aiecc`: `-s dyn` at `(dtype_bytes, M, K)` = `(1, 8, 6)`, `(2, 48, 37)`
and `(4, 100, 3)` all produce a valid xclbin, with `func.call @transpose_dyn` wired to the
right memref types and `mb`/`nb` in the generated MLIR. `(4, 64, 64)` fails to compile:
double-buffering both objectFifos needs `4 * M * K * dtype_bytes` bytes, `64*64*4` puts
that at exactly 65536, and the core's 64 KB L1 has no room left for its 1 KB stack. The
strategy validates `dtype_bytes` and that envelope up front and raises `ValueError`, so an
oversized tile is rejected here rather than surfacing later as a placement failure.
Independently checked the kernel's index arithmetic against `numpy.T` for `(mb, nb)` in
`(8,6)`, `(48,37)`, `(100,3)`, `(1,5)`, `(5,1)`, `(3,3)`: all match.

Compiled and simulated, not yet device-run; I will run the existing `run_jit.lit` line and
report the result on the PR.

## Known limitations

The whole tile must fit one core's L1, unlike `combined`, which tiles through L2. This
example has no aie2 line already (`run_jit.lit` requires `ryzen_ai_npu2` for all five
strategies alike); `transpose_dyn.cc` uses no aie2p-specific API so it should port, but I
have not built or run it there.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (kernel not on the enabled list)
