### PR TITLE
test: let the Peano lanes run without Chess [LOW]

### DIFF
--- a/test/aiecc/generate_pdi.mlir
+++ b/test/aiecc/generate_pdi.mlir
@@ -5,27 +5,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: chess
 // REQUIRES: peano
 
-// Give each run private output/work dirs: Chess drops scratch and aiecc emits
-// per-core dirs into the output dir, so concurrent runs sharing a directory (as
-// the lit suite does) would clobber each other. The PDIs land in %t; the final
-// ls checks both are there.
-// RUN: %aiecc -v --xchesscc --xbridge --get-pdi --pdi-name=MlirAie0.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=XCHESSCC
-// RUN: %aiecc -v --get-pdi --pdi-name=MlirAie1.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=PEANO
+// Private output/work dirs: aiecc emits per-core dirs into the output dir, so
+// concurrent runs sharing one would clobber each other.
+// RUN: %aiecc -v --get-pdi --pdi-name=MlirAie0.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=PEANO
 
 // RUN: ls %t | grep MlirAie | FileCheck %s --check-prefix=CHECK-FILE
 
 // bootgen runs in-process (no exec line); the PDI edge is reported as written.
-// XCHESSCC: wrote edge 'MlirAie0.pdi'
-// XCHESSCC-NOT: xclbinutil
-
-// PEANO: wrote edge 'MlirAie1.pdi'
+// PEANO: wrote edge 'MlirAie0.pdi'
 // PEANO-NOT: xclbinutil
 
 // CHECK-FILE: MlirAie0.pdi
