### PR TITLE
[python] JIT cache: include -I paths in the cache key [HIGH]

### DIFF
--- a/python/utils/compile/jit/_hash.py
+++ b/python/utils/compile/jit/_hash.py
@@ -115,6 +115,7 @@ def _compute_recipe_hash(
     aiecc_flags: list[str] | tuple[str, ...],
     compile_flags: list[str] | tuple[str, ...],
     full_elf: bool = False,
+    include_paths: list[Path] | tuple[Path, ...] = (),
 ) -> str:
     """Hash of the "recipe": generator bytecode + CompileTime[T] kwargs + flags.
 
@@ -125,6 +126,12 @@ def _compute_recipe_hash(
     ``full_elf`` is part of the recipe: full-ELF and xclbin+insts builds emit
     different MLIR (the former injects ``npu.load_pdi``) and different
     artifacts, so they must not share a cache entry.
+
+    ``include_paths`` likewise: they are ``-I`` directories forwarded to the
+    C++ compiler, so two otherwise identical designs pointed at different
+    header trees compile to different objects. Hashed in ORDER, not sorted
+    like the flag lists above, because ``-I`` search order decides which
+    header wins when two directories provide the same name.
     """
     h = hashlib.sha256()
 
@@ -169,6 +176,7 @@ def _compute_recipe_hash(
     h.update(repr(sorted(aiecc_flags)).encode())
     h.update(repr(sorted(compile_flags)).encode())
     h.update(f"full_elf={full_elf}".encode())
+    h.update(repr([str(p) for p in include_paths]).encode())
 
     return h.hexdigest()
 
@@ -280,10 +288,11 @@ def _compute_hash(
     compile_flags: list[str] | tuple[str, ...],
     full_elf: bool = False,
     fold_ddr_addr_offset: bool = True,
+    include_paths: list[Path] | tuple[Path, ...] = (),
 ) -> str:
     """Stable 24-hex SHA-256 cache key combining recipe + artifact hashes."""
     recipe = _compute_recipe_hash(
-        generator, compile_kwargs, aiecc_flags, compile_flags, full_elf
+        generator, compile_kwargs, aiecc_flags, compile_flags, full_elf, include_paths
     )
     artifact = _compute_artifact_hash(
         generator, source_files, object_files, fold_ddr_addr_offset

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -851,6 +851,7 @@ class CompilableDesign:
             self.aiecc_flags,
             self.compile_flags,
             self.full_elf,
+            self.include_paths,
         )
 
     @staticmethod
@@ -890,6 +891,7 @@ class CompilableDesign:
             self.compile_flags,
             self.full_elf,
             self._resolve_fold_ddr_addr_offset(),
+            self.include_paths,
         )
 
     def _bind_generation_device(self):

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -243,6 +243,22 @@ def test_hash_differs_for_different_compile_flags():
     assert hash(d1) != hash(d2)
 
 
+def test_hash_differs_for_different_include_paths():
+    """-I directories change which headers the C++ kernel compiles against."""
+    gen = _gemm_gen()
+    d1 = CompilableDesign(gen, include_paths=["/a/include"])
+    d2 = CompilableDesign(gen, include_paths=["/b/include"])
+    assert hash(d1) != hash(d2)
+
+
+def test_hash_differs_for_include_path_order():
+    """-I search order decides which header wins, so it is not order-free."""
+    gen = _gemm_gen()
+    d1 = CompilableDesign(gen, include_paths=["/a/include", "/b/include"])
+    d2 = CompilableDesign(gen, include_paths=["/b/include", "/a/include"])
+    assert hash(d1) != hash(d2)
+
+
 def test_hash_differs_for_different_generators():
     # Use meaningfully different bodies so that co_code differs.
     def gen_a(*, M: CompileTime[int]):


### PR DESCRIPTION
## Problem

`include_paths` is accepted by `compileconfig()`, stored on `CompilableDesign`, documented as
*"Extra `-I` paths forwarded to the C++ compiler"*, and round-tripped through `to_dict`/`from_dict`.
It reaches neither `_compute_recipe_hash` nor `_compute_artifact_hash`.

So two designs that differ only in which header tree their C++ kernels compile against produce the
same cache key and share a cache entry. The second build returns the first one's artifact.

`_compute_artifact_hash`'s own docstring states the invariant this breaks:

> Captures everything that can change the *output* of compilation without changing the *recipe*:
> edited C++ kernels, swapped object files, upgraded Peano / aiecc, retargeted device.

Include paths change the output and were captured by neither hash.

## Fix

Thread `include_paths` into `_compute_recipe_hash`, alongside the flag lists it belongs with, and
through `_compute_hash` -- the combiner that `__hash__` actually calls via `_compute_cache_hash`.
Adding it only to the `recipe_hash` property leaves the real cache key untouched, which is worth
noting because that is the obvious half-fix.

Hashed in order rather than `sorted()` like the adjacent `aiecc_flags`/`compile_flags`: `-I` search
order decides which header wins when two directories provide the same name, so the order is part of
the meaning.

## Test

Two unit tests in `test/python/test_compilabledesign.py` (device-free, next to the existing
`test_hash_differs_for_different_compile_flags`): one for differing paths, one for differing order.

Both fail against the unmodified files and pass with this change; the file's other 97 tests are
unaffected. `black --check` clean on all three files.

## Scope

This closes the key gap only. The adjacent risk -- a header shadowed by an `-I` reorder changing what
a *fixed* path resolves to -- is content-level and already noted as a known limitation in
`_manifest.py`'s docstring; this change does not address that, and hashing in order rather than
sorted is what keeps the door open to it.
