### PR TITLE
ci: drop assigned from pull_request types, matching every other workflow [LOW]

### DIFF
--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   merge_group:
   schedule:

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   merge_group:
   schedule:

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -16,7 +16,7 @@ concurrency:
 
 on:
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   merge_group:
   schedule:


### PR DESCRIPTION
## Problem

`buildAndTestMulti.yml`, `buildAndTestPythons.yml`, and `lintAndFormat.yml` trigger on
`pull_request: types: [assigned, opened, synchronize, reopened]`. Every other `pull_request`-triggered
workflow in the repo (`buildAndTestHrxXclbinutil.yml`, `buildAndTestRyzenAI.yml`,
`buildAndTestRyzenAIWindows.yml`, `dependabot-sync-locks.yml`) omits `assigned`. Assigning someone to a
PR re-runs full CI for no code change.

A same-SHA duplicate-run search over the last 1000 runs (10 workflows x 100) found exactly one
duplicate pair, and it was `dependabot-sync-locks` + `buildRyzenWheels`, not these three, so this
isn't costing wall-clock today. It's a latent footgun on the three workflows most likely to be
assignee-heavy (multi-platform build, Python matrix, lint), not a throughput fix.

## Fix

Drop `assigned` from the `types:` list in all three files, matching the other workflows' list
exactly (`[opened, synchronize, reopened]`).

## Test

`yaml.safe_load` on all three files. `actionlint` (GOMAXPROCS=1) on all three: one pre-existing
finding (`Setup ccache` action missing a `description`), reproduced identically on unmodified
upstream/main, unrelated to this diff.
