### PR TITLE
aie_kernels: zero.cc include <aie_api/aie.hpp> directly [LOW]

### DIFF
--- a/aie_kernels/aie2/zero.cc
+++ b/aie_kernels/aie2/zero.cc
@@ -8,6 +8,7 @@
 #ifndef ZERO_CC
 #define ZERO_CC
 
+#include <aie_api/aie.hpp>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/aie_kernels/aie2/zero.cc
+++ b/aie_kernels/aie2/zero.cc
@@ -5,8 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ZERO_CC
-#define ZERO_CC
+#ifndef AIE_KERNELS_AIE2_ZERO_CC
+#define AIE_KERNELS_AIE2_ZERO_CC
 
 #include <aie_api/aie.hpp>
 #include <stdint.h>

--- a/aie_kernels/aie2p/zero.cc
+++ b/aie_kernels/aie2p/zero.cc
@@ -8,6 +8,7 @@
 #ifndef ZERO_CC
 #define ZERO_CC
 
+#include <aie_api/aie.hpp>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/aie_kernels/aie2p/zero.cc
+++ b/aie_kernels/aie2p/zero.cc
@@ -5,8 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ZERO_CC
-#define ZERO_CC
+#ifndef AIE_KERNELS_AIE2P_ZERO_CC
+#define AIE_KERNELS_AIE2P_ZERO_CC
 
 #include <aie_api/aie.hpp>
 #include <stdint.h>


### PR DESCRIPTION

## Problem

`aie_kernels/aie2/zero.cc` and `aie_kernels/aie2p/zero.cc` use `aie::vector`, `aie::zeros`, and
`aie::store_v` but never include `<aie_api/aie.hpp>`. Both are header-guarded (`#ifndef ZERO_CC`) and
today compile only because every current includer (`aie2p/mm.cc`, `aie2/mm.cc`, `aie2/mv.cc`,
`aie2/cascade_mm.cc`) happens to include `aie_api/aie.hpp` first. Include either file first in a TU,
or from a new file that doesn't already pull in `aie.hpp`, and it fails with `use of undeclared
identifier 'aie'`.

## Fix

Add `#include <aie_api/aie.hpp>` to both files, ahead of the existing includes, alphabetically
ordered the same way `gelu.cc` and `relu.cc` in the same directories already do it.

## Test/Evidence

Not built against a Peano/mlir-aie instance, so the real aie2/aie2p target compile and lit suite
have not been run. Isolated the specific claim with host clang++ 22.1.8 against
the vendored `aie_api` headers instead: a standalone TU that `#include`s only `zero.cc` (no prior
`aie.hpp` include) fails on unpatched upstream with `use of undeclared identifier 'aie'` at the
`aie::vector` line; the same TU against the patched file resolves the `aie` namespace. Both patched
files are clean under `clang-format --style=file` at `20.1.0` (this repo's current
`formatting`/`Check code format` CI pin, `.github/workflows/lintAndFormat.yml`).
