### PR TITLE
[AIEX] Support the iteration attribute in dma_configure_task [MED]

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -261,6 +261,12 @@ bool isContiguousBDTransfer(llvm::ArrayRef<BDDimLayoutAttr> dims);
 mlir::LogicalResult
 verifyDMABDOutOfOrderId(DMABDOp bd, bool packetEnabledByContext = false);
 
+// Validate the #aie.bd_iteration bounds on a single BD; no-op without the
+// attribute. Also called from AIEX, whose task BDs skip DMABDOp::verify.
+mlir::LogicalResult verifyBDIterationBounds(DMABDOp bd,
+                                            const AIETargetModel &targetModel,
+                                            AIETileType tileType);
+
 // Validate an out-of-order S2MM channel and its receive BDs.
 mlir::LogicalResult
 verifyOutOfOrderChannel(mlir::Operation *op, DMAChannelDir dir, bool outOfOrder,

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1075,8 +1075,11 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [AttrSizedOperandSegments]> {
 
     Do NOT copy an iteration number between the two ops: e.g. `size = 1` disables
     iteration here, but `iteration_size = 1` means *two* executions on
-    `writebd`. The `iteration` attribute is rejected on the other path; express
-    iteration there via the outermost `sizes`/`strides` dimension instead.
+    `writebd`. On the runtime-sequence path (`aiex.dma_configure_task`), the
+    attribute is honored for a compile-time-constant BD with a static `bd_id`;
+    any other BD on that path (runtime-valued, or a dynamic pool `bd_id`)
+    still rejects it, and must express iteration via the outermost
+    `sizes`/`strides` dimension instead.
   }];
 
   let arguments = (ins AnyRankedOrUnrankedMemRef:$buffer,

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1063,8 +1063,11 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [AttrSizedOperandSegments]> {
 
     Do NOT copy an iteration number between the two ops: e.g. `size = 1` disables
     iteration here, but `iteration_size = 1` means *two* executions on
-    `writebd`. The `iteration` attribute is rejected on the other path; express
-    iteration there via the outermost `sizes`/`strides` dimension instead.
+    `writebd`. On the runtime-sequence path (`aiex.dma_configure_task`), the
+    attribute is honored for a compile-time-constant BD with a static `bd_id`;
+    any other BD on that path (runtime-valued, or a dynamic pool `bd_id`)
+    still rejects it, and must express iteration via the outermost
+    `sizes`/`strides` dimension instead.
   }];
 
   let arguments = (ins AnyRankedOrUnrankedMemRef:$buffer,

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2666,6 +2666,35 @@ static bool isBdPacketEnabled(DMABDOp bd) {
   return false;
 }
 
+LogicalResult xilinx::AIE::verifyBDIterationBounds(
+    DMABDOp bd, const AIETargetModel &targetModel, AIETileType tileType) {
+  // Values are true element counts (aie-rt applies the -1 encoding); size == 1
+  // disables iteration, so stride and current only matter when size > 1.
+  auto iter = bd.getIteration();
+  if (!iter)
+    return success();
+  if (!targetModel.hasProperty(AIETargetModel::UsesBDIteration))
+    return bd.emitOpError("BD iteration is not supported on this target");
+  uint32_t size = iter->getSize(), current = iter->getCurrent();
+  if (size < 1 || size > 64) // 64 = aie-rt IterWrapMax + 1
+    return bd.emitOpError("BD iteration size must be in [1, 64]");
+  if (size > 1) {
+    int64_t strideInBytes = static_cast<int64_t>(iter->getStride()) *
+                            bd.getBufferElementTypeWidthInBytes();
+    if (strideInBytes % 4)
+      return bd.emitOpError(
+          "BD iteration stride must be aligned to 32-bit words");
+    int64_t stepInWords = strideInBytes / 4;
+    int64_t maxStep = 1LL << targetModel.getDmaBdStepBits(tileType);
+    if (stepInWords < 1 || stepInWords > maxStep)
+      return bd.emitOpError() << "BD iteration stride must be in [1, "
+                              << maxStep << "] 32-bit words";
+  }
+  if (current >= size)
+    return bd.emitOpError("BD iteration current must be in [0, size)");
+  return success();
+}
+
 LogicalResult
 xilinx::AIE::verifyDMABDOutOfOrderId(DMABDOp bd, bool packetEnabledByContext) {
   std::optional<int32_t> oooId = bd.getOutOfOrderId();
@@ -3302,33 +3331,9 @@ LogicalResult DMABDOp::verify() {
     }
   }
 
-  // BD iteration bounds. Values are true/element (aie-rt encodes value-1);
-  // size <= 1 disables iteration (stride ignored). The stride is checked in
-  // whole 32-bit words against the tile-specific step field; the wrap is a
-  // 6-bit field everywhere. aiex.npu.writebd checks the same tile-correct step
-  // limit (getDmaBdStepBits) inline in its own raw-register terms.
-  if (auto iter = getIteration()) {
-    if (!targetModel.hasProperty(AIETargetModel::UsesBDIteration))
-      return emitOpError("BD iteration is not supported on this target");
-    uint32_t size = iter->getSize(), current = iter->getCurrent();
-    if (size < 1 || size > 64) // 64 = aie-rt IterWrapMax + 1
-      return emitOpError("BD iteration size must be in [1, 64]");
-    if (size > 1) {
-      int64_t strideInBytes = static_cast<int64_t>(iter->getStride()) *
-                              getBufferElementTypeWidthInBytes();
-      if (strideInBytes % 4)
-        return emitOpError(
-            "BD iteration stride must be aligned to 32-bit words");
-      int64_t stepInWords = strideInBytes / 4;
-      int64_t maxStep =
-          1LL << targetModel.getDmaBdStepBits(parentTile.getTileType());
-      if (stepInWords < 1 || stepInWords > maxStep)
-        return emitOpError() << "BD iteration stride must be in [1, " << maxStep
-                             << "] 32-bit words";
-    }
-    if (current >= size)
-      return emitOpError("BD iteration current must be in [0, size)");
-  }
+  if (failed(verifyBDIterationBounds(*this, targetModel,
+                                     parentTile.getTileType())))
+    return failure();
 
   return success();
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2857,6 +2857,35 @@ static bool isBdPacketEnabled(DMABDOp bd) {
   return false;
 }
 
+LogicalResult xilinx::AIE::verifyBDIterationBounds(
+    DMABDOp bd, const AIETargetModel &targetModel, AIETileType tileType) {
+  // Values are true element counts (aie-rt applies the -1 encoding); size == 1
+  // disables iteration, so stride and current only matter when size > 1.
+  auto iter = bd.getIteration();
+  if (!iter)
+    return success();
+  if (!targetModel.hasProperty(AIETargetModel::UsesBDIteration))
+    return bd.emitOpError("BD iteration is not supported on this target");
+  uint32_t size = iter->getSize(), current = iter->getCurrent();
+  if (size < 1 || size > 64) // 64 = aie-rt IterWrapMax + 1
+    return bd.emitOpError("BD iteration size must be in [1, 64]");
+  if (size > 1) {
+    int64_t strideInBytes = static_cast<int64_t>(iter->getStride()) *
+                            bd.getBufferElementTypeWidthInBytes();
+    if (strideInBytes % 4)
+      return bd.emitOpError(
+          "BD iteration stride must be aligned to 32-bit words");
+    int64_t stepInWords = strideInBytes / 4;
+    int64_t maxStep = 1LL << targetModel.getDmaBdStepBits(tileType);
+    if (stepInWords < 1 || stepInWords > maxStep)
+      return bd.emitOpError() << "BD iteration stride must be in [1, "
+                              << maxStep << "] 32-bit words";
+  }
+  if (current >= size)
+    return bd.emitOpError("BD iteration current must be in [0, size)");
+  return success();
+}
+
 LogicalResult
 xilinx::AIE::verifyDMABDOutOfOrderId(DMABDOp bd, bool packetEnabledByContext) {
   std::optional<int32_t> oooId = bd.getOutOfOrderId();
@@ -3500,33 +3529,9 @@ LogicalResult DMABDOp::verify() {
     }
   }
 
-  // BD iteration bounds. Values are true/element (aie-rt encodes value-1);
-  // size <= 1 disables iteration (stride ignored). The stride is checked in
-  // whole 32-bit words against the tile-specific step field; the wrap is a
-  // 6-bit field everywhere. aiex.npu.writebd checks the same tile-correct step
-  // limit (getDmaBdStepBits) inline in its own raw-register terms.
-  if (auto iter = getIteration()) {
-    if (!targetModel.hasProperty(AIETargetModel::UsesBDIteration))
-      return emitOpError("BD iteration is not supported on this target");
-    uint32_t size = iter->getSize(), current = iter->getCurrent();
-    if (size < 1 || size > 64) // 64 = aie-rt IterWrapMax + 1
-      return emitOpError("BD iteration size must be in [1, 64]");
-    if (size > 1) {
-      int64_t strideInBytes = static_cast<int64_t>(iter->getStride()) *
-                              getBufferElementTypeWidthInBytes();
-      if (strideInBytes % 4)
-        return emitOpError(
-            "BD iteration stride must be aligned to 32-bit words");
-      int64_t stepInWords = strideInBytes / 4;
-      int64_t maxStep =
-          1LL << targetModel.getDmaBdStepBits(parentTile.getTileType());
-      if (stepInWords < 1 || stepInWords > maxStep)
-        return emitOpError() << "BD iteration stride must be in [1, " << maxStep
-                             << "] 32-bit words";
-    }
-    if (current >= size)
-      return emitOpError("BD iteration current must be in [0, size)");
-  }
+  if (failed(verifyBDIterationBounds(*this, targetModel,
+                                     parentTile.getTileType())))
+    return failure();
 
   return success();
 }

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -1172,6 +1172,13 @@ AIEX::DMAConfigureTaskOp::canonicalize(AIEX::DMAConfigureTaskOp op,
 // caps the total at 4, which the MemTile's 4 ND dimensions already reach. Both
 // branches therefore land on the same uniform 4-dimension cap enforced later by
 // AIEDMATasksToNPU.
+//
+// The `iteration` attribute (## BD iteration, AIEOps.td) addresses that same
+// shared register directly, in true element values, instead of through a
+// hoisted dimension: a compile-time-constant BD honors it (rewriteSingleBD in
+// AIEDMATasksToNPU.cpp), so it costs one fewer ND dimension here rather than
+// being rejected outright. The dynamic BD-word encoder
+// (rewriteSingleBDDynamic) does not yet implement it.
 static LogicalResult
 verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
                        Region &body) {
@@ -1186,20 +1193,37 @@ verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
       result = failure();
       return;
     }
