### PR TITLE
Build test_lib without Vitis, and fix the XRT_FOUND dereference [HIGH]

### DIFF
--- a/runtime_lib/CMakeLists.txt
+++ b/runtime_lib/CMakeLists.txt
@@ -106,6 +106,9 @@ foreach(target ${AIE_RUNTIME_TARGETS})
   set(enableTestLibProject OFF)
   if (DEFINED VITIS_ROOT OR DEFINED LibXAIE_${target}_DIR)
     set(enableTestLibProject ON)
+  elseif (NOT WIN32 AND TARGET xaiengine_${target})
+    # test_lib's dependency is xaiengine, not Vitis.
+    set(enableTestLibProject ON)
   elseif (WIN32 AND ${target} STREQUAL "x86_64" AND NOT DEFINED LibXAIE_${target}_DIR AND LibXAIE_FOUND)
     set(enableTestLibProject ON)
   endif()
@@ -118,6 +121,10 @@ foreach(target ${AIE_RUNTIME_TARGETS})
       BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${target}/test_lib/lib
       CMAKE_CACHE_ARGS
           -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
+          # test_lib's find_package(XRT) is optional, but a broken system XRT
+          # package raises FATAL_ERROR from inside its own config file, which
+          # QUIET does not suppress.
+          -DCMAKE_DISABLE_FIND_PACKAGE_XRT:BOOL=${CMAKE_DISABLE_FIND_PACKAGE_XRT}
       CMAKE_ARGS
           -DCMAKE_TOOLCHAIN_FILE=${${target}_TOOLCHAIN_FILE}
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -48,7 +48,7 @@ if (BUILD_TEST_UTILS_LIBRARY)
   # XRT headers on Windows pull in boost/any.hpp which is not typically
   # available.  Skip XRT integration there; the core helpers (load_instr_*,
   # nearly_equal, etc.) are still usable without it.
-  if (${XRT_FOUND} AND NOT WIN32)
+  if (XRT_FOUND AND NOT WIN32)
     target_compile_options(test_utils PRIVATE -DTEST_UTILS_USE_XRT)
     target_include_directories(test_utils PRIVATE ${XRT_INCLUDE_DIR})
   endif()


### PR DESCRIPTION
## Problem

Two things stop `test_lib` from building without Vitis.

`runtime_lib/CMakeLists.txt` gates the whole subproject on Vitis:

```cmake
if (DEFINED VITIS_ROOT OR DEFINED LibXAIE_${target}_DIR)
  set(enableTestLibProject ON)
```

`test_lib` links `xaiengine`, not Vitis, so a build that has `xaiengine` but no Vitis gets no
`test_lib` at all.

Turn it on and the configure fails, because `find_package(XRT QUIET)` leaves `XRT_FOUND`
undefined rather than false, and line 51 dereferences it:

```cmake
if (${XRT_FOUND} AND NOT WIN32)
```

```
CMake Error at CMakeLists.txt:5 (if):
  if given arguments:
    "AND" "NOT" "WIN32"
  Unknown arguments specified
```

The two are linked: the deref is only reachable once the subproject builds without Vitis, which
is why they are in one change.

Separately, `find_package(XRT QUIET)` is not reliably quiet. A broken system XRT package raises
`FATAL_ERROR` from inside its own config file, which `QUIET` does not suppress, and the nested
project does not inherit the parent's `CMAKE_DISABLE_FIND_PACKAGE_XRT`:

```
CMake Error at /usr/share/cmake/XRT/xrt-config.cmake:58 (include):
  * The installation package was faulty and contained
     "/usr/share/cmake/XRT/xrt-targets.cmake"
    but not all the files it references.
```

## Fix

Enable `test_lib` when the target's `xaiengine` exists, dereference `XRT_FOUND` as a condition
rather than by expansion, and pass `CMAKE_DISABLE_FIND_PACKAGE_XRT` through to the
ExternalProject.

## Test / Evidence

Configured the same tree twice on a Vitis-free machine, identical flags
(`-DAIE_RUNTIME_TARGETS=x86_64 -DCMAKE_DISABLE_FIND_PACKAGE_XRT=ON`), and counted the test_lib
targets ninja knows about:

```
before:  0
after:   4
```

With the change, `ninja test_lib_x86_64` builds and installs `libtest_utils.a`,
`libtest_lib.a`, `libmemory_allocator_ion.a` and `libmemory_allocator_sim_aie.a`.

That configure only reaches test_lib's `if` at all because `CMAKE_DISABLE_FIND_PACKAGE_XRT` is
now passed down, and it only survives it because of the `XRT_FOUND` change: with the variable
unset, `if (${XRT_FOUND} AND NOT WIN32)` is a hard error, while `if (XRT_FOUND AND NOT WIN32)`
is false. The `xrt-config.cmake` FATAL_ERROR quoted above is from this machine, which carries
such a package.
