### PR TITLE
[python] Move ceildiv into helpers.util, where its callers live [HIGH]

### DIFF
--- a/python/helpers/taplib/tensortiler2d.py
+++ b/python/helpers/taplib/tensortiler2d.py
@@ -6,8 +6,8 @@ from functools import partial
 from typing import Sequence
 
 import numpy as np
-from aie.utils.tensor_factory import ceildiv
 
+from ..util import ceildiv
 from .tas import TensorAccessSequence
 from .utils import validate_and_clean_sizes_strides, validate_tensor_dims
 

--- a/python/helpers/taplib/visualization2d.py
+++ b/python/helpers/taplib/visualization2d.py
@@ -8,7 +8,8 @@ import matplotlib.animation as animation
 import matplotlib.patheffects as pe
 import matplotlib.pyplot as plt
 import numpy as np
-from aie.utils.tensor_factory import ceildiv
+
+from ..util import ceildiv
 
 
 def animate_from_accesses(

--- a/python/helpers/util.py
+++ b/python/helpers/util.py
@@ -198,6 +198,11 @@ def memref_type_to_np_dtype(memref_type):
     return _memref_type_to_np_dtype.get(memref_type)
 
 
+def ceildiv(a, b):
+    """Ceiling division: smallest integer >= a/b."""
+    return -(a // -b)
+
+
 def np_ndarray_type_get_shape(ndarray_type: type[np.ndarray]) -> tuple[int, ...]:
     shape = get_args(ndarray_type)[0]
     assert isinstance(shape, tuple), "np.ndarray shape must be a tuple of integers"

--- a/python/utils/tensor_factory.py
+++ b/python/utils/tensor_factory.py
@@ -17,6 +17,7 @@ import os
 
 import numpy as np
 
+from ..helpers.util import ceildiv as ceildiv
 from .hostruntime.tensor_class import NpuTensor
 
 _logger = logging.getLogger(__name__)
@@ -168,11 +169,6 @@ def npu_runtime_folds_ddr_addr_offset() -> bool:
     attribute, so the JIT cache and the compiler always agree on the ABI.
     """
     return DEFAULT_TENSOR_CLASS.FOLDS_DDR_ADDR_OFFSET
-
-
-def ceildiv(a, b):
-    """Ceiling division: smallest integer >= a/b."""
-    return -(a // -b)
 
 
 def tensor(*args, **kwargs):


### PR DESCRIPTION
### Problem

`python/helpers/taplib` imports `ceildiv` from `aie.utils.tensor_factory`. That is the
only `python/helpers` -> `python/utils` edge in the tree; 17 files go the other way, so
`helpers` is the lower layer and this one import inverts it.

It inverts it for a two-line integer helper with no dependency on anything in `utils`.
`tensor_factory.py` is scoped to tensor construction and host-backend selection; ceiling
division is neither.

### Fix

Define `ceildiv` in `python/helpers/util.py` and re-export it from
`python/utils/tensor_factory.py`. The two taplib call sites import from their own package.

Nothing about the public surface moves: `aie.utils.ceildiv`, `aie.iron.ceildiv` and
`aie.utils.tensor_factory.ceildiv` all still resolve, to the same object.

### Test

Checked by import rather than by a new test, since the function is two lines and unchanged:

- `aie.utils.ceildiv is aie.helpers.util.ceildiv` and
  `aie.utils.tensor_factory.ceildiv is aie.helpers.util.ceildiv` both hold, so the eight
  `programming_examples` that use it and `test/python/taplib/matmul_whole_array_tiling_sweep.py`
  see exactly what they saw before.
- Both taplib modules import cleanly.
- `grep` for a `helpers` -> `utils` import now returns nothing.