-    if (bd.getIteration()) {
-      // See aie.dma_bd's ## BD iteration doc in AIEOps.td.
-      bd.emitOpError() << "the iteration attribute is not supported on the "
-                          "runtime-sequence path; express iteration via the "
-                          "outermost sizes/strides dimension instead";
-      result = failure();
-      return;
+    auto iter = bd.getIteration();
+    if (iter) {
+      bool constBd = (!bd.getLen() || bd.getConstantLen().has_value()) &&
+                     (!bd.getOffset() || bd.getConstantOffset().has_value()) &&
+                     llvm::all_of(bd.getMixedSizes(),
+                                  [](OpFoldResult s) {
+                                    return getConstantIntValue(s).has_value();
+                                  }) &&
+                     llvm::all_of(bd.getMixedStrides(), [](OpFoldResult s) {
+                       return getConstantIntValue(s).has_value();
+                     });
+      if (!constBd) {
+        bd.emitOpError() << "the iteration attribute requires a "
+                            "compile-time-constant buffer descriptor on the "
+                            "runtime-sequence path; express iteration via "
+                            "the outermost sizes/strides dimension instead";
+        result = failure();
+        return;
+      }
     }
+    // The attribute claims the same slot a hoisted 4th ND dimension would
+    // otherwise use, so it leaves one fewer dimension free.
+    size_t thisMaxNDims = iter ? maxNDims - 1 : maxNDims;
     size_t numDims = bd.getMixedSizes().size();
-    if (numDims > maxNDims) {
-      bd.emitOpError() << "Cannot give more than " << std::to_string(maxNDims)
+    if (numDims > thisMaxNDims) {
+      bd.emitOpError() << "Cannot give more than "
+                       << std::to_string(thisMaxNDims)
                        << " dimensions for step sizes and wraps on this tile "
-                          "(got "
-                       << std::to_string(numDims) << " dimensions).";
+                       << (iter ? "when the iteration attribute is also set "
+                                : "")
+                       << "(got " << std::to_string(numDims) << " dimensions).";
       result = failure();
     }
   });

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -1178,6 +1178,13 @@ AIEX::DMAConfigureTaskOp::canonicalize(AIEX::DMAConfigureTaskOp op,
 // caps the total at 4, which the MemTile's 4 ND dimensions already reach. Both
 // branches therefore land on the same uniform 4-dimension cap enforced later by
 // AIEDMATasksToNPU.
+//
+// The `iteration` attribute (## BD iteration, AIEOps.td) addresses that same
+// shared register directly, in true element values, instead of through a
+// hoisted dimension: a compile-time-constant BD honors it (rewriteSingleBD in
+// AIEDMATasksToNPU.cpp), so it costs one fewer ND dimension here rather than
+// being rejected outright. The dynamic BD-word encoder
+// (rewriteSingleBDDynamic) does not yet implement it.
 static LogicalResult
 verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
                        Region &body) {
@@ -1192,20 +1199,37 @@ verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
       result = failure();
       return;
     }
