### PR TITLE
[AIE] Report a diagnostic when a register field value overflows its width [LOW]

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -558,8 +558,9 @@ public:
                                       bool isMem = false) const;
 
   /// Encode a field value with proper bit shifting.
-  /// Return Value shifted to correct bit position
-  uint32_t encodeFieldValue(const BitFieldInfo &field, uint32_t value) const;
+  /// Return nullopt if value does not fit in the field's bit width.
+  std::optional<uint32_t> encodeFieldValue(const BitFieldInfo &field,
+                                           uint32_t value) const;
 
   /// Compute a 32-bit mask for a register field.
   /// Return nullopt if the field does not fit in a 32-bit register.

--- a/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
+++ b/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
@@ -78,8 +78,10 @@ public:
   std::optional<uint32_t> lookupEvent(llvm::StringRef name,
                                       llvm::StringRef module) const;
 
-  /// Encode a value for a specific bitfield
-  uint32_t encodeFieldValue(const BitFieldInfo &field, uint32_t value) const;
+  /// Encode a value for a specific bitfield.
+  /// Return nullopt if value does not fit in the field's bit width.
+  std::optional<uint32_t> encodeFieldValue(const BitFieldInfo &field,
+                                           uint32_t value) const;
 
 private:
   RegisterDatabase() = default;

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -74,8 +74,9 @@ std::optional<uint32_t> AIETargetModel::lookupEvent(llvm::StringRef name,
   return db->lookupEvent(name, getModuleForTileEvents(*this, tile, isMem));
 }
 
