### PR TITLE
ci: persist ccache across buildAndTestRyzenAISw.yml runs [MED]

### DIFF
--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -65,6 +65,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: "true"
+
+      # The build runs inside a docker container (below), so this only
+      # primes a host-side cache dir. It is bind-mounted into the container
+      # with the same path and handed to ccache there via CCACHE_DIR, so the
+      # container's compiler invocations land in the same cache the
+      # actions/cache post-step later saves.
+      - uses: ./.github/actions/setup_ccache
+        id: setup_ccache
+        with:
+          MATRIX_OS: ${{ matrix.ubuntu_version }}
+          MATRIX_ARCH: x86
+          EXTRA_KEY: ryzenai-sw
+
       - uses: uraimo/run-on-arch-action@fd7aa8593480287702b446a273a68f788a9bad3a  # v3
         name: Build and Test
         id: runcmd
@@ -74,8 +87,10 @@ jobs:
           githubToken: ${{ github.token }}
           dockerRunArgs: |
             --mac-address 02:42:ac:11:00:02
+            -v ${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}:${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}
           env: |
             XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
+            CCACHE_DIR: ${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}
           run: |
 
             MLIR_DIR=$PWD
@@ -148,7 +163,13 @@ jobs:
                 -DCMAKE_MODULE_PATH=$MLIR_DIR/cmake/modulesXilinx \
                 -DMLIR_DIR=/workspace/mlir/lib/cmake/mlir
 
+            # See https://github.com/hendrikmuhs/ccache-action/issues/146:
+            # compare by content, not mtime, since the checkout the compiler
+            # invocations run against is fresh every job.
+            ccache --set-config=compiler_check=content
+            ccache -s
             ninja install
+            ccache -s
             # filter out slow tests (e.g. create-flows/vecmul_4x4_slow_test.mlir) due to timeout.
             export LIT_OPTS="-j1 -sv --timeout 600 --filter-out slow_test"
             ninja check-aie


### PR DESCRIPTION
## Problem

`buildAndTestRyzenAISw.yml` ("Build and Test with Ryzen AI Software") is the largest single
required check in the PR gate: 32m14s (ubuntu24) / 29m13s (ubuntu22) in a sampled run. It sets
`CMAKE_CXX_COMPILER_LAUNCHER=ccache`, and cmake confirms ccache is found ("Using ccache with
precompiled headers with non-Clang compilers is not [supported]"), but the launcher does nothing
across runs: the build happens inside a fresh `run-on-arch-action` docker container every time,
with no cache mount and no `actions/cache` step, so `CCACHE_DIR` resolves to an ephemeral path
that is discarded with the container. Timestamped log for a recent green run: cmake configure
finishes at 02:45:06, the last link step at 02:54:58, i.e. ~9m52s of cold C++ compilation of
~1173 ninja targets, every single run, regardless of whether the PR touched any C++ source.

## Fix

Reuse this repo's own `.github/actions/setup_ccache` composite (already used by
`buildAndTestMulti.yml`, `buildAndTestPythons.yml`, `generateDocs.yml`, `mlirAIEDistro.yml`) to
restore/save a host-side ccache directory via `actions/cache`, keyed per `ubuntu_version`. Bind
mount that same host path into the container (`dockerRunArgs: -v host:host`, which
`run-on-arch-action` runs on `docker run --workdir $GITHUB_WORKSPACE -v $GITHUB_WORKSPACE:...`
already documents as its supported way to add volumes) and point the container's `CCACHE_DIR` at
it via the action's `env:` passthrough. `compiler_check=content` matches the setting other
ccache users in this repo already need for the same reason: the checkout the compiler runs
against is fresh every job, so mtime is not a valid signal.

## Test

`yaml.safe_load` on the changed file. `actionlint` (GOMAXPROCS=1, run twice for determinism)
introduces zero new findings; the one finding on the touched lines ("Setup ccache" action missing
a `description`) reproduces identically on unmodified `upstream/main` via the composite's other
callers.

## Known limitations

Not verified against a real run: whether the container (likely root) writing into the
bind-mounted, `runner`-owned host cache directory leaves files the `actions/cache` post-step can
still read back. The `ccache` step in the composite already sets `continue-on-error: true`, so
the failure mode if this doesn't work is zero cache benefit, not a broken build. Actual hit rate
and time saved need a real CI run to measure; this PR does not claim a number.
