### PR TITLE
[python] ParameterScratchpad: take the buffer length and check it [HIGH]

### DIFF
--- a/python/ParameterScratchpadModule.cpp
+++ b/python/ParameterScratchpadModule.cpp
@@ -25,7 +25,9 @@ PYBIND11_MODULE(_parameter_scratchpad, m) {
              if (info.itemsize * info.size < 4)
                throw py::value_error("buffer too small: need at least 4 bytes");
              auto *ptr = static_cast<uint32_t *>(info.ptr);
-             return new test_utils::ParameterScratchpad(ptr, paramsPath);
+             return new test_utils::ParameterScratchpad(
+                 ptr, static_cast<size_t>(info.itemsize) * info.size,
+                 paramsPath);
            }),
            py::arg("buffer"), py::arg("params_path"),
            py::keep_alive<1, 2>()) // prevent GC of buffer while alive

--- a/runtime_lib/test_lib/parameter_scratchpad.h
+++ b/runtime_lib/test_lib/parameter_scratchpad.h
@@ -61,10 +61,19 @@ public:
   }
 #endif
 
-  /// Construct from a raw buffer pointer (Python bindings / testing).
-  ParameterScratchpad(uint32_t *buffer, const std::string &paramsPath)
+  /// Construct from a raw buffer and its size in bytes (Python bindings /
+  /// testing). The size is required: clear() and every write index off
+  /// scratchpadSizeBytes, which parseParams derives from the params file, not
+  /// from the buffer.
+  ParameterScratchpad(uint32_t *buffer, size_t bufferSizeBytes,
+                      const std::string &paramsPath)
       : boMap(buffer) {
     parseParams(paramsPath);
+    if (bufferSizeBytes < scratchpadSizeBytes)
+      throw std::runtime_error("ParameterScratchpad: buffer size (" +
+                               std::to_string(bufferSizeBytes) +
+                               ") < required scratchpad size (" +
+                               std::to_string(scratchpadSizeBytes) + ")");
     clear();
   }
 


### PR DESCRIPTION
## Problem

`ParameterScratchpad` has two constructors and only one of them checks the buffer.

The XRT constructor rejects a BO smaller than the parameter set needs:

```cpp
if (scratchpadBo.size() < scratchpadSizeBytes)
  throw std::runtime_error(...);
```

The raw-buffer constructor takes a bare `uint32_t*` with no length and checks nothing. That is the
one the Python binding uses, and `ParameterScratchpadModule.cpp` validates only 4-byte alignment and
a 4-byte minimum, so the caller's actual buffer length never reaches the class.

`scratchpadSizeBytes` comes from `parseParams` (`4 * numParams` in the params file), not from the
buffer, and `clear()` zeroes that many words unconditionally. So a numpy view declaring one `uint32`
against a four-parameter `params.txt` constructs cleanly and writes three words past its end, and
later `write()` calls land there too.

## Fix

Give the raw-buffer constructor a `bufferSizeBytes` parameter and reuse the XRT path's check; pass
`info.itemsize * info.size` from the binding.

The length is required rather than defaulted, so an out-of-tree caller of the two-argument form gets
a compile error instead of silently keeping the unchecked behaviour.

## Test / Evidence

Standalone probe against the header, one declared word with a four-parameter params file, canaries
after the declared end:

```
before: constructed WITHOUT error
        canary words past the declared end that were overwritten: 3
after:  threw: ParameterScratchpad: buffer size (4) < required scratchpad size (16)
        canary words past the declared end that were overwritten: 0
```

## Known limitations

No device-free test target exists for `runtime_lib/test_lib`, so this carries no lit test; the
existing scratchpad tests are `npu-xrt` device tests. Happy to add one if you would like a home for
it.
