### PR TITLE
[python] run_conv_torch_test: size the output buffer in elements, not bytes [HIGH]

### DIFF
--- a/python/utils/ml.py
+++ b/python/utils/ml.py
@@ -444,7 +444,9 @@ def run_conv_torch_test(
 
     in1 = iron.tensor(ifm_mem_fmt, dtype=dtype_in)
     in2 = iron.tensor(total_wts, dtype=dtype_wts)
-    out_size = int(np.prod(out_shape_in_layout) * dtype_out.itemsize)
+    # zeros() takes a shape in elements, and out is reshaped to
+    # out_shape_in_layout below, so this must not be scaled by itemsize.
+    out_size = int(np.prod(out_shape_in_layout))
     out = iron.zeros(out_size, dtype=dtype_out)
     buffers = [in1, in2, out]
 


### PR DESCRIPTION
### Problem

`run_conv_torch_test` sizes the output buffer in bytes and then uses it as a count of
elements:

```python
out_size = int(np.prod(out_shape_in_layout) * dtype_out.itemsize)
out = iron.zeros(out_size, dtype=dtype_out)
...
temp_out = data_buffer.reshape(out_shape_in_layout)
```

`zeros(*size)` documents `size` as the shape of the tensor, so the `itemsize` factor
overallocates by exactly that factor and the reshape further down then fails.

### Fix

Drop the `itemsize` scaling.

### Test

No test, and worth saying why rather than adding one that does not exercise the path:
`run_conv_torch_test` needs torch and a device, and there is no existing test module for
`aie/utils/ml.py` to extend.

The defect is also not reachable from anything in tree today, which is why it has gone
unnoticed. `dtype_out` defaults to `np.int8`, `programming_examples/ml/bottleneck` passes
`np.uint8`, and `programming_examples/ml/conv2d` passes a variable that resolves to
`np.uint8` or `np.int8`. At itemsize 1 the multiply is a no-op. For
`out_shape_in_layout=(32, 8, 32, 8)`:

| dtype_out | itemsize | allocated (before) | needed | reshape |
|---|---|---|---|---|
| int8 / uint8 | 1 | 65536 | 65536 | ok |
| int16 | 2 | 131072 | 65536 | ValueError |
| int32 | 4 | 262144 | 65536 | ValueError |

`dtype_out` carries no documented restriction to one-byte types, so any wider-output conv
example would hit this.