-// CHECK-FILE: MlirAie1.pdi
 
 module {
   aie.device(npu1) {

--- a/test/aiecc/generate_pdi_chess.mlir
+++ b/test/aiecc/generate_pdi_chess.mlir
@@ -1,0 +1,41 @@
+//===- generate_pdi_chess.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: chess
+// REQUIRES: peano
+
+// Give each run private output/work dirs: Chess drops scratch and aiecc emits
+// per-core dirs into the output dir, so concurrent runs sharing a directory (as
+// the lit suite does) would clobber each other. The PDIs land in %t; the final
+// ls checks both are there.
+// RUN: %aiecc -v --xchesscc --xbridge --get-pdi --pdi-name=MlirAie0.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %aiecc -v --get-pdi --pdi-name=MlirAie1.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=PEANO
+
+// RUN: ls %t | grep MlirAie | FileCheck %s --check-prefix=CHECK-FILE
+
+// bootgen runs in-process (no exec line); the PDI edge is reported as written.
+// XCHESSCC: wrote edge 'MlirAie0.pdi'
+// XCHESSCC-NOT: xclbinutil
+
+// PEANO: wrote edge 'MlirAie1.pdi'
+// PEANO-NOT: xclbinutil
+
+// CHECK-FILE: MlirAie0.pdi
+// CHECK-FILE: MlirAie1.pdi
+
+module {
+  aie.device(npu1) {
+  %12 = aie.tile(1, 2)
+  %buf = aie.buffer(%12) : memref<256xi32>
+  %4 = aie.core(%12)  {
+    %0 = arith.constant 0 : i32
+    %1 = arith.constant 0 : index
+    memref.store %0, %buf[%1] : memref<256xi32>
+    aie.end
+  }
+  }
+}

--- a/test/aiecc/generate_pdi_chess.mlir
+++ b/test/aiecc/generate_pdi_chess.mlir
@@ -8,10 +8,10 @@
 // REQUIRES: chess
 // REQUIRES: peano
 
-// Give each run private output/work dirs: Chess drops scratch and aiecc emits
-// per-core dirs into the output dir, so concurrent runs sharing a directory (as
-// the lit suite does) would clobber each other. The PDIs land in %t; the final
-// ls checks both are there.
+// Private output/work dirs for this test: Chess drops scratch and aiecc emits
+// per-core dirs into the output dir, so concurrent tests sharing a directory
+// (as the lit suite does) would clobber each other. Both runs below land their
+// PDI in this test's own %t; the final ls checks both are there.
 // RUN: %aiecc -v --xchesscc --xbridge --get-pdi --pdi-name=MlirAie0.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 // RUN: %aiecc -v --get-pdi --pdi-name=MlirAie1.pdi --output-dir=%t --tmpdir=%t.prj %s 2>&1 | FileCheck %s --check-prefix=PEANO
 

--- a/test/aiecc/simple.mlir
+++ b/test/aiecc/simple.mlir
@@ -8,13 +8,13 @@
 
 // REQUIRES: peano
 
-// RUN: %aiecc --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
+// RUN: %aiecc --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
 // The NOCOMPILE runs assert that no core compiler is invoked; they request
 // input_with_addresses so the driver still produces (compiler-free) output for
 // FileCheck to scan instead of an empty graph.
-// RUN: %aiecc --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
-// RUN: %aiecc --no-unified --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
-// RUN: %aiecc --no-unified --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %aiecc --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %aiecc --no-unified --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
+// RUN: %aiecc --no-unified --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
 
 // Note that llc determines the architecture from the llvm IR.
 

--- a/test/aiecc/simple.mlir
+++ b/test/aiecc/simple.mlir
@@ -6,10 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: chess
 // REQUIRES: peano
 
-// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 // RUN: %aiecc --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
 // The NOCOMPILE runs assert that no core compiler is invoked; they request
 // input_with_addresses so the driver still produces (compiler-free) output for
@@ -20,9 +18,6 @@
 
 // Note that llc determines the architecture from the llvm IR.
 
-// XCHESSCC-NOT: {{[^ ]*llc }}
-// XCHESSCC: xchesscc_wrapper aie
-// XCHESSCC-NOT: {{[^ ]*llc }}
 // PEANO-NOT: xchesscc_wrapper
 // PEANO: {{[^ ]*llc }}
 // PEANO-SAME: --march=aie

--- a/test/aiecc/simple_aie2.mlir
+++ b/test/aiecc/simple_aie2.mlir
@@ -6,10 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: chess
 // REQUIRES: peano
 
-// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 // RUN: %aiecc --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
 // The NOCOMPILE runs assert that no core compiler is invoked; they request
 // input_with_addresses so the driver still produces (compiler-free) output for
@@ -19,9 +17,6 @@
 // RUN: %aiecc --no-unified --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
 
 // Note that llc determines the architecture from the llvm IR.
-// XCHESSCC-NOT: {{[^ ]*llc }}
-// XCHESSCC: xchesscc_wrapper aie2
-// XCHESSCC-NOT: {{[^ ]*llc }}
 // PEANO-NOT: xchesscc_wrapper
 // PEANO: {{[^ ]*llc }}
 // PEANO-SAME: --march=aie2

--- a/test/aiecc/simple_aie2.mlir
+++ b/test/aiecc/simple_aie2.mlir
@@ -8,13 +8,13 @@
 
 // REQUIRES: peano
 
-// RUN: %aiecc --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
+// RUN: %aiecc --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple_aie2.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
 // The NOCOMPILE runs assert that no core compiler is invoked; they request
 // input_with_addresses so the driver still produces (compiler-free) output for
 // FileCheck to scan instead of an empty graph.
-// RUN: %aiecc --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
-// RUN: %aiecc --no-unified --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
-// RUN: %aiecc --no-unified --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %aiecc --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple_aie2.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %aiecc --no-unified --get-core-elfs -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple_aie2.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=PEANO
+// RUN: %aiecc --no-unified --get-input-with-addresses -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple_aie2.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=NOCOMPILE
 
 // Note that llc determines the architecture from the llvm IR.
 // PEANO-NOT: xchesscc_wrapper

--- a/test/aiecc/simple_aie2_chess.mlir
+++ b/test/aiecc/simple_aie2_chess.mlir
@@ -1,0 +1,29 @@
+//===- simple_aie2_chess.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022 Xilinx, Inc.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: chess
+
+// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
+
+// Note that llc determines the architecture from the llvm IR.
+// XCHESSCC-NOT: {{[^ ]*llc }}
+// XCHESSCC: xchesscc_wrapper aie2
+// XCHESSCC-NOT: {{[^ ]*llc }}
+
+module {
+  aie.device(xcve2302) {
+  %12 = aie.tile(1, 2)
+  %buf = aie.buffer(%12) : memref<256xi32>
+  %4 = aie.core(%12)  {
+    %0 = arith.constant 0 : i32
+    %1 = arith.constant 0 : index
+    memref.store %0, %buf[%1] : memref<256xi32>
+    aie.end
+  }
+  }
+}

--- a/test/aiecc/simple_aie2_chess.mlir
+++ b/test/aiecc/simple_aie2_chess.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: chess
 
-// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple_aie2_chess.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 
 // Note that llc determines the architecture from the llvm IR.
 // XCHESSCC-NOT: {{[^ ]*llc }}

--- a/test/aiecc/simple_chess.mlir
+++ b/test/aiecc/simple_chess.mlir
@@ -1,0 +1,30 @@
+//===- simple_chess.mlir ---------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022 Xilinx, Inc.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: chess
+
+// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
+
+// Note that llc determines the architecture from the llvm IR.
+
+// XCHESSCC-NOT: {{[^ ]*llc }}
+// XCHESSCC: xchesscc_wrapper aie
+// XCHESSCC-NOT: {{[^ ]*llc }}
+
+module {
+  aie.device(xcvc1902) {
+    %12 = aie.tile(1, 2)
+    %buf = aie.buffer(%12) : memref<256xi32>
+    %4 = aie.core(%12)  {
+      %0 = arith.constant 0 : i32
+      %1 = arith.constant 0 : index
+      memref.store %0, %buf[%1] : memref<256xi32>
+      aie.end
+    }
+  }
+}

--- a/test/aiecc/simple_chess.mlir
+++ b/test/aiecc/simple_chess.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: chess
 
-// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o test.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %aiecc --get-core-elfs --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib -o simple_chess.elf -- %S/test.cpp 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 
 // Note that llc determines the architecture from the llvm IR.
 

--- a/test/aiecc/simple_xclbin_chess.mlir
+++ b/test/aiecc/simple_xclbin_chess.mlir
@@ -1,4 +1,4 @@
-//===- simple.mlir ---------------------------------------------*- MLIR -*-===//
+//===- simple_xclbin_chess.mlir --------------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2022 Xilinx, Inc.
 // Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
@@ -6,17 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: peano
+// REQUIRES: chess
 
-// RUN: %aiecc -nv --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s 2>&1 | FileCheck %s --check-prefix=PEANO
+// RUN: %aiecc --xchesscc -nv --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 
 // Note that llc determines the architecture from the llvm IR.
 // bootgen runs in-process (no exec line); the xclbin packaging step (xclbinutil)
 // is still an external tool.
-// PEANO-NOT: xchesscc_wrapper
-// PEANO: {{[^ ]*llc }}
-// PEANO-SAME: --march=aie2
-// PEANO: xclbinutil
+// XCHESSCC-NOT: {{[^ ]*llc }}
+// XCHESSCC: xchesscc_wrapper aie2
+// XCHESSCC: xclbinutil
+// XCHESSCC-NOT: {{[^ ]*llc }}
 
 module {
   aie.device(npu1) {

--- a/test/aiecc/simple_xclbin_chess.mlir
+++ b/test/aiecc/simple_xclbin_chess.mlir
@@ -8,7 +8,7 @@
 
 // REQUIRES: chess
 
-// RUN: %aiecc --xchesscc -nv --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s 2>&1 | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %aiecc --xchesscc -nv --get-xclbin --get-npu-insts --xclbin-name=aie_chess.xclbin --npu-insts-name=insts_chess.txt %s 2>&1 | FileCheck %s --check-prefix=XCHESSCC
 
 // Note that llc determines the architecture from the llvm IR.
 // bootgen runs in-process (no exec line); the xclbin packaging step (xclbinutil)


### PR DESCRIPTION
## Problem

`test/aiecc/{simple,simple_aie2,simple_xclbin,generate_pdi}.mlir` each carry a file-level `REQUIRES: chess` over RUN lines that are pure Peano lanes with their own FileCheck prefix. Two `REQUIRES:` lines are ANDed, so all four are skipped wherever Chess is absent -- including `buildAndTestRyzenAIWindows.yml`, which is Peano-only by design and runs the lit suite on every pull request. Eleven Peano RUN lines never execute there.

## Fix

Split each into the Peano file and a `_chess` sibling, the shape `test/generate-mmap/allocation_error{,_chess}.mlir` already uses.

`generate_pdi_chess.mlir` keeps both backends in one `%t` and its `ls %t | grep MlirAie` check over `MlirAie0.pdi` and `MlirAie1.pdi`, so the assertion that the two backends do not clobber each other's scratch is unchanged; it keeps `REQUIRES: chess` and `REQUIRES: peano` for that reason. The new `generate_pdi.mlir` is the Peano lane alone.

## Test

`lit test/aiecc` with Peano and no Vitis:

| | discovered | passed | unsupported | failed |
|---|---|---|---|---|
| before | 75 | 58 | 10 | 7 |
| after | 79 | 62 | 10 | 7 |

Same seven pre-existing failures (`aiebu-asm` absent). The four new passes are the Peano lanes; the four `_chess` files are unsupported here, exactly as the un-split files were.