-    if (bd.getIteration()) {
-      // See aie.dma_bd's ## BD iteration doc in AIEOps.td.
-      bd.emitOpError() << "the iteration attribute is not supported on the "
-                          "runtime-sequence path; express iteration via the "
-                          "outermost sizes/strides dimension instead";
-      result = failure();
-      return;
+    auto iter = bd.getIteration();
+    if (iter) {
+      bool constBd = (!bd.getLen() || bd.getConstantLen().has_value()) &&
+                     (!bd.getOffset() || bd.getConstantOffset().has_value()) &&
+                     llvm::all_of(bd.getMixedSizes(),
+                                  [](OpFoldResult s) {
+                                    return getConstantIntValue(s).has_value();
+                                  }) &&
+                     llvm::all_of(bd.getMixedStrides(), [](OpFoldResult s) {
+                       return getConstantIntValue(s).has_value();
+                     });
+      if (!constBd) {
+        bd.emitOpError() << "the iteration attribute requires a "
+                            "compile-time-constant buffer descriptor on the "
+                            "runtime-sequence path; express iteration via "
+                            "the outermost sizes/strides dimension instead";
+        result = failure();
+        return;
+      }
     }
+    // The attribute claims the same slot a hoisted 4th ND dimension would
+    // otherwise use, so it leaves one fewer dimension free.
+    size_t thisMaxNDims = iter ? maxNDims - 1 : maxNDims;
     size_t numDims = bd.getMixedSizes().size();
-    if (numDims > maxNDims) {
-      bd.emitOpError() << "Cannot give more than " << std::to_string(maxNDims)
+    if (numDims > thisMaxNDims) {
+      bd.emitOpError() << "Cannot give more than "
+                       << std::to_string(thisMaxNDims)
                        << " dimensions for step sizes and wraps on this tile "
-                          "(got "
-                       << std::to_string(numDims) << " dimensions).";
+                       << (iter ? "when the iteration attribute is also set "
+                                : "")
+                       << "(got " << std::to_string(numDims) << " dimensions).";
       result = failure();
     }
   });

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -798,6 +798,10 @@ LogicalResult AIEX::NpuWriteBdOp::verify() {
   if (static_cast<uint32_t>(getIterationStride()) > maxStep)
     return emitOpError() << "Iteration Stride exceeds the [0:" << maxStep
                          << "] range.";
+  // Encoded fields are actual-1, so current must not exceed size. Guards a
+  // hand-written writebd (front-end verifiers already enforce current < size).
+  if (getIterationCurrent() > getIterationSize())
+    return emitOpError() << "Iteration Current exceeds Iteration Size.";
   if (targetModel.isShimNOCTile(getColumn(), getRow()) && getD2Size() != 0)
     return emitOpError("ShimTile only supports 3 dimensions of sizes.");
   if (targetModel.isShimNOCTile(getColumn(), getRow()) &&
@@ -1215,6 +1219,13 @@ verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
                             "compile-time-constant buffer descriptor on the "
                             "runtime-sequence path; express iteration via "
                             "the outermost sizes/strides dimension instead";
+        result = failure();
+        return;
+      }
+      // DMABDOp::verify is skipped for task BDs (parent is the task op, not a
+      // *DMAOp), so enforce the iteration bounds here too.
+      if (failed(AIE::verifyBDIterationBounds(
+              bd, targetModel, targetModel.getTileType(col, row)))) {
         result = failure();
         return;
       }

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -792,6 +792,10 @@ LogicalResult AIEX::NpuWriteBdOp::verify() {
   if (static_cast<uint32_t>(getIterationStride()) > maxStep)
     return emitOpError() << "Iteration Stride exceeds the [0:" << maxStep
                          << "] range.";
+  // Encoded fields are actual-1, so current must not exceed size. Guards a
+  // hand-written writebd (front-end verifiers already enforce current < size).
+  if (getIterationCurrent() > getIterationSize())
+    return emitOpError() << "Iteration Current exceeds Iteration Size.";
   if (targetModel.isShimNOCTile(getColumn(), getRow()) && getD2Size() != 0)
     return emitOpError("ShimTile only supports 3 dimensions of sizes.");
   if (targetModel.isShimNOCTile(getColumn(), getRow()) &&
@@ -1209,6 +1213,13 @@ verifyTaskBDDimensions(const AIE::AIETargetModel &targetModel, int col, int row,
                             "compile-time-constant buffer descriptor on the "
                             "runtime-sequence path; express iteration via "
                             "the outermost sizes/strides dimension instead";
+        result = failure();
+        return;
+      }
+      // DMABDOp::verify is skipped for task BDs (parent is the task op, not a
+      // *DMAOp), so enforce the iteration bounds here too.
+      if (failed(AIE::verifyBDIterationBounds(
+              bd, targetModel, targetModel.getTileType(col, row)))) {
         result = failure();
         return;
       }

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -668,15 +668,20 @@ struct AIEDMATasksToNPUPass
       if (bd_op.getPadDimensions().has_value())
         return bd_op->emitOpError(
             "zero padding is not supported with runtime sizes/strides/len.");
-      // The verifier only rejects the iteration attribute for a BD that is
-      // itself runtime-valued; a compile-time-constant BD assigned a
-      // dynamic (pool-drawn) bd_id also reaches here (runtimeBdId), and the
-      // dynamic BD-word encoder below does not implement the attribute.
-      if (bd_op.getIteration())
+      // The verifier normally catches a runtime-valued BD with iteration set
+      // before this pass runs, but it is skipped on an unplaced tile; don't
+      // assume runtimeBdId is the cause just because this branch was taken.
+      if (bd_op.getIteration()) {
+        if (runtimeBdId)
+          return bd_op->emitOpError(
+              "the iteration attribute is not supported with a dynamic "
+              "(runtime-pool) bd_id; assign a static bd_id or express "
+              "iteration via the outermost sizes/strides dimension instead.");
         return bd_op->emitOpError(
-            "the iteration attribute is not supported with a dynamic "
-            "(runtime-pool) bd_id; assign a static bd_id or express "
-            "iteration via the outermost sizes/strides dimension instead.");
+            "the iteration attribute requires a compile-time-constant "
+            "buffer descriptor on the runtime-sequence path; express "
+            "iteration via the outermost sizes/strides dimension instead");
+      }
       // Realizability of the constant size/stride operands (runtime ones are
       // guarded at lowering by the shared encoder). Mixed lists are
       // outermost-first; the helper wants innermost-first.

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -668,9 +668,9 @@ struct AIEDMATasksToNPUPass
       if (bd_op.getPadDimensions().has_value())
         return bd_op->emitOpError(
             "zero padding is not supported with runtime sizes/strides/len.");
-      // The verifier normally catches a runtime-valued BD with iteration set
-      // before this pass runs, but it is skipped on an unplaced tile; don't
-      // assume runtimeBdId is the cause just because this branch was taken.
+      // DMABDOp::verify skips all task BDs and verifyTaskBDDimensions only
+      // covers placed tiles, so the dynamic BD-word encoder rejects iteration
+      // here too. Either bd_id kind can reach this; don't assume runtimeBdId.
       if (bd_op.getIteration()) {
         if (runtimeBdId)
           return bd_op->emitOpError(

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -668,6 +668,15 @@ struct AIEDMATasksToNPUPass
       if (bd_op.getPadDimensions().has_value())
         return bd_op->emitOpError(
             "zero padding is not supported with runtime sizes/strides/len.");
+      // The verifier only rejects the iteration attribute for a BD that is
+      // itself runtime-valued; a compile-time-constant BD assigned a
+      // dynamic (pool-drawn) bd_id also reaches here (runtimeBdId), and the
+      // dynamic BD-word encoder below does not implement the attribute.
+      if (bd_op.getIteration())
+        return bd_op->emitOpError(
+            "the iteration attribute is not supported with a dynamic "
+            "(runtime-pool) bd_id; assign a static bd_id or express "
+            "iteration via the outermost sizes/strides dimension instead.");
       // Realizability of the constant size/stride operands (runtime ones are
       // guarded at lowering by the shared encoder). Mixed lists are
       // outermost-first; the helper wants innermost-first.
@@ -737,6 +746,7 @@ struct AIEDMATasksToNPUPass
     auto d2stride = 0;
     auto iteration_size = 0;
     auto iteration_stride = 0;
+    auto iteration_current = 0;
 
     if (dims && !dims->empty()) {
       llvm::SmallVector<int64_t, 4> input_sizes =
@@ -864,6 +874,29 @@ struct AIEDMATasksToNPUPass
                << "        Padding is supported only on MemTiles.";
       }
     }
+    // The `iteration` attribute (## BD iteration, AIEOps.td) addresses the
+    // same register as the dim[3] hoist above, in true element values, and
+    // the verifier has confirmed dims leaves that slot free when this is
+    // set. Route it through the same encoder as a lone dimension 3 so the
+    // scaling/bias math cannot drift from the dims path, then override:
+    // dims never produced a real 4th dimension here (verified above), so
+    // there is nothing to combine with. Mirrors AIERT.cpp's
+    // getSize() > 1 / getStride() > 0 guard for the structural lowering of
+    // the same attribute.
+    if (auto iter = bd_op.getIteration();
+        iter && iter->getSize() > 1 && iter->getStride() > 0) {
+      llvm::SmallVector<int64_t, 4> iterInSizes = {1, 1, 1,
+                                                   (int64_t)iter->getSize()};
+      llvm::SmallVector<int64_t, 4> iterInStrides = {0, 0, 0,
+                                                     iter->getStride()};
+      llvm::SmallVector<int64_t, 4> iterSizes(4, 0), iterStrides(4, 0);
+      getHardwareStridesWraps(target_model, bd_op, buffer_type, iterInSizes,
+                              iterInStrides, iterSizes, iterStrides);
+      iteration_size = iterSizes[3];
+      iteration_stride = iterStrides[3];
+      iteration_current = static_cast<int32_t>(iter->getCurrent());
+    }
+
     auto fieldsOr = gatherBdTemplateFields(block, bd_op, tile, target_model,
                                            packet, outOfOrder);
     if (failed(fieldsOr))
@@ -881,7 +914,8 @@ struct AIEDMATasksToNPUPass
         /*d0_size=*/d0size, /*d0_stride=*/d0stride,
         /*d1_size=*/d1size, /*d1_stride=*/d1stride,
         /*d2_size=*/d2size, /*d2_stride=*/d2stride,
-        /*iteration_current=*/0, /*iteration_size=*/iteration_size,
+        /*iteration_current=*/iteration_current,
+        /*iteration_size=*/iteration_size,
         /*iteration_stride=*/iteration_stride,
         /*next_bd=*/f.next_bd_id,
         /*row=*/tile.getRow(),

--- a/lib/Dialect/AIEX/Transforms/AIEDecomposeLargeDmaBd.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDecomposeLargeDmaBd.cpp
@@ -380,6 +380,13 @@ struct DecomposeLargeDmaBdTaskPattern : OpRewritePattern<AIE::DMABDOp> {
                                   pattern))
       return failure();
 
+    // Iteration uses the outermost ND slot, so there is no free dimension to
+    // factor into, and chain-slicing has no defined iteration semantics.
+    if (op.getIteration())
+      return op.emitOpError()
+             << "buffer descriptor with the iteration attribute is too large "
+                "to lower and cannot be decomposed";
+
     auto decomposed =
         decomposeNdDmaPattern(op, bufferType, pattern, targetModel, col, row);
     // failed() already guards both dereferences below via short-circuit /

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -299,11 +299,35 @@ def packet_info_attr_builder(tups: Tuple[int] | List[int], context=None):
     )
 
 
+@dataclass
+class BdIteration:
+    """Iteration state of a buffer descriptor for aie.dma_bd.
+
+    Lets one BD cover ``size`` sub-buffers over ``size`` executions instead of an
+    N-deep chain. Values are true/element: the base advances by ``stride``
+    elements each execution and wraps after ``size`` executions; ``current`` is
+    the starting step (default 0). The lowering applies the hardware ``-1`` bias
+    and element->word scaling. NOTE: the identically-named ``iteration_*`` family
+    on the runtime-sequence path uses RAW register values instead -- do not copy
+    numbers between them.
+    """
+
+    size: int
+    stride: int
+    current: int = 0
+
+
 @register_attribute_builder("BDIterationAttr")
-def bd_iteration_attr_builder(tup: Tuple[int] | List[int], context=None):
-    assert (isinstance(tup, list) or isinstance(tup, tuple)) and len(tup) == 3
+def bd_iteration_attr_builder(
+    value: BdIteration | Tuple[int] | List[int], context=None
+):
+    if isinstance(value, BdIteration):
+        size, stride, current = value.size, value.stride, value.current
+    else:
+        assert (isinstance(value, list) or isinstance(value, tuple)) and len(value) == 3
+        size, stride, current = value
     return Attribute.parse(
-        f"#aie.bd_iteration<size = {tup[0]}, stride = {tup[1]}, current = {tup[2]}>",
+        f"#aie.bd_iteration<size = {size}, stride = {stride}, current = {current}>",
         context=context,
     )
 

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -18,6 +18,7 @@ from ._aiex_ops_gen import (
 from ._aie_ops_gen import ObjectFifoCreateOp, EndOp, RuntimeSequenceOp
 from . import aie
 from .aie import (
+    BdIteration,
     DMAChannelDir,
     LockAction,
     Neighbors,
@@ -280,6 +281,7 @@ def shim_dma_bd(
     axcache: int | None = None,
     packet: tuple[int] | None = None,
     offset_parameter: str | None = None,
+    iteration: BdIteration | None = None,
 ):
     if tap and not (offset is None and sizes is None and strides is None):
         raise ValueError(
@@ -313,6 +315,7 @@ def shim_dma_bd(
         axcache=axcache,
         packet=packet,
         offset_parameter=offset_parameter,
+        iteration=iteration,
     )
 
 
@@ -329,6 +332,7 @@ def shim_dma_single_bd_task(
     axcache: int | None = None,
     packet: tuple[int] | None = None,
     offset_parameter: str | None = None,
+    iteration: BdIteration | None = None,
 ):
     """_summary_
     Enables data transfers between the AIE Engine array and external memory.
@@ -346,6 +350,7 @@ def shim_dma_single_bd_task(
         axcache (optional): The raw 4-bit AxCACHE value for the DMA's AXI-MM transfers. If
             omitted, the target model's default AxCACHE value is used.
         packet (optional): The packet header information represented as a (packet_type, packet_id) tuple.
+        iteration (optional): The BD iteration state as a BdIteration(size, stride, current).
 
     Example:
         out_task = shim_dma_single_bd_task(of_out, C, sizes=[1, 1, 1, N], issue_token=True)
@@ -366,45 +371,51 @@ def shim_dma_single_bd_task(
         # so here we make sure it is evaluated and properly is seen as an integer.
         offset = int(tap.offset)
 
-    # The shim DMA BD has 3 access dimensions plus a hardware repeat/iteration
-    # dimension. The repeat_count below hoists sizes[0] into that iteration
-    # dimension, but the transferred extent is prod(sizes[-3:]) (see shim_dma_bd),
-    # so sizes[0] is left out of it only when there are 4 dimensions. With fewer
-    # than 4 dims and sizes[0] > 1, sizes[0] is counted both as a real access dim
-    # (in transfer_len and in the BD dimensions) and as repeat_count, so the shim
-    # re-issues the whole transfer sizes[0] times, waits on the objectfifo for that
-    # many objects, and dma_await_task never returns. Normalize to the canonical
-    # 4-dim form (left-pad with unit dims) so sizes[0] is only ever the iteration
-    # dimension, and reject taps with more than 4 dims instead of silently emitting
-    # a wrong BD.
-    if sizes is not None:
-        if len(sizes) > 4:
-            raise ValueError(
-                f"shim DMA BD supports at most 4 dimensions, got {len(sizes)}"
-            )
-        while len(sizes) < 4:
-            sizes = [1] + list(sizes)
-            if strides is not None:
-                strides = [0] + list(strides)
-
-    # The outer (sizes[0]) dimension becomes the queue-push repeat_count. A
-    # constant folds to the repeat_count attribute (static path, unchanged); a
-    # runtime Value flows into the repeat_count_val operand so a dynamic tile
-    # count is supported.
+    # The iteration attribute (when set) claims the shim's single iteration/repeat
+    # slot, so the BD carries ONLY its access dimensions (<=3) and does NOT also
+    # hoist an outer dimension.
     repeat_count = 0
     repeat_count_val = None
-    if sizes:
-        s0 = sizes[0]
-        if isinstance(s0, (int, np.integer)):
-            if s0 > 1:
-                repeat_count = int(s0) - 1
-        else:
-            # Runtime: repeat = s0 - 1 as arith, in i32 (the queue field width).
-            # sizes may be i64 (DynamicIndexList); truncate before subtracting.
-            s0_i32 = s0
-            if s0.type != T.i32():
-                s0_i32 = arith.trunci(T.i32(), s0)
-            repeat_count_val = s0_i32 - _as_i32(1)
+    if iteration is not None:
+        if sizes is not None and len(sizes) > 3:
+            raise ValueError(
+                "shim_dma_single_bd_task: iteration= supports at most 3 access "
+                "dimensions (the iteration attribute claims the 4th/iteration "
+                f"slot); got {len(sizes)}."
+            )
+    else:
+        # sizes[0] is hoisted into the hardware repeat_count, while the transfer
+        # itself covers only the inner 3 dims. So an un-padded leading dim > 1 gets
+        # double-counted -- once in the transfer, once as the repeat -- and the shim
+        # re-runs the whole transfer sizes[0] times, hanging dma_await_task on
+        # objects that never arrive. Left-pad to 4 dims so sizes[0] is only ever the
+        # repeat slot, and reject > 4 dims rather than emit a wrong BD.
+        if sizes is not None:
+            if len(sizes) > 4:
+                raise ValueError(
+                    f"shim DMA BD supports at most 4 dimensions, got {len(sizes)}"
+                )
+            while len(sizes) < 4:
+                sizes = [1] + list(sizes)
+                if strides is not None:
+                    strides = [0] + list(strides)
+
+        # The outer (sizes[0]) dimension becomes the queue-push repeat_count. A
+        # constant folds to the repeat_count attribute (static path, unchanged); a
+        # runtime Value flows into the repeat_count_val operand so a dynamic tile
+        # count is supported.
+        if sizes:
+            s0 = sizes[0]
+            if isinstance(s0, (int, np.integer)):
+                if s0 > 1:
+                    repeat_count = int(s0) - 1
+            else:
+                # Runtime: repeat = s0 - 1 as arith, in i32 (the queue field width).
+                # sizes may be i64 (DynamicIndexList); truncate before subtracting.
+                s0_i32 = s0
+                if s0.type != T.i32():
+                    s0_i32 = arith.trunci(T.i32(), s0)
+                repeat_count_val = s0_i32 - _as_i32(1)
     task = dma_configure_task_for(
         alloc,
         repeat_count=repeat_count,
@@ -423,6 +434,7 @@ def shim_dma_single_bd_task(
                 axcache=axcache,
                 packet=packet,
                 offset_parameter=offset_parameter,
+                iteration=iteration,
             )
             EndOp()
     return task

--- a/python/iron/dataflow/tile_dma.py
+++ b/python/iron/dataflow/tile_dma.py
@@ -31,6 +31,7 @@ from ...dialects._aie_enum_gen import (  # pyright: ignore[reportMissingImports]
     LockAction,
 )
 from ...dialects.aie import (
+    BdIteration,  # pyright: ignore[reportAttributeAccessIssue]
     EndOp,  # pyright: ignore[reportAttributeAccessIssue]
     dma_bd,  # pyright: ignore[reportAttributeAccessIssue]
     dma_bd_packet,  # pyright: ignore[reportAttributeAccessIssue]
@@ -72,24 +73,6 @@ class Release:
 
     def emit(self) -> None:
         use_lock(self.lock.op, LockAction.Release, value=self.value)
-
-
-@dataclass
-class BdIteration:
-    """Iteration state of a buffer descriptor for aie.dma_bd.
-
-    Lets one BD cover ``size`` sub-buffers over ``size`` executions instead of an
-    N-deep chain. Values are true/element: the base advances by ``stride``
-    elements each execution and wraps after ``size`` executions; ``current`` is
-    the starting step (default 0). The lowering applies the hardware ``-1`` bias
-    and element->word scaling. NOTE: the identically-named ``iteration_*`` family
-    on the runtime-sequence path uses RAW register values instead -- do not copy
-    numbers between them.
-    """
-
-    size: int
-    stride: int
-    current: int = 0
 
 
 @dataclass
@@ -391,8 +374,7 @@ class TileDma(Resolvable):
                         if bd.pad_dimensions is not None:
                             bd_kwargs["pad_dimensions"] = bd.pad_dimensions
                         if bd.iteration is not None:
-                            it = bd.iteration
-                            bd_kwargs["iteration"] = (it.size, it.stride, it.current)
+                            bd_kwargs["iteration"] = bd.iteration
                         if ch.out_of_order:
                             bd_kwargs["bd_id"] = _ooo_slot_id(bd, bd_pos)
                         elif bd.bd_id is not None:

--- a/test/Conversion/DmaToNpu/dma_to_npu_core_tile.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_core_tile.mlir
@@ -9,7 +9,7 @@
 
 // Verify WriteBdOp packing for a core tile
 // CHECK-LABEL: module
-// CHECK: memref.global "private" constant @blockwrite_data_0 : memref<6xi32> = dense<[1180485, 1430061056, 9093684, 266847009, 22249971, 1465218380]>
+// CHECK: memref.global "private" constant @blockwrite_data_0 : memref<6xi32> = dense<[1180485, 1430061056, 9093684, 266847009, 14385651, 1465218380]>
 // CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 2216128 : ui32} : memref<6xi32>
 module {
   aie.device(npu1_1col) {
@@ -37,7 +37,7 @@ module {
         d2_zero_after = 0 : i32,
         d2_zero_before = 0 : i32,
         ddr_id = 0 : i32,
-        iteration_current = 42 : i32,
+        iteration_current = 27 : i32,
         iteration_stride = 499 : i32,
         iteration_size = 28 : i32,
         lock_acq_enable = 1 : i32,

--- a/test/Conversion/DmaToNpu/dma_to_npu_core_tile.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_core_tile.mlir
@@ -9,7 +9,7 @@
 
 // Verify WriteBdOp packing for a core tile
 // CHECK-LABEL: module
-// CHECK: memref.global "private" constant @blockwrite_data_0 : memref<6xi32> = dense<[1180485, 1430061056, 9093684, 266847009, 22249971, 1465218380]>
+// CHECK: memref.global "private" constant @blockwrite_data_0 : memref<6xi32> = dense<[1180485, 1430061056, 9093684, 266847009, 11239923, 1465218380]>
 // CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 2216128 : ui32} : memref<6xi32>
 module {
   aie.device(npu1_1col) {
@@ -37,7 +37,7 @@ module {
         d2_zero_after = 0 : i32,
         d2_zero_before = 0 : i32,
         ddr_id = 0 : i32,
-        iteration_current = 42 : i32,
+        iteration_current = 21 : i32,
         iteration_stride = 499 : i32,
         iteration_size = 28 : i32,
         lock_acq_enable = 1 : i32,

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-bounds.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-bounds.mlir
@@ -1,0 +1,42 @@
+//===- bad-iteration-bounds.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The aie.dma_bd verifier is skipped for runtime-sequence BDs, so
+// verifyTaskBDDimensions enforces the #aie.bd_iteration bounds: size in [1, 64]
+// and current in [0, size). With both checked, current > 63 is unreachable.
+
+// RUN: aie-opt --verify-diagnostics --split-input-file %s
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<64xi32>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        // expected-error @+1 {{BD iteration size must be in [1, 64]}}
+        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64) {bd_id = 5 : i32, iteration = #aie.bd_iteration<size = 65, stride = 16, current = 0>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+    }
+  }
+}
+
+// -----
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<64xi32>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        // expected-error @+1 {{BD iteration current must be in [0, size)}}
+        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64) {bd_id = 5 : i32, iteration = #aie.bd_iteration<size = 4, stride = 16, current = 4>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-dynamic-bdid.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-dynamic-bdid.mlir
@@ -1,0 +1,31 @@
+//===- bad-iteration-dynamic-bdid.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A compile-time-constant BD (see good-iteration-attribute.mlir) still
+// rejects #aie.bd_iteration when the BD draws its bd_id from the runtime
+// free-list pool (good-runtime-bdid.mlir): the verifier cannot see this from
+// the sizes/strides alone, so the dynamic BD-word encoder rejects it once
+// dma-tasks-to-npu resolves that the bd_id is runtime.
+
+// RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<1024xi32>) {
+      %bd = aiex.dma_bd_pool_pop(0, 0) : i32
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        // expected-error @+1 {{the iteration attribute is not supported with a dynamic (runtime-pool) bd_id}}
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256) bd_id_val %bd : i32 {iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_await_task(%t)
+      aiex.dma_bd_pool_push(0, 0) bd_id %bd : i32
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-runtime-dims-static-bdid.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-runtime-dims-static-bdid.mlir
@@ -1,0 +1,31 @@
+//===- bad-iteration-runtime-dims-static-bdid.mlir --------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// verifyTaskBDDimensions normally catches a runtime-valued BD with
+// #aie.bd_iteration before this pass ever runs (dma_task_iteration_rejected.mlir),
+// so the lowering-path diagnostic below is unreachable with a placed tile and
+// verification enabled. Disable both to isolate the pass's own diagnostic:
+// with a STATIC bd_id but a runtime-valued dimension forcing the dynamic BD
+// path, it must report the compile-time-constant BD cause, not the dynamic
+// (runtime-pool) bd_id cause the same branch also reports for a different
+// input (bad-iteration-dynamic-bdid.mlir).
+
+// RUN: aie-opt --mlir-very-unsafe-disable-verifier-on-parsing --verify-each=false --verify-diagnostics --aie-dma-tasks-to-npu %s
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<64xi32>, %n: i64) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        // expected-error @+1 {{the iteration attribute requires a compile-time-constant buffer descriptor on the runtime-sequence path}}
+        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64 sizes = [1, %n, 8, 4] strides = [4096, 512, 4, 1]) { bd_id = 5 : i32, iteration = #aie.bd_iteration<size = 4, stride = 16, current = 0> }
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-too-many-dims.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-iteration-too-many-dims.mlir
@@ -1,0 +1,27 @@
+//===- bad-iteration-too-many-dims.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// #aie.bd_iteration claims the same hardware slot a hoisted 4th ND dimension
+// would otherwise use (see good-iteration-attribute.mlir for the accepted
+// 3-dimension + iteration combination), so a full 4-dimensional access
+// pattern leaves no room for it.
+
+// RUN: aie-opt --verify-diagnostics %s
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<8192xi32>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        // expected-error @+1 {{Cannot give more than 3 dimensions for step sizes and wraps on this tile when the iteration attribute is also set (got 4 dimensions)}}
+        aie.dma_bd(%arg0 : memref<8192xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1]) {bd_id = 5 : i32, iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-iteration-attribute.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-iteration-attribute.mlir
@@ -1,0 +1,38 @@
+//===- good-iteration-attribute.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A compile-time-constant BD's #aie.bd_iteration attribute lowers to the raw
+// npu.writebd iteration_current/size/stride fields: true element values (size
+// = 4, stride = 16) become the off-by-one/word-scaled register form (3, 15),
+// same conversion AIERT.cpp applies on the structural path; current (2) is
+// unbiased. The second task combines it with a real 3-dimensional access
+// pattern, showing the attribute does not clobber that encoding (it claims
+// the would-be-hoisted 4th slot instead, per verifyTaskBDDimensions).
+
+// RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+
+    aie.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<8192xi32>) {
+      // CHECK: aiex.npu.writebd {axcache = 2 : i32, bd_id = 5 : i32, buffer_length = 64 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d0_zero_after = 0 : i32, d0_zero_before = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d1_zero_after = 0 : i32, d1_zero_before = 0 : i32, d2_size = 0 : i32, d2_stride = 0 : i32, d2_zero_after = 0 : i32, d2_zero_before = 0 : i32, enable_packet = 0 : i32, iteration_current = 2 : i32, iteration_size = 3 : i32, iteration_stride = 15 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64) {bd_id = 5 : i32, iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t1)
+
+      // CHECK: aiex.npu.writebd {axcache = 2 : i32, bd_id = 6 : i32, buffer_length = 32 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d0_zero_after = 0 : i32, d0_zero_before = 0 : i32, d1_size = 8 : i32, d1_stride = 31 : i32, d1_zero_after = 0 : i32, d1_zero_before = 0 : i32, d2_size = 0 : i32, d2_stride = 511 : i32, d2_zero_after = 0 : i32, d2_zero_before = 0 : i32, enable_packet = 0 : i32, iteration_current = 2 : i32, iteration_size = 3 : i32, iteration_stride = 15 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      %t2 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg1 : memref<8192xi32> offset = 0 len = 32 sizes = [4, 8, 1] strides = [512, 32, 1]) {bd_id = 6 : i32, iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t2)
+    }
+  }
+}

--- a/test/dialect/AIEX/decompose_large_dma_task.mlir
+++ b/test/dialect/AIEX/decompose_large_dma_task.mlir
@@ -199,3 +199,33 @@ module {
     }
   }
 }
+
+
+// -----
+
+// Test: PRESERVED -- a legal (in-range) iteration BD is left untouched. The pass
+// only rewrites oversized patterns, and it refuses to decompose iteration BDs.
+//
+// RUN: aie-opt --pass-pipeline='any(aie.device(aie-decompose-large-dma-bd))' \
+// RUN:   --split-input-file %s | FileCheck %s --check-prefix=ITER
+
+// ITER-LABEL: @iteration_preserved
+// ITER:         aie.dma_bd
+// ITER-SAME:      sizes = [4, 8, 1] strides = [512, 32, 1]
+// ITER-SAME:      iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>
+// ITER-NOT:     aie.next_bd
+module {
+  aie.device(npu2_1col) {
+    %t = aie.tile(0, 0)
+    aie.shim_dma_allocation @a (%t, MM2S, 0)
+    aie.runtime_sequence @iteration_preserved(%in: memref<8192xi32>) {
+      %tk = aiex.dma_configure_task_for @a {
+        aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 32 sizes = [4, 8, 1] strides = [512, 32, 1])
+          {iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tk)
+      aiex.dma_await_task(%tk)
+    }
+  }
+}

--- a/test/dialect/AIEX/decompose_large_dma_task_iteration.mlir
+++ b/test/dialect/AIEX/decompose_large_dma_task_iteration.mlir
@@ -1,0 +1,29 @@
+//===- decompose_large_dma_task_iteration.mlir -----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// An oversized task-path aie.dma_bd that carries the iteration attribute cannot
+// be decomposed.
+
+// RUN: aie-opt --pass-pipeline='any(aie.device(aie-decompose-large-dma-bd))' \
+// RUN:   --split-input-file --verify-diagnostics %s
+
+module {
+  aie.device(npu2_1col) {
+    %t = aie.tile(0, 0)
+    aie.shim_dma_allocation @a (%t, MM2S, 0)
+    aie.runtime_sequence @iteration_oversized(%in: memref<8192xi32>) {
+      %tk = aiex.dma_configure_task_for @a {
+        // expected-error @+1 {{buffer descriptor with the iteration attribute is too large to lower and cannot be decomposed}}
+        aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 2062 sizes = [1, 1031, 2] strides = [0, 3, 1])
+          {iteration = #aie.bd_iteration<size = 4, stride = 2062, current = 0>}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tk)
+      aiex.dma_await_task(%tk)
+    }
+  }
+}

--- a/test/dialect/AIEX/dma_task_iteration_rejected.mlir
+++ b/test/dialect/AIEX/dma_task_iteration_rejected.mlir
@@ -5,19 +5,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-// The grouped #aie.bd_iteration attribute drives the structural path.
-// On the runtime-sequence path, iteration is expressed via the outermost
-// sizes/strides dimension.
+// A runtime-valued BD still rejects the #aie.bd_iteration attribute: the
+// dynamic BD-word encoder does not implement it. A compile-time-constant BD
+// does not hit this (see good-iteration-attribute.mlir in
+// bd-chains-and-dma-tasks/dma-tasks-to-npu/); on that path iteration is
+// expressed via the outermost sizes/strides dimension only when a runtime
+// value forces it here.
 
 // RUN: aie-opt --verify-diagnostics %s
 
 module {
   aie.device(npu1) {
     %tile_0_0 = aie.tile(0, 0)
-    aie.runtime_sequence(%arg0: memref<64xi32>) {
+    aie.runtime_sequence(%arg0: memref<64xi32>, %n: i64) {
       %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        // expected-error @+1 {{the iteration attribute is not supported on the runtime-sequence path}}
-        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64) { iteration = #aie.bd_iteration<size = 4, stride = 16, current = 0> }
+        // expected-error @+1 {{the iteration attribute requires a compile-time-constant buffer descriptor on the runtime-sequence path}}
+        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64 sizes = [1, %n, 8, 4] strides = [4096, 512, 4, 1]) { bd_id = 5 : i32, iteration = #aie.bd_iteration<size = 4, stride = 16, current = 0> }
         aie.end
       }
     }

--- a/test/npu-xrt/bd_iteration_dma_task/aie.mlir
+++ b/test/npu-xrt/bd_iteration_dma_task/aie.mlir
@@ -1,0 +1,61 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A single S2MM buffer descriptor on the runtime-sequence path
+// (aiex.dma_configure_task) receives a 4096-element stream in four chunks; its
+// #aie.bd_iteration advances the write base one slot per run (current=2), so
+// chunk k lands at slot ((2 + k) % 4). Drained back to the host to check.
+
+module {
+  aie.device(NPUDEVICE) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+
+    %prod_lock = aie.lock(%tile_0_1, 0) {init = 4 : i32, sym_name = "prod_lock"}
+    %cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "cons_lock"}
+    %out_buff = aie.buffer(%tile_0_1) {sym_name = "out_buff"} : memref<4096xi32>
+
+    aie.flow(%tile_0_0, DMA : 0, %tile_0_1, DMA : 0)
+    aie.flow(%tile_0_1, DMA : 0, %tile_0_0, DMA : 0)
+
+    aie.runtime_sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>) {
+      %t0 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<4096xi32> offset = 0 len = 4096) {bd_id = 0 : i32}
+        aie.end
+      }
+
+      // The iteration BD under test; repeat_count=3 gives it four executions,
+      // one cons_lock release each.
+      %t1 = aiex.dma_configure_task(%tile_0_1, S2MM, 0) {
+        %c1 = arith.constant 1 : i32
+        aie.use_lock(%prod_lock, AcquireGreaterEqual, %c1)
+        aie.dma_bd(%out_buff : memref<4096xi32> offset = 0 len = 1024) {bd_id = 0 : i32, iteration = #aie.bd_iteration<size = 4, stride = 1024, current = 2>}
+        %c1_0 = arith.constant 1 : i32
+        aie.use_lock(%cons_lock, Release, %c1_0)
+        aie.end
+      } {repeat_count = 3 : i32}
+      aiex.dma_start_task(%t0)
+      aiex.dma_start_task(%t1)
+
+      %t2 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
+        %c4 = arith.constant 4 : i32
+        aie.use_lock(%cons_lock, AcquireGreaterEqual, %c4)
+        aie.dma_bd(%out_buff : memref<4096xi32> offset = 0 len = 4096) {bd_id = 1 : i32}
+        %c4_0 = arith.constant 4 : i32
+        aie.use_lock(%prod_lock, Release, %c4_0)
+        aie.end
+      }
+      %t3 = aiex.dma_configure_task(%tile_0_0, S2MM, 0) {
+        aie.dma_bd(%arg1 : memref<4096xi32> offset = 0 len = 4096) {bd_id = 1 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t2)
+      aiex.dma_start_task(%t3)
+      aiex.dma_await_task(%t3)
+    }
+  }
+}

--- a/test/npu-xrt/bd_iteration_dma_task/run.lit
+++ b/test/npu-xrt/bd_iteration_dma_task/run.lit
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %aiecc --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: %host_clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags %host_link_flags %test_utils_flags
+// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/bd_iteration_dma_task/test.cpp
+++ b/test/npu-xrt/bd_iteration_dma_task/test.cpp
@@ -1,0 +1,84 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "cxxopts.hpp"
+#include "test_utils.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+// Must match the #aie.bd_iteration attribute in aie.mlir.
+constexpr int SIZE = 4;     // iteration_size (slots)
+constexpr int START = 2;    // iteration_current
+constexpr int CHUNK = 1024; // elements per execution
+constexpr int N = SIZE * CHUNK;
+
+int main(int argc, const char *argv[]) {
+  cxxopts::Options options("bd_iteration_dma_task");
+  test_utils::add_default_options(options);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+
+  auto device = xrt::device(0);
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+  std::string kernelName = vm["kernel"].as<std::string>();
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_in = xrt::bo(device, N * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+                       kernel.group_id(3));
+  auto bo_out = xrt::bo(device, N * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+                        kernel.group_id(4));
+
+  uint32_t *bufIn = bo_in.map<uint32_t *>();
+  for (int i = 0; i < N; i++)
+    bufIn[i] = i + 1;
+
+  memcpy(bo_instr.map<void *>(), instr_v.data(), instr_v.size() * sizeof(int));
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_in.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  auto run = kernel(3, bo_instr, instr_v.size(), bo_in, bo_out);
+  if (run.wait() != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete\n";
+    return 1;
+  }
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+  int errors = 0;
+  for (int k = 0; k < SIZE; k++) {
+    int slot = (START + k) % SIZE;
+    for (int j = 0; j < CHUNK; j++) {
+      uint32_t want = bufIn[k * CHUNK + j];
+      uint32_t got = bufOut[slot * CHUNK + j];
+      if (got != want) {
+        if (errors < 16)
+          std::cout << "out[" << slot * CHUNK + j << "] = " << got
+                    << " != " << want << "\n";
+        errors++;
+      }
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  }
+  std::cout << "\n" << errors << " mismatches.\n\nfailed.\n\n";
+  return 1;
+}

--- a/test/python/shim_dma_bd_iteration.py
+++ b/test/python/shim_dma_bd_iteration.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import numpy as np
+from aie.dialects.aie import AIEDevice, BdIteration, device, object_fifo, tile
+from aie.dialects.aiex import *
+from util import construct_and_print_module
+
+# RUN: %python %s | FileCheck %s
+
+
+# The shim helpers forward iteration= to aie.dma_bd as an #aie.bd_iteration attr.
+
+
+# CHECK-LABEL: shim_bd_forwards_iteration
+# CHECK: aie.dma_bd({{.*}} sizes = [4, 8, 1] strides = [512, 32, 1])
+# CHECK-SAME: iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>
+@construct_and_print_module
+def shim_bd_forwards_iteration(module):
+    N = 64
+
+    @device(AIEDevice.npu1)
+    def device_body():
+        N_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        S = tile(0, 0)
+        M = tile(0, 2)
+        of_out = object_fifo("out", M, S, 2, N_ty)
+
+        @runtime_sequence(N_ty)
+        def sequence(C):
+            task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(task) as bd:
+                with bd[0]:
+                    shim_dma_bd(
+                        C,
+                        sizes=[4, 8, 1],
+                        strides=[512, 32, 1],
+                        iteration=BdIteration(size=4, stride=16, current=2),
+                    )
+                    EndOp()
+            dma_start_task(task)
+
+    return module
+
+
+# With iteration= set the helper skips its usual pad-to-4, so the BD stays 3-dim;
+# emitted sizes = [4, 8, 1] (not padded to [1, 4, 8, 1]) proves the skip.
+
+
+# CHECK-LABEL: shim_task_forwards_iteration
+# CHECK: aie.dma_bd({{.*}} sizes = [4, 8, 1] strides = [512, 32, 1])
+# CHECK-SAME: iteration = #aie.bd_iteration<size = 4, stride = 16, current = 2>
+@construct_and_print_module
+def shim_task_forwards_iteration(module):
+    N = 64
+
+    @device(AIEDevice.npu1)
+    def device_body():
+        N_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        S = tile(0, 0)
+        M = tile(0, 2)
+        of_out = object_fifo("out", M, S, 2, N_ty)
+
+        @runtime_sequence(N_ty)
+        def sequence(C):
+            task = shim_dma_single_bd_task(
+                of_out,
+                C,
+                sizes=[4, 8, 1],
+                strides=[512, 32, 1],
+                iteration=BdIteration(size=4, stride=16, current=2),
+                issue_token=True,
+            )
+            dma_start_task(task)
+
+    return module
+
+
+# >3 access dims with iteration= must raise.
+# CHECK-LABEL: shim_task_rejects_extra_dims
+# CHECK: ValueError: shim_dma_single_bd_task: iteration= supports at most 3 access dimensions
+print("\nTEST: shim_task_rejects_extra_dims")
+
+
+def _bad_iteration_dims(module):
+    N = 64
+
+    @device(AIEDevice.npu1)
+    def device_body():
+        N_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        S = tile(0, 0)
+        M = tile(0, 2)
+        of_out = object_fifo("out", M, S, 2, N_ty)
+
+        @runtime_sequence(N_ty)
+        def sequence(C):
+            shim_dma_single_bd_task(
+                of_out,
+                C,
+                sizes=[2, 4, 8, 1],
+                strides=[4096, 512, 32, 1],
+                iteration=BdIteration(size=4, stride=16, current=2),
+            )
+
+    return module
+
+
+try:
+    construct_and_print_module(_bad_iteration_dims)
+except ValueError as e:
+    print(f"ValueError: {e}")


### PR DESCRIPTION
## Description

#3538 added `#aie.bd_iteration<size, stride, current>` to `aie.dma_bd` but rejects it
outright when the same op sits inside `aiex.dma_configure_task` (the runtime-sequence
DMA-task path), directing the author to "express iteration via the outermost
sizes/strides dimension instead". That workaround is not equivalent to what it
replaces: the outermost-dimension route (`AIEDMATasksToNPU.cpp`) hardcodes
`iteration_current = 0` unconditionally, so the register's resume-index field cannot be
set on this path at all — not degraded, absent — while the message reads as if the two
spellings were interchangeable.

This honors the attribute for a compile-time-constant BD with a static `bd_id`
(`rewriteSingleBD`), feeding `(size, stride)` through the same `getHardwareStridesWraps`
encoder the outermost-dimension path already uses so the off-by-one and word-scaling
math cannot drift between the two, and passing `current` through unbiased (matching the
structural lowering in `AIERT.cpp`). `verifyTaskBDDimensions` now costs the attribute one
ND dimension rather than rejecting it, and rejects precisely instead of blanket: a
runtime-valued BD at verify time (bd-local, so the message is immediate), and a BD given
a dynamic free-list-pool `bd_id` at lowering time (only visible once dma-tasks-to-npu
resolves it).

Four FileCheck lit tests cover it: `good-iteration-attribute.mlir` (lowers to the exact
`npu.writebd` iteration fields — size 4/stride 16/current 2 → raw 3/15/2, alone and
combined with a real 3-dimensional access pattern), plus
`dma_task_iteration_rejected.mlir`, `bad-iteration-dynamic-bdid.mlir` and
`bad-iteration-too-many-dims.mlir` for the three cases that still reject, each asserting
the exact message. 285 pre-existing lit tests under `test/dialect/` and
`test/bd-chains-and-dma-tasks/` still pass (excluding peano/XRT-gated ones, not built
here).

One pre-existing test changes. `test/Conversion/DmaToNpu/dma_to_npu_core_tile.mlir`
(added in #2824) packs `iteration_current = 42` against `iteration_size = 28`. Those
fields are encoded actual-1, so current must not exceed size, and the new bound now
rejects it — the values were arbitrary bit-packing fodder, never a legal BD. Lowered to
`iteration_current = 21` and the expected word updated accordingly
(`(21<<19)|(28<<13)|499 = 11239923`). It is the only writebd in the tree that violated
the rule; the rest of the sweep is unchanged.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (no Python touched)
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (file not on the enabled list)
