### PR TITLE
[cmake] Record the validated Peano version in aie/version.h [LOW]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ find_package(XRT)
 # (https://github.com/Xilinx/llvm-aie.git <sha>)". That is identity/provenance, not a compatibility
 # predicate: llvm-aie's LLVM_VERSION stays fixed between releases, so there is no meaningful ">="
 # range to gate on here, only "which exact build is this." Record it for diagnostics.
+set(PEANO_VERSION_STRING "")
+set(PEANO_REVISION "")
 if(NOT PEANO_INSTALL_DIR STREQUAL "<unset>")
   # FindPeano.cmake lives in the cmake/modulesXilinx submodule, and this file only puts that
   # directory on CMAKE_MODULE_PATH on WIN32; every other build passes -DCMAKE_MODULE_PATH (see
@@ -164,8 +166,6 @@ if(NOT PEANO_INSTALL_DIR STREQUAL "<unset>")
       "under ${PEANO_INSTALL_DIR}/include/. Fix PEANO_INSTALL_DIR, or unset it to configure without "
       "Peano.")
   else()
-    set(PEANO_VERSION_STRING "")
-    set(PEANO_REVISION "")
     if(PEANO_CLANG)
       execute_process(
         COMMAND ${PEANO_CLANG} --version
@@ -190,6 +190,20 @@ if(NOT PEANO_INSTALL_DIR STREQUAL "<unset>")
       message(STATUS "Peano (llvm-aie) validated: ${PEANO_DIR}")
     endif()
   endif()
+endif()
+
+# Description of the Peano used to configure this build, recorded into aie/version.h so a
+# built tool can report which llvm-aie it was configured against. This is provenance, not a
+# compatibility check: llvm-aie publishes no version query to gate on (see FindPeano above).
+if(PEANO_INSTALL_DIR STREQUAL "<unset>")
+  set(AIE_PEANO_VERSION "not configured")
+elseif(PEANO_VERSION_STRING AND PEANO_REVISION)
+  set(AIE_PEANO_VERSION "${PEANO_VERSION_STRING} (${PEANO_REVISION})")
+elseif(PEANO_VERSION_STRING)
+  set(AIE_PEANO_VERSION "${PEANO_VERSION_STRING}")
+else()
+  # Validated above, but clang --version did not run or did not parse.
+  set(AIE_PEANO_VERSION "unknown")
 endif()
 
 # Find AIEBU library for direct ELF generation (optional, falls back to subprocess)

--- a/include/aie/version.h.in
+++ b/include/aie/version.h.in
@@ -7,5 +7,6 @@
 #define AIE_VERSION_H
 
 #define AIE_GIT_COMMIT "@AIE_GIT_COMMIT@"
+#define AIE_PEANO_VERSION "@AIE_PEANO_VERSION@"
 
 #endif

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -26,6 +26,7 @@ using namespace mlir;
 
 static void version_printer(raw_ostream &os) {
   os << "aie-opt " << AIE_GIT_COMMIT << "\n";
+  os << "  peano: " << AIE_PEANO_VERSION << "\n";
 }
 
 int main(int argc, char **argv) {

--- a/tools/aie-translate/aie-translate.cpp
+++ b/tools/aie-translate/aie-translate.cpp
@@ -49,6 +49,7 @@ static void registerToLLVMIRTranslation() {
 
 static void version_printer(raw_ostream &os) {
   os << "aie-translate " << AIE_GIT_COMMIT << "\n";
+  os << "  peano: " << AIE_PEANO_VERSION << "\n";
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Problem

`FindPeano` already extracts the Peano version and git revision from `clang --version`, but both
end at a `message(STATUS)`. Once configure is over a built tree cannot say which llvm-aie it was
configured against, so `aie-opt --version` reports the mlir-aie commit and nothing about the
compiler that emits the AIE code.

## Fix

Reuse the values already computed: derive one description string in CMake and record it as
`AIE_PEANO_VERSION` in `aie/version.h`, beside the existing `AIE_GIT_COMMIT`. `aie-opt` and
`aie-translate` print it. This records provenance; it is not a compatibility check.

## Test

Built `aie-opt` from this branch against main af819a80 with `PEANO_INSTALL_DIR` set:

```
$ aie-opt --version
AOMP-23.0-60 (http://github.com/ROCm/aomp):
 Source ID:23.0-60-8b7c0c42edfe088700d312231739eff0dabd913c
  LLVM version 24.0.0
  Optimized build with assertions.
aie-opt 52f62c9604b65a86a31f8e2605369403c83c79d8
  peano: 22.0.0git
```

Re-configured with `PEANO_INSTALL_DIR` unset: the header records `"not configured"`. A Peano that
is found and validated but whose `clang --version` does not run or does not parse records
`"unknown"`, so a build with no Peano stays distinguishable from one whose version could not be
read; that third branch is by inspection, not executed.

## Known limitation

The revision half of the existing `message(STATUS)` logic, which this reuses, only matches an
`https://github.com/Xilinx/llvm-aie` remote. A Peano built from a fork or cloned over SSH reports
`clang version 22.0.0git (git@github.com:<user>/llvm-aie.git <sha>)`, which the regex misses, so the
header records the version without the revision, as above. Pre-existing behaviour, not introduced
here; happy to widen the pattern separately if that is wanted.