-uint32_t AIETargetModel::encodeFieldValue(const BitFieldInfo &field,
-                                          uint32_t value) const {
+std::optional<uint32_t>
+AIETargetModel::encodeFieldValue(const BitFieldInfo &field,
+                                 uint32_t value) const {
   const auto *db = getRegisterDatabase();
   if (!db)
     return 0;

--- a/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
@@ -782,13 +782,17 @@ struct AIEInsertTraceFlowsPass
       if (!resetField)
         llvm::report_fatal_error(
             "Failed to lookup Reset_Event field in Timer_Control");
-      uint32_t timerCtrlValue =
+      auto timerCtrlValue =
           targetModel.encodeFieldValue(*resetField, *broadcastEvent);
+      if (!timerCtrlValue)
+        llvm::report_fatal_error("Broadcast event does not fit in "
+                                 "Timer_Control's Reset_Event field");
 
       xilinx::AIEX::NpuWrite32Op::create(
           builder, runtimeSeq.getLoc(),
           AIEX::createConstantI32(builder, runtimeSeq.getLoc(), timerCtrlAddr),
-          AIEX::createConstantI32(builder, runtimeSeq.getLoc(), timerCtrlValue),
+          AIEX::createConstantI32(builder, runtimeSeq.getLoc(),
+                                  *timerCtrlValue),
           nullptr, builder.getI32IntegerAttr(col),
           builder.getI32IntegerAttr(row));
     }
@@ -860,8 +864,11 @@ struct AIEInsertTraceFlowsPass
         if (!ctrlIdField)
           llvm::report_fatal_error("Failed to lookup Controller_ID field in " +
                                    llvm::Twine(ctrlRegName));
-        uint32_t ctrlIdValue =
+        auto ctrlIdValue =
             targetModel.encodeFieldValue(*ctrlIdField, ctrlIdAttr.getPktId());
+        if (!ctrlIdValue)
+          llvm::report_fatal_error("Controller ID does not fit in the "
+                                   "Controller_ID field");
         auto ctrlIdMask = targetModel.getFieldMask(*ctrlIdField);
         if (!ctrlIdMask)
           llvm::report_fatal_error(
@@ -869,7 +876,7 @@ struct AIEInsertTraceFlowsPass
         xilinx::AIEX::NpuMaskWrite32Op::create(
             builder, runtimeSeq.getLoc(),
             AIEX::createConstantI32(builder, runtimeSeq.getLoc(), ctrlAddr),
-            AIEX::createConstantI32(builder, runtimeSeq.getLoc(), ctrlIdValue),
+            AIEX::createConstantI32(builder, runtimeSeq.getLoc(), *ctrlIdValue),
             AIEX::createConstantI32(builder, runtimeSeq.getLoc(), *ctrlIdMask),
             nullptr, builder.getI32IntegerAttr(shimCol),
             builder.getI32IntegerAttr(0));
@@ -889,9 +896,14 @@ struct AIEInsertTraceFlowsPass
         if (!tokenField || !bdIdField)
           llvm::report_fatal_error(
               "Failed to lookup Enable_Token_Issue or Start_BD_ID fields");
-        uint32_t queueValue =
-            targetModel.encodeFieldValue(*tokenField, 1) |
+        auto tokenValue = targetModel.encodeFieldValue(*tokenField, 1);
+        auto bdIdValue =
             targetModel.encodeFieldValue(*bdIdField, chanDesc.bdId);
+        if (!tokenValue || !bdIdValue)
+          llvm::report_fatal_error("BD ID does not fit in the Start_BD_ID "
+                                   "field of " +
+                                   llvm::Twine(taskQueueRegName));
+        uint32_t queueValue = *tokenValue | *bdIdValue;
         xilinx::AIEX::NpuWrite32Op::create(
             builder, runtimeSeq.getLoc(),
             AIEX::createConstantI32(builder, runtimeSeq.getLoc(),
@@ -920,14 +932,17 @@ struct AIEInsertTraceFlowsPass
         if (!shimResetField)
           llvm::report_fatal_error(
               "Failed to lookup Reset_Event in shim Timer_Control");
-        uint32_t shimTimerCtrlValue =
+        auto shimTimerCtrlValue =
             targetModel.encodeFieldValue(*shimResetField, *userEvent1);
+        if (!shimTimerCtrlValue)
+          llvm::report_fatal_error("USER_EVENT_1 does not fit in shim "
+                                   "Timer_Control's Reset_Event field");
         xilinx::AIEX::NpuWrite32Op::create(
             builder, runtimeSeq.getLoc(),
             AIEX::createConstantI32(builder, runtimeSeq.getLoc(),
                                     shimTimerCtrlAddr),
             AIEX::createConstantI32(builder, runtimeSeq.getLoc(),
-                                    shimTimerCtrlValue),
+                                    *shimTimerCtrlValue),
             nullptr, builder.getI32IntegerAttr(shimCol),
             builder.getI32IntegerAttr(0));
 

--- a/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
@@ -899,7 +899,11 @@ struct AIEInsertTraceFlowsPass
         auto tokenValue = targetModel.encodeFieldValue(*tokenField, 1);
         auto bdIdValue =
             targetModel.encodeFieldValue(*bdIdField, chanDesc.bdId);
-        if (!tokenValue || !bdIdValue)
+        if (!tokenValue)
+          llvm::report_fatal_error("Enable_Token_Issue does not fit in the "
+                                   "field of " +
+                                   llvm::Twine(taskQueueRegName));
+        if (!bdIdValue)
           llvm::report_fatal_error("BD ID does not fit in the Start_BD_ID "
                                    "field of " +
                                    llvm::Twine(taskQueueRegName));

--- a/lib/Dialect/AIE/Transforms/AIETraceToConfig.cpp
+++ b/lib/Dialect/AIE/Transforms/AIETraceToConfig.cpp
@@ -606,12 +606,18 @@ struct AIETraceRegPackWritesPass
               << "], width=" << fieldInfo->getWidth();
           return signalPassFailure();
         }
-        uint32_t shiftedValue = targetModel.encodeFieldValue(*fieldInfo, value);
+        auto shiftedValue = targetModel.encodeFieldValue(*fieldInfo, value);
+        if (!shiftedValue) {
+          regOp.emitError("Value ")
+              << value << " does not fit in field " << regOp.getRegName() << "."
+              << fieldInfo->name << " (width " << fieldInfo->getWidth() << ")";
+          return signalPassFailure();
+        }
         // Create new operation with mask
         builder.setInsertionPoint(regOp);
         TraceRegOp::create(builder, regOp.getLoc(), regOp.getRegNameAttr(),
                            nullptr, // no field
-                           builder.getI32IntegerAttr(shiftedValue),
+                           builder.getI32IntegerAttr(*shiftedValue),
                            builder.getI32IntegerAttr(*mask),
                            regOp.getCommentAttr());
 

--- a/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
+++ b/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
@@ -294,8 +294,9 @@ std::optional<uint32_t> RegisterDatabase::lookupEvent(StringRef name,
   return std::nullopt;
 }
 
-uint32_t RegisterDatabase::encodeFieldValue(const BitFieldInfo &field,
-                                            uint32_t value) const {
+std::optional<uint32_t>
+RegisterDatabase::encodeFieldValue(const BitFieldInfo &field,
+                                   uint32_t value) const {
   // Validate value fits in field width
   uint32_t width = field.getWidth();
   if (width == 0)
@@ -304,13 +305,10 @@ uint32_t RegisterDatabase::encodeFieldValue(const BitFieldInfo &field,
   uint64_t maxValue = width >= 32 ? std::numeric_limits<uint32_t>::max()
                                   : ((1ULL << width) - 1ULL);
 
-  if (value > maxValue) {
-    llvm::errs() << "Warning: value " << value << " exceeds field width "
-                 << width << "\n";
-    value = static_cast<uint32_t>(value & maxValue); // Truncate
-  } else if (width < 32) {
+  if (value > maxValue)
+    return std::nullopt;
+  if (width < 32)
     value &= static_cast<uint32_t>(maxValue);
-  }
 
   // Shift to correct bit position
   uint64_t encoded = (static_cast<uint64_t>(value) << field.bit_start);

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -965,13 +965,18 @@ struct AIEDMATasksToNPUPass
       return op.emitOpError()
              << ctrlRegName
              << " Enable_Out_of_Order field does not fit in a 32-bit register";
+    std::optional<uint32_t> oooValue = tm.encodeFieldValue(*oooField, 1);
+    if (!oooValue)
+      return op.emitOpError()
+             << ctrlRegName
+             << " Enable_Out_of_Order field value does not fit in its bit "
+                "width";
 
     Location loc = op.getLoc();
     IntegerAttr colAttr = builder.getI32IntegerAttr(col);
     IntegerAttr rowAttr = builder.getI32IntegerAttr(row);
     Value addr = createConstantI32(builder, loc, ctrlAddrLocal);
-    Value val =
-        createConstantI32(builder, loc, tm.encodeFieldValue(*oooField, 1));
+    Value val = createConstantI32(builder, loc, *oooValue);
     Value mask = createConstantI32(builder, loc, *oooMask);
     NpuMaskWrite32Op::create(builder, loc, addr, val, mask, nullptr, colAttr,
                              rowAttr);

--- a/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
@@ -57,6 +57,10 @@ struct CoreResetToMaskWrite32Pattern : OpConversionPattern<CoreResetOp> {
     if (!resetMask)
       return op.emitOpError("Core_Control Reset field does not fit in a 32-bit "
                             "register");
+    std::optional<uint32_t> resetValue = tm.encodeFieldValue(*resetField, 1);
+    if (!resetValue)
+      return op.emitOpError(
+          "Core_Control Reset field value does not fit in its bit width");
 
     Location loc = op.getLoc();
     IntegerAttr colAttr = rewriter.getI32IntegerAttr(col);
@@ -73,8 +77,7 @@ struct CoreResetToMaskWrite32Pattern : OpConversionPattern<CoreResetOp> {
     // MaskWrite32. Constants are materialized in named locals so the emitted IR
     // order does not depend on unspecified C++ argument-evaluation order.
     Value assertAddr = createConstantI32(rewriter, loc, ctrlReg->offset);
-    Value assertVal =
-        createConstantI32(rewriter, loc, tm.encodeFieldValue(*resetField, 1));
+    Value assertVal = createConstantI32(rewriter, loc, *resetValue);
     Value assertMask = createConstantI32(rewriter, loc, *resetMask);
     NpuMaskWrite32Op::create(rewriter, loc, assertAddr, assertVal, assertMask,
                              nullptr, colAttr, rowAttr);

--- a/lib/Dialect/AIEX/Transforms/AIELowerDmaChannelReset.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerDmaChannelReset.cpp
@@ -224,6 +224,11 @@ struct DmaChannelResetToMaskWrite32Pattern
     if (!resetMask)
       return op.emitOpError()
              << ctrlRegName << " Reset field does not fit in a 32-bit register";
+    std::optional<uint32_t> resetValue = tm.encodeFieldValue(*resetField, 1);
+    if (!resetValue)
+      return op.emitOpError()
+             << ctrlRegName
+             << " Reset field value does not fit in its bit width";
 
     Location loc = op.getLoc();
     IntegerAttr colAttr = rewriter.getI32IntegerAttr(col);
@@ -237,8 +242,7 @@ struct DmaChannelResetToMaskWrite32Pattern
     // in named locals so the emitted IR order does not depend on unspecified
     // C++ argument-evaluation order.
     Value assertAddr = createConstantI32(rewriter, loc, ctrlAddrLocal);
-    Value assertVal =
-        createConstantI32(rewriter, loc, tm.encodeFieldValue(*resetField, 1));
+    Value assertVal = createConstantI32(rewriter, loc, *resetValue);
     Value assertMask = createConstantI32(rewriter, loc, *resetMask);
     NpuMaskWrite32Op::create(rewriter, loc, assertAddr, assertVal, assertMask,
                              nullptr, colAttr, rowAttr);

--- a/test/CppTests/register_database.cpp
+++ b/test/CppTests/register_database.cpp
@@ -202,13 +202,16 @@ void test_encode_field_value() {
     throw std::runtime_error("Failed to find Cnt0_Start_Event field");
   }
 
-  uint32_t encoded0 = db->encodeFieldValue(*cnt0Start, 0x25);
-  if (encoded0 != 0x25) {
-    std::cerr << "Expected 0x25, got 0x" << std::hex << encoded0 << std::dec
+  auto encoded0 = db->encodeFieldValue(*cnt0Start, 0x25);
+  if (!encoded0) {
+    throw std::runtime_error("Cnt0_Start_Event encoding unexpectedly failed");
+  }
+  if (*encoded0 != 0x25) {
+    std::cerr << "Expected 0x25, got 0x" << std::hex << *encoded0 << std::dec
               << "\n";
     throw std::runtime_error("Cnt0_Start_Event encoding failed");
   }
-  std::cout << "  ✓ Cnt0_Start_Event(0x25) = 0x" << std::hex << encoded0
+  std::cout << "  ✓ Cnt0_Start_Event(0x25) = 0x" << std::hex << *encoded0
             << std::dec << "\n";
 
   // Test encoding Cnt0_Stop_Event (bits 14:8)
@@ -218,13 +221,16 @@ void test_encode_field_value() {
     throw std::runtime_error("Failed to find Cnt0_Stop_Event field");
   }
 
-  uint32_t encoded1 = db->encodeFieldValue(*cnt0Stop, 0x21);
-  if (encoded1 != 0x2100) {
-    std::cerr << "Expected 0x2100, got 0x" << std::hex << encoded1 << std::dec
+  auto encoded1 = db->encodeFieldValue(*cnt0Stop, 0x21);
+  if (!encoded1) {
+    throw std::runtime_error("Cnt0_Stop_Event encoding unexpectedly failed");
+  }
+  if (*encoded1 != 0x2100) {
+    std::cerr << "Expected 0x2100, got 0x" << std::hex << *encoded1 << std::dec
               << "\n";
     throw std::runtime_error("Cnt0_Stop_Event encoding failed");
   }
-  std::cout << "  ✓ Cnt0_Stop_Event(0x21) = 0x" << std::hex << encoded1
+  std::cout << "  ✓ Cnt0_Stop_Event(0x21) = 0x" << std::hex << *encoded1
             << std::dec << "\n";
 }
 
@@ -248,13 +254,16 @@ void test_encode_single_bit_field() {
     throw std::runtime_error("Failed to find Enable field");
   }
 
-  uint32_t enableEncoded = db->encodeFieldValue(*enableField, 1);
-  if (enableEncoded != 0x1) {
-    std::cerr << "Expected 0x1, got 0x" << std::hex << enableEncoded << std::dec
-              << "\n";
+  auto enableEncoded = db->encodeFieldValue(*enableField, 1);
+  if (!enableEncoded) {
+    throw std::runtime_error("Enable encoding unexpectedly failed");
+  }
+  if (*enableEncoded != 0x1) {
+    std::cerr << "Expected 0x1, got 0x" << std::hex << *enableEncoded
+              << std::dec << "\n";
     throw std::runtime_error("Enable encoding failed");
   }
-  std::cout << "  ✓ Enable(1) = 0x" << std::hex << enableEncoded << std::dec
+  std::cout << "  ✓ Enable(1) = 0x" << std::hex << *enableEncoded << std::dec
             << "\n";
 
   // Test Reset field (bit 1)
@@ -263,14 +272,44 @@ void test_encode_single_bit_field() {
     throw std::runtime_error("Failed to find Reset field");
   }
 
-  uint32_t resetEncoded = db->encodeFieldValue(*resetField, 1);
-  if (resetEncoded != 0x2) {
-    std::cerr << "Expected 0x2, got 0x" << std::hex << resetEncoded << std::dec
+  auto resetEncoded = db->encodeFieldValue(*resetField, 1);
+  if (!resetEncoded) {
+    throw std::runtime_error("Reset encoding unexpectedly failed");
+  }
+  if (*resetEncoded != 0x2) {
+    std::cerr << "Expected 0x2, got 0x" << std::hex << *resetEncoded << std::dec
               << "\n";
     throw std::runtime_error("Reset encoding failed");
   }
-  std::cout << "  ✓ Reset(1) = 0x" << std::hex << resetEncoded << std::dec
+  std::cout << "  ✓ Reset(1) = 0x" << std::hex << *resetEncoded << std::dec
             << "\n";
+}
+
+void test_encode_field_value_overflow() {
+  std::cout << "Test: Encode Field Value Overflow\n";
+
+  auto db = RegisterDatabase::loadAIE2();
+  if (!db) {
+    throw std::runtime_error("Failed to load database");
+  }
+
+  // Core_Control's single-bit Enable field cannot hold a value above 1.
+  auto coreControl = db->lookupRegister("Core_Control", "core");
+  if (!coreControl) {
+    throw std::runtime_error("Failed to find Core_Control");
+  }
+  const BitFieldInfo *enableField = coreControl->getField("Enable");
+  if (!enableField) {
+    throw std::runtime_error("Failed to find Enable field");
+  }
+
+  auto overflowed = db->encodeFieldValue(*enableField, 2);
+  if (overflowed.has_value()) {
+    throw std::runtime_error(
+        "Expected nullopt when a value overflows its field width");
+  }
+  std::cout << "  ✓ Correctly returns nullopt when a value overflows its "
+               "field width\n";
 }
 
 int main() {
@@ -289,6 +328,7 @@ int main() {
     test_register_bit_fields();
     test_encode_field_value();
     test_encode_single_bit_field();
+    test_encode_field_value_overflow();
 
     std::cout << "\n==============================================\n";
     std::cout << "All tests passed! ✓\n";


### PR DESCRIPTION
## Description

`RegisterDatabase::encodeFieldValue` truncates an out-of-range value to the field width
and prints `llvm::errs() << "Warning: ..."`. Every one of its call sites already checks
`lookupRegister`/`getField`/`getFieldMask` for failure and reports it as a proper
diagnostic (`op.emitOpError`, `emitError` + `signalPassFailure`, or `report_fatal_error`,
whichever matches that site's local idiom). `encodeFieldValue` was the one
register-database call a caller could not fail on, so an overflow degraded silently into
a truncated register write instead of surfacing the way the others do.

It now returns `std::optional<uint32_t>`, `nullopt` on overflow, mirroring
`getFieldMask`'s existing contract. Every call site checks the result and reports through
the mechanism already used next to it for the sibling lookups: `op.emitOpError` in
`AIELowerCoreReset`/`AIELowerDmaChannelReset`/`AIEDMATasksToNPU`, `emitError` +
`signalPassFailure` in the `aie-trace-pack-reg-writes` pass, and `report_fatal_error` in
`AIEInsertTraceFlows` matching its own adjacent `lookupRegister`/`lookupEvent` checks. No
caller changes behavior on the non-overflow path. The trace-flow overflow reports name the
specific field that failed rather than always attributing it to `Start_BD_ID`.

Added `test_encode_field_value_overflow` to `test/CppTests/register_database.cpp`
(Core_Control's 1-bit `Enable` field rejects value 2) and updated the existing encode
assertions to the `optional`-returning signature.

Built `aie-opt` clean against the touched object graph and ran it by hand against every
lit test under `test/Passes/lower-core-reset/`, `test/Passes/lower-dma-channel-reset/`,
`test/dialect/AIE/trace/`, `test/dialect/AIE/combo_edge/` and `test/dialect/AIEX/trace/`
(34 files) — all pass unmodified, since none exercise the overflow branch. Compiled and
ran `register_database` standalone against `libMLIRAIEUtil` (this box has no
Vitis/python-bindings toolchain to build the `test/CppTests` CMake target, which is gated
on `AIE_ENABLE_BINDINGS_PYTHON`): 12/12 assertions pass, including the new overflow case.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (no Python touched)
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (files not on the enabled list)
