### PR TITLE
Rewrite ATB kernels with Peano

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -207,12 +207,6 @@ jobs:
           # Set number of contexts to maintain in cache per process
           export XRT_CONTEXT_CACHE_SIZE=2
 
-          # gemm_asymmetric_tile_buffering chess builds peak ~8 GB RSS and
-          # ~9 min wall alone on 32 GB; they run serialized via lit's atb_chess
-          # group and need a longer timeout, so they get their own invocation.
-          GEMM=gemm_asymmetric_tile_buffering
-          ATB_LIT_OPTS="-j4 -sv --time-tests --timeout 1200 --show-unsupported --show-excluded"
-
           # run_suite <name> full|only-failed
           #   full        -- the suite's normal invocation
           #   only-failed -- restrict to RETRY_LIT_FILTER (retry of the failed suite)
@@ -223,21 +217,13 @@ jobs:
               concurrency) if [ "$2" = only-failed ]; then LIT_FILTER="$RETRY_LIT_FILTER" ninja check-aie-concurrency
                            else ninja check-aie-concurrency; fi ;;
               refs)        if [ "$2" = only-failed ]; then LIT_FILTER="$RETRY_LIT_FILTER" ninja check-reference-designs
-                           else LIT_FILTER_OUT="$GEMM" ninja check-reference-designs; fi ;;
+                           else ninja check-reference-designs; fi ;;
               guide)       if [ "$2" = only-failed ]; then LIT_FILTER="$RETRY_LIT_FILTER" ninja check-programming-guide
                            else ninja check-programming-guide; fi ;;
-              atb)         if [ "$2" = only-failed ]; then LIT_OPTS="$ATB_LIT_OPTS" LIT_FILTER="$RETRY_LIT_FILTER" ninja check-reference-designs
-                           else LIT_OPTS="$ATB_LIT_OPTS" LIT_FILTER="$GEMM" ninja check-reference-designs; fi ;;
             esac
           }
 
-          # gemm_asymmetric_tile_buffering reproduces a paper rather than gating
-          # a regression, and is ~6 min of an 18-24 min job that does not shrink
-          # on a bigger host. Nightly, plus test-ryzen-ai for on-demand runs.
           SUITES="check-aie concurrency refs guide"
-          if [ "$GITHUB_EVENT_NAME" = schedule ] || [ "$GITHUB_REF_NAME" = test-ryzen-ai ]; then
-            SUITES="$SUITES atb"
-          fi
 
           # Only treat FAILED_SUITE as valid if it EXACTLY names a known suite
           # (fixed-string match, not a glob) -- else force the full re-run path.

--- a/aie_kernels/aie_kernel_utils.h
+++ b/aie_kernels/aie_kernel_utils.h
@@ -28,11 +28,20 @@ Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
 #define AIE_TRY_INITIATION_INTERVAL(x)
 #define AIE_PREPARE_FOR_POSTPIPELINING
 #define AIE_LOOP_FLATTEN chess_flatten_loop
+#define AIE_LOOP_HINT(k, v)
+#define AIE_LOOP_GPR_REALLOC
 
 #elif defined(__AIECC__)
 #ifndef __STRINGIFY
 #define __STRINGIFY(a) #a
 #endif
+#define AIE_PRAGMA_STR(x) _Pragma(#x)
+#define AIE_PRAGMA(x) AIE_PRAGMA_STR(x)
+#define AIE_LOOP_HINT(k, v) AIE_PRAGMA(clang loop hint(k, v))
+// clang-format off: aie-gpr-realloc is a single pragma hint token, not an
+// arithmetic expression.
+#define AIE_LOOP_GPR_REALLOC AIE_LOOP_HINT(aie-gpr-realloc, 1)
+// clang-format on
 #define AIE_LOOP_UNROLL(x) _Pragma(__STRINGIFY(clang loop unroll_count(x)))
 #define AIE_LOOP_UNROLL_FULL _Pragma("clang loop unroll(full)")
 #define AIE_LOOP_NO_UNROLL _Pragma("clang loop unroll(disable)")
@@ -74,6 +83,8 @@ Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
 #define AIE_TRY_INITIATION_INTERVAL(x)
 #define AIE_PREPARE_FOR_POSTPIPELINING
 #define AIE_LOOP_FLATTEN
+#define AIE_LOOP_HINT(k, v)
+#define AIE_LOOP_GPR_REALLOC
 #endif
 
 // Runs `body` (a zero-arg lambda) `count` times.  When count >= MinIters the

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -174,7 +174,3 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 if config.enable_board_tests:
     lit_config.parallelism_groups["board"] = 1
     config.parallelism_group = "board"
-
-# Opt-in serialization group for chess builds whose peak RSS is large enough
-# to OOM the CI runner under -j4. Tests opt in via a lit.local.cfg.
-lit_config.parallelism_groups["atb_chess"] = 1

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/README.md
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/README.md
@@ -55,14 +55,12 @@ combined tradeoff) see Sections 3 – 5 of the paper.
 
 ## Examples
 
-These designs use IRON and currently require the **chess** compiler (each
-`config*/n32_core.py` declares its bfp16 mac kernel with `use_chess=True`
-on the `ExternalFunction`).  The reason is register placement rather than
-codegen support: the kernels pin their ping and pong tiles and accumulators
-to named registers with `chess_storage(ex0..ex7)` and `chess_storage(dm0..dm3)`,
-which is the asymmetric buffering these examples exist to demonstrate.  Peano
-defines `chess_storage(...)` as an empty macro, so those placements are dropped
-and its allocator chooses instead.
+These designs use IRON and build with the **Peano** compiler (the default
+`ExternalFunction` path). The kernels make the register placement behind the
+asymmetric buffering explicit via DM-bank annotations
+(`__aie_dm_resource_a/b/c/d`) on the tile pointers and buffer streams, and
+tune software pipelining with the loop-hint macros from
+[`aie_kernels/aie_kernel_utils.h`](../../../../aie_kernels/aie_kernel_utils.h).
 
 Build any of them with:
 
@@ -114,20 +112,20 @@ make devicename=npu2 run M=4096 K=4096 N=2048
 
 ## Performance
 
-All three examples build and run end-to-end against `mlir-aie` HEAD (May 2026
-wheel) with the **chess** compiler.
+All three examples build and run end-to-end against `mlir-aie` HEAD (August 2025) with the Peano compiler.
 
 Peak throughput at the paper-scale shapes, using `sudo xrt-smi configure
---pmode turbo` and 20 warmup + 20 iters (min NPU time across iters):
+--pmode turbo` and 20 warmup + 20 iters (min NPU time across iters), measured
+on Strix Point (Ryzen AI MAX+ 395, ASUS ROG Flow Z13):
 
-| Config | Shape (M × K × N) | L1 tile `m × k × n` | ρ | Strix Point NPU | Krackan Point NPU |
-|---|---|---|---|---|---|
-| 1 | 4096 × 4096 × 2048 | 128 × 64 × 128 | 4 | 24.3 TFLOPS | 27.33 TFLOPS |
-| 2 | 3072 × 4096 × 1536 | 192 × 128 × 96 | 6 | 31.3 TFLOPS | 31.58 TFLOPS |
-| 3 | 4096 × 4096 × 2048 | 128 × 64 × 128 | 4 | 28.5 TFLOPS | 28.60 TFLOPS |
+| Config | Shape (M × K × N) | L1 tile `m × k × n` | ρ | Strix Point NPU |
+|---|---|---|---|---|
+| 1 | 4096 × 4096 × 2048 | 128 × 64 × 128 | 4 | 24.2 TFLOPS |
+| 2 | 3072 × 4096 × 1536 | 192 × 128 × 96 | 6 | 32.5 TFLOPS |
+| 3 | 4096 × 4096 × 2048 | 128 × 64 × 128 | 4 | 30.3 TFLOPS |
 
-Strix Point column: Ryzen AI 9 HX 370. Krackan Point column: Ryzen AI 7,
-ASUS Vivobook.
+For reference, the paper reports 24.3 / 31.3 / 28.5 TFLOPS for configs
+1 / 2 / 3 on a Strix Point laptop.
 
 ## Reference
 

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/mm_bfp_mixed.cc
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/mm_bfp_mixed.cc
@@ -5,34 +5,49 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "aie_kernel_utils.h"
+// ATB microkernel, bf16 A / bfp16ebs8 B / bf16 C variant. A is converted to
+// bfp16ebs8 in a stack staging buffer first (sizeof(bfp16ebs8) == 1 on Peano,
+// so all bfp16ebs8* arithmetic below is byte arithmetic), then the MAC loop
+// streams A and B as 576-bit blocks while C is plain bf16 load/store.
+// Register placement uses DM-bank annotations: A -> bank A, B -> bank B,
+// C -> bank C, raw A input -> bank D.
+//
+// Compute structure: per call, 2 block rows x 8 blocks of 16x16; each block
+// runs 8 expanded k-steps (2 A pops + 2 B pops + 4 8x8x8 MACs, B-first at
+// fill steps 0 and 4) in a post-RA-pipelined blk loop with next-block C
+// prefetch. Measured II=42, NS=2.
+
 #include <aie_api/aie.hpp>
 
-template <typename T, int M, int N>
-void zero_vectorized(T *__restrict c) {
-  constexpr int r = 512 / (sizeof(T) * 8);
-  static_assert((M * N) % r == 0);
-  const aie::vector<T, r> zeros = aie::zeros<T, r>();
-  const T *__restrict c_end = c + M * N;
-  for (; c < c_end; c += r) {
-    aie::store_v(c, zeros);
-  }
-}
-constexpr int M = 128 / 4;
-constexpr int K = 64;
-constexpr int N = 128;
-constexpr int m = 128 / 4;
+#include "aie_kernel_utils.h"
+
+template <typename T, unsigned N, aie_dm_resource R>
+using InBufStream = aie::block_vector_restrict_input_buffer_stream<T, N, R>;
+template <typename T, unsigned N, aie_dm_resource R>
+using OutBufStream = aie::block_vector_output_buffer_stream<T, N, R>;
+
+// Per-core L1 C tile is (m, n); the L1 A sub-tile is (m/rho, k). The kernel
+// is invoked rho times per (A-sub-tile, B-tile) pair and rotates over the
+// rho C stripes (m/rho rows each) via g_counter.
+constexpr int rho = 4;
+constexpr int m = 128;
 constexpr int k = 64;
 constexpr int n = 128;
-constexpr int r = 8;
-constexpr int s = 8;
-constexpr int t = 8;
+constexpr int m_a = m / rho;
+
+// aie::mmul sub-tile shape (the only shape supported for bfp16ebs8 on
+// AIE2P): per MAC, an r x s A panel times an s x t B panel accumulates
+// into r x t of C.
+constexpr int r = 8; // MAC rows (A/C)
+constexpr int s = 8; // MAC reduction step (k-columns per MAC)
+constexpr int t = 8; // MAC columns (B/C)
+
+static_assert(m * rho == 512 && k == 64 && n == 128 && rho == 4);
 
 extern "C" {
 
-// MATMUL_ONLY / ZERO_ONLY gates — distinct ExternalFunction .o builds
-// of this TU emit exactly one symbol. Without any macro, both symbols
-// are emitted (legacy behaviour).
+// MATMUL_ONLY / ZERO_ONLY gates — distinct ExternalFunction .o builds of
+// this TU emit exactly one symbol. Without any macro, both are emitted.
 #if !defined(MATMUL_ONLY) && !defined(ZERO_ONLY)
 #define MATMUL_ONLY
 #define ZERO_ONLY
@@ -41,405 +56,112 @@ extern "C" {
 static int g_counter = 0;
 
 #ifdef MATMUL_ONLY
-void matmul_vectorized_different_datatypes(bfloat16 *__restrict pA,
-                                           bfp16ebs8 *__restrict pB,
+void matmul_vectorized_different_datatypes(bfloat16 *__restrict pA_in,
+                                           bfp16ebs8 *__restrict pB_in,
                                            bfloat16 *__restrict pC_curtile) {
-
   event0();
-  pC_curtile += g_counter * m * n;
-  if (g_counter == 3) {
-    g_counter = 0;
-  } else {
-    g_counter = g_counter + 1;
-  }
-  // convert pA from bfloat16 to bfp16ebs8
-  // sizeof(bfp16ebs8) does not track the stream's per-push byte stride
-  // (llvm-aie#1232); size the scratch buffer from memory_bytes() instead.
-  using ConvertedABlock = aie::block_vector<bfp16ebs8, 64>;
-  alignas(aie::vector_decl_align)
-      uint8_t converted_A_storage[(M / 8 / 2) * (K / 8) * 2 *
-                                  ConvertedABlock::memory_bytes()];
-  bfp16ebs8 *converted_A = reinterpret_cast<bfp16ebs8 *>(converted_A_storage);
-  aie::block_vector_output_buffer_stream<bfp16ebs8, 64> pA_bfp16_stream(
-      converted_A);
-  pA_bfp16_stream.seek(0);
-  aie::vector<bfloat16, 64> A_temp;
-  for (int row = 0; row < M / 8 / 2; row++) {
-    for (int col = 0; col < K / 8; col++) {
-      for (int innerid = 0; innerid < 2; innerid++) {
-        A_temp = aie::load_v<64>(pA + (row * 2 + innerid) * 8 * 64 + col * 64);
-        aie::accum<accfloat, 64> A0_data_float;
-        A0_data_float = A_temp;
-        pA_bfp16_stream.push(A0_data_float.template to_vector<bfp16ebs8>());
-      }
+  // Round-to-nearest-even (Peano defaults to floor on converts).
+  aie::set_rounding(aie::rounding_mode::conv_even);
+  bfloat16 *__restrict pC_tile = pC_curtile + g_counter * (m_a * n);
+  g_counter = (g_counter == rho - 1) ? 0 : g_counter + 1;
+
+  uint8_t converted_A[m_a * k / 8 * 9] __attribute__((aligned(64)));
+
+  OutBufStream<bfp16ebs8, r * s, aie_dm_resource::a> a_out(
+      (bfp16ebs8 *)converted_A);
+  const bfloat16 __aie_dm_resource_d *__restrict pA =
+      (const bfloat16 __aie_dm_resource_d *)pA_in;
+
+  for (int rp = 0; rp < m_a / (2 * r); rp++) {
+    const bfloat16 __aie_dm_resource_d *__restrict q = pA + rp * (2 * r * k);
+    AIE_PREPARE_FOR_POSTPIPELINING
+    for (int cb = 0; cb < k / s; cb++) {
+      aie::vector<bfloat16, r * s> v0 = aie::load_v<r * s>(q);
+      aie::vector<bfloat16, r * s> v1 = aie::load_v<r * s>(q + r * k);
+      a_out.push(
+          aie::accum<accfloat, r * s>(v0).template to_vector<bfp16ebs8>());
+      a_out.push(
+          aie::accum<accfloat, r * s>(v1).template to_vector<bfp16ebs8>());
+      q += r * s;
     }
   }
 
-  for (int i = 0; i < m * n / (16 * 16); i = i + 4) {
-    int block_row = i / (n / 16);
-    int block_col = i % (n / 16);
+  using AStream = InBufStream<bfp16ebs8, r * s, aie_dm_resource::a>;
+  using BStream = InBufStream<bfp16ebs8, s * t, aie_dm_resource::b>;
+  using CPtr = bfloat16 __aie_dm_resource_c *__restrict;
+  using MMUL = aie::mmul<r, s, t, bfp16ebs8>;
 
-    bfloat16 *pC = pC_curtile + block_row * N * 16 +
-                   block_col * 2 *
-                       64; // 64 elements per 8x8 innermost block, 2x2 per block
+  const bfp16ebs8 *pA_base = (const bfp16ebs8 *)converted_A;
+  CPtr const pC_base = (CPtr)pC_tile;
 
-    int A_stream_index = block_row * 2 * k / 8;
-    int B_stream_index = block_col * (k / 8) * 2;
+  for (int br = 0; br < m_a / (2 * r); br++) {
+    // Persistent sliding B stream per block row.
+    BStream b_stream(pB_in);
+    {
+      // C layout: r x t row-major sub-blocks over the (m, n) tile; the
+      // +r*n offsets below step to the second r-row half (rows r..2r-1)
+      // of the 2r-row block.
+      CPtr pC = pC_base + br * (2 * r * n);
 
-    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pB_stream(pB);
-    pB_stream.seek(B_stream_index);
-    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream(converted_A);
-    pA_stream.seek(A_stream_index);
+      aie::vector<bfloat16, r * t> c0 = aie::load_v<r * t>(pC);
+      aie::vector<bfloat16, r * t> c1 = aie::load_v<r * t>(pC + r * t);
+      for (int blk = 0; blk < n / (2 * t); blk++) {
+        CPtr pCb = pC + blk * (2 * r * t);
+        CPtr pNext = (blk < n / (2 * t) - 1) ? pCb + 2 * r * t : pCb;
 
-    aie::accum<accfloat, 64> chess_storage(dm1) acc0_data(aie::load_v<64>(pC));
-    aie::accum<accfloat, 64> chess_storage(dm2)
-        acc1_data(aie::load_v<64>(pC + 64));
-    aie::accum<accfloat, 64> chess_storage(dm3)
-        acc2_data(aie::load_v<64>(pC + 0 + N * 8));
-    aie::accum<accfloat, 64> chess_storage(dm4)
-        acc3_data(aie::load_v<64>(pC + 64 + N * 8));
+        MMUL acc0((aie::accum<accfloat, r * t>(c0)));
+        MMUL acc1((aie::accum<accfloat, r * t>(c1)));
+        MMUL acc2(
+            (aie::accum<accfloat, r * t>(aie::load_v<r * t>(pCb + r * n))));
+        MMUL acc3((aie::accum<accfloat, r * t>(
+            aie::load_v<r * t>(pCb + r * t + r * n))));
 
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex0) A0_data_bfp;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex1) A1_data_bfp;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex2) B0_data_bfp;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex3) B1_data_bfp;
+        // Prefetch next block's first C pair while this block computes.
+        c0 = aie::load_v<r * t>(pNext);
+        c1 = aie::load_v<r * t>(pNext + r * t);
 
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex4) A0_data_bfp_pong;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex6) A1_data_bfp_pong;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex5) B0_data_bfp_pong;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex7) B1_data_bfp_pong;
+        // Fresh A stream per block: re-reads this block row's band (fills
+        // constant-fold before pops 0 and 8).
+        AStream a_stream(pA_base);
+        a_stream.seek(br * (2 * k / s));
 
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex8) A0_data_bfp_2;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex9) A1_data_bfp_2;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex10) B0_data_bfp_2;
-    aie::block_vector<bfp16ebs8, 64> chess_storage(ex11) B1_data_bfp_2;
+        // One k-step: 2 A pops + 2 B pops + 4 8x8x8 MACs. On fill steps
+        // (B pops 0 and 8 of each 16-pop stream buffer) the B pops come
+        // first so the fifo_ld_fill emits ahead of the A-stream ops.
+        auto kstep = [&]<bool BFILL>() __attribute__((always_inline)) {
+          aie::block_vector<bfp16ebs8, r * s> A0, A1; // r x s A panels
+          aie::block_vector<bfp16ebs8, s * t> B0, B1; // s x t B panels
+          if constexpr (BFILL) {
+            B0 = b_stream.pop();
+            B1 = b_stream.pop();
+            A0 = a_stream.pop();
+            A1 = a_stream.pop();
+          } else {
+            A0 = a_stream.pop();
+            A1 = a_stream.pop();
+            B0 = b_stream.pop();
+            B1 = b_stream.pop();
+          }
+          acc0.mac(A0, aie::op_transpose(B0));
+          acc1.mac(A0, aie::op_transpose(B1));
+          acc2.mac(A1, aie::op_transpose(B0));
+          acc3.mac(A1, aie::op_transpose(B1));
+        };
+        kstep.operator()<true>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
+        kstep.operator()<true>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
 
-    A0_data_bfp = pA_stream.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream.pop();
-    B1_data_bfp = pB_stream.pop();
-
-    A0_data_bfp_pong = pA_stream.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream2(
-        converted_A);
-    pA_stream2.seek(A_stream_index);
-
-    A0_data_bfp_2 = pA_stream2.pop();
-    B0_data_bfp_2 = pB_stream.pop();
-    A1_data_bfp_2 = pA_stream2.pop();
-    B1_data_bfp_2 = pB_stream.pop();
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream2.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream2.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-
-    aie::store_v(pC, acc0_data.template to_vector<bfloat16>());
-    acc0_data = aie::load_v<64>(pC + 128);
-    aie::store_v(pC + 64, acc1_data.template to_vector<bfloat16>());
-    acc1_data = aie::load_v<64>(pC + 192);
-    aie::store_v(pC + 0 + N * 8, acc2_data.template to_vector<bfloat16>());
-    acc2_data = aie::load_v<64>(pC + 128 + N * 8);
-    aie::store_v(pC + 64 + N * 8, acc3_data.template to_vector<bfloat16>());
-    acc3_data = aie::load_v<64>(pC + 192 + N * 8);
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-    A0_data_bfp_2 = pA_stream2.pop();
-    B0_data_bfp_2 = pB_stream.pop();
-    A1_data_bfp_2 = pA_stream2.pop();
-    B1_data_bfp_2 = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream2.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream2.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-    A0_data_bfp_2 = pA_stream2.pop();
-    B0_data_bfp_2 = pB_stream.pop();
-    A1_data_bfp_2 = pA_stream2.pop();
-    B1_data_bfp_2 = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream2.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream2.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-    A0_data_bfp_2 = pA_stream2.pop();
-    B0_data_bfp_2 = pB_stream.pop();
-    A1_data_bfp_2 = pA_stream2.pop();
-    B1_data_bfp_2 = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream2.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream2.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-
-    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream3(
-        converted_A);
-    pA_stream3.seek(A_stream_index);
-
-    A0_data_bfp = pA_stream3.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream3.pop();
-    B1_data_bfp = pB_stream.pop();
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream3.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream3.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-
-    aie::store_v(pC + 128, acc0_data.template to_vector<bfloat16>());
-    acc0_data = aie::load_v<64>(pC + 256);
-    aie::store_v(pC + 192, acc1_data.template to_vector<bfloat16>());
-    acc1_data = aie::load_v<64>(pC + 320);
-    aie::store_v(pC + 128 + N * 8, acc2_data.template to_vector<bfloat16>());
-    acc2_data = aie::load_v<64>(pC + 256 + N * 8);
-    aie::store_v(pC + 192 + N * 8, acc3_data.template to_vector<bfloat16>());
-    acc3_data = aie::load_v<64>(pC + 320 + N * 8);
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream3.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream3.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream3.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream3.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream3.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream3.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream3.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream3.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream3.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream3.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream3.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream3.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream4(
-        converted_A);
-    pA_stream4.seek(A_stream_index);
-
-    A0_data_bfp = pA_stream4.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream4.pop();
-    B1_data_bfp = pB_stream.pop();
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream4.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream4.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-
-    aie::store_v(pC + 256, acc0_data.template to_vector<bfloat16>());
-    acc0_data = aie::load_v<64>(pC + 384);
-    aie::store_v(pC + 320, acc1_data.template to_vector<bfloat16>());
-    acc1_data = aie::load_v<64>(pC + 448);
-    aie::store_v(pC + 256 + N * 8, acc2_data.template to_vector<bfloat16>());
-    acc2_data = aie::load_v<64>(pC + 384 + N * 8);
-    aie::store_v(pC + 320 + N * 8, acc3_data.template to_vector<bfloat16>());
-    acc3_data = aie::load_v<64>(pC + 448 + N * 8);
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream4.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream4.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream4.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream4.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream4.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream4.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream4.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream4.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-    A0_data_bfp = pA_stream4.pop();
-    B0_data_bfp = pB_stream.pop();
-    A1_data_bfp = pA_stream4.pop();
-    B1_data_bfp = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    A0_data_bfp_pong = pA_stream4.pop();
-    B0_data_bfp_pong = pB_stream.pop();
-    A1_data_bfp_pong = pA_stream4.pop();
-    B1_data_bfp_pong = pB_stream.pop();
-    acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-    acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-    acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-    acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-    acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-    aie::store_v(pC + 384, acc0_data.template to_vector<bfloat16>());
-    aie::store_v(pC + 448, acc1_data.template to_vector<bfloat16>());
-    aie::store_v(pC + 384 + N * 8, acc2_data.template to_vector<bfloat16>());
-    aie::store_v(pC + 448 + N * 8, acc3_data.template to_vector<bfloat16>());
+        aie::store_v(pCb, acc0.template to_vector<bfloat16>());
+        aie::store_v(pCb + r * t, acc1.template to_vector<bfloat16>());
+        aie::store_v(pCb + r * n, acc2.template to_vector<bfloat16>());
+        aie::store_v(pCb + r * t + r * n, acc3.template to_vector<bfloat16>());
+      }
+    }
   }
 
   event1();
@@ -448,7 +170,12 @@ void matmul_vectorized_different_datatypes(bfloat16 *__restrict pA,
 
 #ifdef ZERO_ONLY
 void zero_kernel_bf16(bfloat16 *__restrict cOut) {
-  zero_vectorized<bfloat16, DIM_M, DIM_N>(cOut);
+  constexpr int vec = 64; // bf16 elements per store (2x 512-bit)
+  const aie::vector<bfloat16, vec> zeros = aie::zeros<bfloat16, vec>();
+  bfloat16 __aie_dm_resource_c *__restrict p =
+      (bfloat16 __aie_dm_resource_c *)cOut;
+  for (int i = 0; i < m * n / vec; i++)
+    aie::store_v(p + i * vec, zeros);
 }
 #endif
 }

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/n32_core.py
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/n32_core.py
@@ -67,26 +67,19 @@ def n32_core_gemm(
     B_l1_ty = np.ndarray[(k, n // 8), np.dtype[v8bfp16ebs8]]
     C_l1_ty = np.ndarray[(m, n), np.dtype[bfloat16]]
 
-    kernel_flags = [
-        f"-DDIM_M={m}",
-        f"-DDIM_K={k}",
-        f"-DDIM_N={n}",
-        f"-I{_AIE_KERNELS_INC}",
-    ]
+    kernel_flags = [f"-I{_AIE_KERNELS_INC}"]
 
     zero_kernel = ExternalFunction(
         "zero_kernel_bf16",
         source_file=str(_KERNEL_SRC),
         arg_types=[C_l1_ty],
         compile_flags=kernel_flags + ["-DZERO_ONLY"],
-        use_chess=True,
     )
     matmul_kernel = ExternalFunction(
         "matmul_vectorized_different_datatypes",
         source_file=str(_KERNEL_SRC),
         arg_types=[A_l1_ty, B_l1_ty, C_l1_ty],
         compile_flags=kernel_flags + ["-DMATMUL_ONLY"],
-        use_chess=True,
     )
 
     A_l3l2_fifos: list[ObjectFifo] = []

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/run_strix_makefile.lit
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/run_strix_makefile.lit
@@ -1,11 +1,11 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai_npu2, chess
+// REQUIRES: ryzen_ai_npu2, peano
 // REQUIRES: makefile_examples
 //
-// RUN: mkdir -p test_stx_chess
-// RUN: cd test_stx_chess
+// RUN: mkdir -p test_stx
+// RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2
 // RUN: %run_on_npu2% make -f %S/Makefile devicename=npu2 run

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/mm_bfp_mixed.cc
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/mm_bfp_mixed.cc
@@ -5,40 +5,58 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "aie_kernel_utils.h"
+// ATB microkernel, all-bfp16ebs8 variant: A, B and C tiles are all
+// v8bfp16ebs8. One flat post-RA-pipelined loop over all 12 (16x16) C blocks
+// of the per-call stripe, cross-block pipelined: accumulators init from the
+// previous iteration's prefetched C vectors, run 16 expanded k-steps,
+// prefetch the next block's C, push the results. Measured II=77 (= RecMII),
+// NS=2, ZOL (m=192, k=128, n=96, rho=6). Requires -mllvm
+// -aie-postpipeliner-maxii=120 -aie-postpipeliner-maxtry-ii=50 (via
+// compile_flags in n32_core.py): the loop's ResMII=68 exceeds the default
+// max II of 60.
+
 #include <aie_api/aie.hpp>
 
-template <int M, int N>
-void zero_vectorized_v64bfp16ebs8(bfp16ebs8 *__restrict cOut) {
-  int const vectorSize = 64;
+#include "aie_kernel_utils.h"
 
-  const aie::accum<accfloat, vectorSize> acc =
-      aie::zeros<accfloat, vectorSize>();
+template <typename T, unsigned N, aie_dm_resource R>
+using InBufStream = aie::block_vector_restrict_input_buffer_stream<T, N, R>;
+template <typename T, unsigned N, aie_dm_resource R>
+using OutBufStream = aie::block_vector_output_buffer_stream<T, N, R>;
 
-  aie::block_vector_output_buffer_stream<bfp16ebs8, vectorSize> outStreamC(
-      cOut);
-
-  for (int i = 0; i < M * N / 64; i++) {
-    outStreamC << acc.to_vector<bfp16ebs8>();
-  }
-}
-
-constexpr int DIV = 6;
-constexpr int M = 192 / DIV;
-constexpr int K = 128;
-constexpr int N = 96;
-constexpr int m = 192 / DIV;
+// Per-core L1 C tile is (m, n); the L1 A sub-tile is (m/rho, k). The kernel
+// is invoked rho times per (A-sub-tile, B-tile) pair and rotates over the
+// rho C stripes via g_counter.
+constexpr int m = 192;
 constexpr int k = 128;
 constexpr int n = 96;
-constexpr int r = 8;
-constexpr int s = 8;
-constexpr int t = 8;
+constexpr int rho = 6;
+constexpr int m_a = m / rho;
+
+// aie::mmul sub-tile shape (the only shape supported for bfp16ebs8 on
+// AIE2P): per MAC, an r x s A panel times an s x t B panel accumulates
+// into r x t of C.
+constexpr int r = 8; // MAC rows (A/C)
+constexpr int s = 8; // MAC reduction step (k-columns per MAC)
+constexpr int t = 8; // MAC columns (B/C)
+
+constexpr int nbc = n / (2 * t); // column blocks of 2t cols
+constexpr int nblk = (m_a / (2 * r)) * nbc;
+
+// Bytes per 64-value bfp16ebs8 block (8 exponent-sharing groups of 8
+// values at 9 bytes each); bfp16ebs8* arithmetic is byte arithmetic on
+// Peano (sizeof(bfp16ebs8) == 1).
+constexpr int blk_bytes = r * s / 8 * 9; // = 72
+
+static_assert(m == 192 && m % rho == 0 && m_a % (2 * r) == 0 && k == 128 &&
+                  n == 96 && n % (2 * t) == 0 && rho == 6,
+              "the pipelined flat loop carries k/s == 16 expanded k-steps "
+              "over (2r)x(2t) C blocks");
 
 extern "C" {
 
-// MATMUL_ONLY / ZERO_ONLY gates — distinct ExternalFunction .o builds
-// of this TU emit exactly one symbol. Without any macro, both symbols
-// are emitted (legacy behaviour).
+// MATMUL_ONLY / ZERO_ONLY gates — distinct ExternalFunction .o builds of
+// this TU emit exactly one symbol. Without any macro, both are emitted.
 #if !defined(MATMUL_ONLY) && !defined(ZERO_ONLY)
 #define MATMUL_ONLY
 #define ZERO_ONLY
@@ -47,207 +65,122 @@ extern "C" {
 static int g_counter = 0;
 
 #ifdef MATMUL_ONLY
-void matmul_vectorized_bfp16(bfp16ebs8 *__restrict pA, bfp16ebs8 *__restrict pB,
-                             bfp16ebs8 *__restrict pC) {
+void matmul_vectorized_bfp16(bfp16ebs8 *__restrict pA_in,
+                             bfp16ebs8 *__restrict pB_in,
+                             bfp16ebs8 *__restrict pC_in) {
   event0();
-  pC += g_counter * m * n / 8; // divde by 8 because 1 address have 8 data
-  if (g_counter == DIV - 1) {
-    g_counter = 0;
-  } else {
-    g_counter = g_counter + 1;
-  }
+  // Round-to-nearest-even (Peano defaults to floor on converts).
+  aie::set_rounding(aie::rounding_mode::conv_even);
 
-  int run_num = 1;
-  for (int run = 0; run < run_num; run++) {
-    // each ouput block contains 8x8 elements
-    for (int block_row = 0; block_row < m / 16; block_row = block_row + 1) {
-      for (int block_col = 0; block_col < n / 16; block_col = block_col + 1) {
+  // sizeof(bfp16ebs8) == 1 on Peano: pointer arithmetic below is byte
+  // arithmetic (64-element block = 72 bytes; C stripe = m_a*n/8*9 bytes).
+  const bfp16ebs8 __aie_dm_resource_a *__restrict pA =
+      (const bfp16ebs8 __aie_dm_resource_a *)pA_in;
+  const bfp16ebs8 __aie_dm_resource_b *__restrict pB =
+      (const bfp16ebs8 __aie_dm_resource_b *)pB_in;
+  bfp16ebs8 __aie_dm_resource_c *__restrict pC =
+      (bfp16ebs8 __aie_dm_resource_c *)pC_in + g_counter * (m_a * n / 8 * 9);
+  g_counter = (g_counter == rho - 1) ? 0 : g_counter + 1;
 
-        aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pB_stream(pB);
-        pB_stream.seek(2 * block_col * k / 8);
+  using AStream = InBufStream<bfp16ebs8, r * s, aie_dm_resource::a>;
+  using BStream = InBufStream<bfp16ebs8, s * t, aie_dm_resource::b>;
+  using CInStream = InBufStream<bfp16ebs8, r * t, aie_dm_resource::c>;
+  using COutStream = OutBufStream<bfp16ebs8, r * t, aie_dm_resource::c>;
+  using MMUL = aie::mmul<r, s, t, bfp16ebs8>;
 
-        aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream(pA);
-        int A_stream_index = 2 * block_row * k / 8;
-        pA_stream.seek(A_stream_index);
+  // Persistent C streams over the stripe in linear block order. The prefetch
+  // pops run one block ahead: the last iteration reads 288 bytes past the
+  // stripe (unused, stays in tile data memory).
+  CInStream cin(pC);
+  COutStream cout(pC);
 
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex0) A0_data_bfp =
-            pA_stream.pop();
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex2) A1_data_bfp =
-            pA_stream.pop();
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex1) B0_data_bfp =
-            pB_stream.pop();
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex3) B1_data_bfp =
-            pB_stream.pop();
+  // Prologue: prefetch C-in vectors for block 0.
+  aie::block_vector<bfp16ebs8, r * t> c0 = cin.pop();
+  aie::block_vector<bfp16ebs8, r * t> c1 = cin.pop();
+  aie::block_vector<bfp16ebs8, r * t> c2 = cin.pop();
+  aie::block_vector<bfp16ebs8, r * t> c3 = cin.pop();
 
-        int C_stream_index = (block_row * n / 16 + block_col) * 4;
-        aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pC0In_stream(pC);
-        pC0In_stream.seek(C_stream_index);
-        aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pC1In_stream(pC);
-        pC1In_stream.seek(C_stream_index + 2);
+  int br = 0, bc = 0;
+  // aie-gpr-realloc: II 79 -> 77. pipeline(disable) hands the loop directly
+  // to the post-RA pipeliner: II 89 -> 77.
+  AIE_LOOP_GPR_REALLOC
+  AIE_PREPARE_FOR_POSTPIPELINING
+  for (int blk = 0; blk < nblk; blk++) {
+    // Fresh A/B streams per block at computed bases (no seek fifo ops).
+    // One 2r-row A band (resp. 2t-col B band) holds 2*k/s stream blocks.
+    AStream a_stream(pA + br * (2 * k / s) * blk_bytes);
+    BStream b_stream(pB + bc * (2 * k / s) * blk_bytes);
 
-        aie::accum<accfloat, 64> chess_storage(dm0)
-            acc0_data(pC0In_stream.pop());
-        aie::accum<accfloat, 64> chess_storage(dm2)
-            acc1_data(pC0In_stream.pop());
-        aie::accum<accfloat, 64> chess_storage(dm1)
-            acc2_data(pC1In_stream.pop());
-        aie::accum<accfloat, 64> chess_storage(dm3)
-            acc3_data(pC1In_stream.pop());
+    MMUL acc0((aie::accum<accfloat, r * t>(c0)));
+    MMUL acc1((aie::accum<accfloat, r * t>(c1)));
+    MMUL acc2((aie::accum<accfloat, r * t>(c2)));
+    MMUL acc3((aie::accum<accfloat, r * t>(c3)));
 
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex4) A0_data_bfp_pong =
-            pA_stream.pop();
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex6) A1_data_bfp_pong =
-            pA_stream.pop();
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex5) B0_data_bfp_pong =
-            pB_stream.pop();
-        aie::block_vector<bfp16ebs8, 64> chess_storage(ex7) B1_data_bfp_pong =
-            pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-        A0_data_bfp = pA_stream.pop();
-        A1_data_bfp = pA_stream.pop();
-        B0_data_bfp = pB_stream.pop();
-        B1_data_bfp = pB_stream.pop();
-
-        acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-        A0_data_bfp_pong = pA_stream.pop();
-        A1_data_bfp_pong = pA_stream.pop();
-        B0_data_bfp_pong = pB_stream.pop();
-        B1_data_bfp_pong = pB_stream.pop();
-
-        acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-        acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-        acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-        acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> pC0Out_stream(pC);
-        pC0Out_stream.seek(C_stream_index);
-        pC0Out_stream.push(acc0_data.template to_vector<bfp16ebs8>());
-        pC0Out_stream.push(acc1_data.template to_vector<bfp16ebs8>());
-        pC0Out_stream.push(acc2_data.template to_vector<bfp16ebs8>());
-        pC0Out_stream.push(acc3_data.template to_vector<bfp16ebs8>());
+    // One k-step: 2 A pops + 2 B pops + 4 8x8x8 MACs. On fill steps (B pops
+    // 0 and 8 of each 16-pop buffer) B pops come first so the fifo_ld_fill
+    // emits ahead of the A-stream ops.
+    auto kstep = [&]<bool BFILL>() __attribute__((always_inline)) {
+      aie::block_vector<bfp16ebs8, r * s> A0, A1; // r x s A panels
+      aie::block_vector<bfp16ebs8, s * t> B0, B1; // s x t B panels
+      if constexpr (BFILL) {
+        B0 = b_stream.pop();
+        B1 = b_stream.pop();
+        A0 = a_stream.pop();
+        A1 = a_stream.pop();
+      } else {
+        A0 = a_stream.pop();
+        A1 = a_stream.pop();
+        B0 = b_stream.pop();
+        B1 = b_stream.pop();
       }
-    }
+      acc0.mac(A0, aie::op_transpose(B0));
+      acc1.mac(A0, aie::op_transpose(B1));
+      acc2.mac(A1, aie::op_transpose(B0));
+      acc3.mac(A1, aie::op_transpose(B1));
+    };
+    kstep.operator()<true>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<true>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+    kstep.operator()<false>();
+
+    // Prefetch next block's C (read region is never written by this call).
+    c0 = cin.pop();
+    c1 = cin.pop();
+    c2 = cin.pop();
+    c3 = cin.pop();
+
+    cout.push(acc0.template to_vector<bfp16ebs8>());
+    cout.push(acc1.template to_vector<bfp16ebs8>());
+    cout.push(acc2.template to_vector<bfp16ebs8>());
+    cout.push(acc3.template to_vector<bfp16ebs8>());
+
+    bc = (bc == nbc - 1) ? 0 : bc + 1;
+    br += (bc == 0) ? 1 : 0;
   }
+
+  event1();
 }
 #endif
 
 #ifdef ZERO_ONLY
 void zero_kernel(bfp16ebs8 *__restrict cOut) {
-  zero_vectorized_v64bfp16ebs8<DIM_M, DIM_N>(cOut);
+  const aie::accum<accfloat, r * t> acc = aie::zeros<accfloat, r * t>();
+  OutBufStream<bfp16ebs8, r * t, aie_dm_resource::c> out_stream(cOut);
+  for (int i = 0; i < m * n / (r * t); i++) {
+    out_stream.push(acc.template to_vector<bfp16ebs8>());
+  }
 }
 #endif
 }

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/n32_core.py
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/n32_core.py
@@ -8,7 +8,7 @@
 
 All-bfp16 variant of the config1 design: A, B, and C are
 ``v8bfp16ebs8``; each AIE2P core's L1 A-tile is (m//DIV, k//8) with
-asymmetry ratio DIV=6. Strix-only; chess-built kernel.
+asymmetry ratio DIV=6. Strix-only; Peano-built kernel.
 """
 
 import argparse
@@ -67,9 +67,6 @@ def n32_core_gemm(
     C_l1_ty = np.ndarray[(m, n // 8), np.dtype[v8bfp16ebs8]]
 
     kernel_flags = [
-        f"-DDIM_M={m}",
-        f"-DDIM_K={k}",
-        f"-DDIM_N={n}",
         f"-I{_AIE_KERNELS_INC}",
     ]
 
@@ -78,14 +75,22 @@ def n32_core_gemm(
         source_file=str(_KERNEL_SRC),
         arg_types=[C_l1_ty],
         compile_flags=kernel_flags + ["-DZERO_ONLY"],
-        use_chess=True,
     )
+    # The flat pipelined block loop in the matmul kernel has ResMII=68, which
+    # exceeds the post-RA pipeliner's default max II (60); raise the cap and
+    # the retry budget for this TU.
     matmul_kernel = ExternalFunction(
         "matmul_vectorized_bfp16",
         source_file=str(_KERNEL_SRC),
         arg_types=[A_l1_ty, B_l1_ty, C_l1_ty],
-        compile_flags=kernel_flags + ["-DMATMUL_ONLY"],
-        use_chess=True,
+        compile_flags=kernel_flags
+        + [
+            "-DMATMUL_ONLY",
+            "-mllvm",
+            "-aie-postpipeliner-maxii=120",
+            "-mllvm",
+            "-aie-postpipeliner-maxtry-ii=50",
+        ],
     )
 
     A_l3l2_fifos: list[ObjectFifo] = []

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/run_strix_makefile.lit
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/run_strix_makefile.lit
@@ -1,11 +1,11 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai_npu2, chess
+// REQUIRES: ryzen_ai_npu2, peano
 // REQUIRES: makefile_examples
 //
-// RUN: mkdir -p test_stx_chess
-// RUN: cd test_stx_chess
+// RUN: mkdir -p test_stx
+// RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2
 // RUN: %run_on_npu2% make -f %S/Makefile devicename=npu2 run

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/mm_bfp_mixed.cc
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/mm_bfp_mixed.cc
@@ -5,469 +5,172 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "aie_kernel_utils.h"
+// ATB microkernel; C is accumulated in bf16: the kernel rotates over 4
+// stripes (stripes 0/1 alias the first 2*m*n bf16 of the bfp16 C tile,
+// stripes 2/3 live in the TU-local staging buffer) and converts both halves
+// to bfp16ebs8 in place after (K_Problemsize/k)*DIV calls.
+//
+// Compute structure (config1-style): per call, 2 block rows x 8 blocks of
+// 16x16; each block runs 8 expanded k-steps (2 A pops + 2 B pops + 4 8x8x8
+// MACs, B-first at fill steps 0 and 4) in a post-RA-pipelined blk loop with
+// next-block C prefetch. Measured II=41, NS=2.
+
 #include <aie_api/aie.hpp>
 
-// The kernel's `c_bf16_2nd_half` BF16 staging buffer is flushed back to the
-// BFP-encoded C output once per output tile, after exactly
-// (K_Problemsize / k) * DIV matmul calls. The flush count is fixed at compile
-// time, so this kernel only supports K = K_Problemsize at runtime. Both this
-// example's Makefile default and the lit test pin K to this value; running
-// at a different K via CLI override is not supported by this kernel.
+template <typename T, unsigned N, aie_dm_resource R>
+using InBufStream = aie::block_vector_restrict_input_buffer_stream<T, N, R>;
+template <typename T, unsigned N, aie_dm_resource R>
+using OutBufStream = aie::block_vector_output_buffer_stream<T, N, R>;
+
+// The bf16 -> bfp16 flush happens once per output tile, after exactly
+// (K_Problemsize / k) * DIV matmul calls; this kernel only supports
+// K = K_Problemsize.
 constexpr int K_Problemsize = 4096;
-constexpr int DIV = 4;
-constexpr int M = 128 / 4;
-constexpr int K = 64;
-constexpr int N = 128;
-constexpr int m = 128 / 4;
+constexpr int rho = 4;
+constexpr int m = 128 / rho;
 constexpr int k = 64;
 constexpr int n = 128;
-constexpr int r = 8;
-constexpr int s = 8;
-constexpr int t = 8;
 
-alignas(aie::vector_decl_align) bfloat16 c_bf16_2nd_half[m * DIV * n / 2];
+// aie::mmul sub-tile shape (the only shape supported for bfp16ebs8 on
+// AIE2P): per MAC, an r x s A panel times an s x t B panel accumulates
+// into r x t of C. C blocks are stored block-linearly: each (2r)x(2t)
+// block is 4 consecutive r x t panels (offsets 0, rt, 2rt, 3rt).
+constexpr int r = 8; // MAC rows (A/C)
+constexpr int s = 8; // MAC reduction step (k-columns per MAC)
+constexpr int t = 8; // MAC columns (B/C)
 
-template <int Mz, int Nz>
-void zero_vectorized_v64bfp16ebs8(bfp16ebs8 *__restrict cOut) {
+// bf16 vector width for the flush/zero passes.
+constexpr int vec = 64;
 
-  bfloat16 *c_ptr_bf16 = (bfloat16 *)cOut;
-  const aie::vector<bfloat16, 64> zeros = aie::zeros<bfloat16, 64>();
-  for (int i = 0; i < m * DIV * n / 64 / 2; i++) {
-    aie::store_v(c_ptr_bf16 + i * 64, zeros);
-  }
+static_assert(m * rho == 128 && k == 64 && n == 128 && rho == 4);
 
-  bfloat16 *c_bf16_2nd_half_ptr = c_bf16_2nd_half;
-  for (int i = 0; i < m * DIV * n / 64 / 2; i++) {
-    aie::store_v(c_bf16_2nd_half_ptr + i * 64, zeros);
-  }
-}
+// bf16 staging for C stripes 2 and 3. matmul and zero share this buffer, so
+// both ExternalFunctions must point at the same .o (see n32_core.py).
+alignas(aie::vector_decl_align) bfloat16 c_bf16_2nd_half[m * rho * n / 2];
 
 extern "C" {
 
 static int g_counter = 0;
-
 static int k_counter = 0;
 
-// matmul + zero share the TU-local `c_bf16_2nd_half` staging buffer
-// (matmul accumulates into it, zero clears it), so we can't split them
-// into per-symbol .o builds the way mm_bfp.cc allows. The @iron.jit
-// design points both ExternalFunctions at the same .o; chess emits
-// both symbols here and the link picks one resolution per symbol.
-
-void matmul_vectorized_bfp16(bfp16ebs8 *__restrict pA, bfp16ebs8 *__restrict pB,
+void matmul_vectorized_bfp16(bfp16ebs8 *__restrict pA_in,
+                             bfp16ebs8 *__restrict pB_in,
                              bfp16ebs8 *__restrict pC_bfp16) {
+  event0();
+  // Round-to-nearest-even (Peano defaults to floor on converts).
+  aie::set_rounding(aie::rounding_mode::conv_even);
 
-  bfloat16 *pC;
-  if (g_counter == 0) {
-    pC = (bfloat16 *)pC_bfp16;
-  } else if (g_counter == 1) {
-    pC = (bfloat16 *)pC_bfp16;
-    pC += 1 * m * n;
-  } else if (g_counter == 2) {
-    pC = c_bf16_2nd_half;
-  } else {
-    pC = c_bf16_2nd_half + 1 * m * n;
-  }
+  using AStream = InBufStream<bfp16ebs8, r * s, aie_dm_resource::a>;
+  using BStream = InBufStream<bfp16ebs8, s * t, aie_dm_resource::b>;
+  using CPtr = bfloat16 __aie_dm_resource_c *__restrict;
+  using MMUL = aie::mmul<r, s, t, bfp16ebs8>;
 
-  if (g_counter == DIV - 1) {
-    g_counter = 0;
-  } else {
-    g_counter = g_counter + 1;
-  }
-  int run_num = 1;
-  for (int run = 0; run < run_num; run++) {
-    for (int i = 0; i < m * n / (16 * 16); i = i + 4) {
-      int block_row = i / (n / 16);
-      int block_col = i % (n / 16);
+  const bfp16ebs8 *pA_base = (const bfp16ebs8 *)pA_in;
 
-      int A_stream_index = block_row * 2 * k / 8;
-      int B_stream_index = block_col * (k / 8) * 2;
+  bfloat16 *const pC_sel = (g_counter < 2)
+                               ? (bfloat16 *)pC_bfp16 + g_counter * (m * n)
+                               : c_bf16_2nd_half + (g_counter - 2) * (m * n);
+  g_counter = (g_counter == rho - 1) ? 0 : g_counter + 1;
+  CPtr const pC_base = (CPtr)pC_sel;
 
-      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pB_stream(pB);
-      pB_stream.seek(B_stream_index);
-      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream(pA);
-      pA_stream.seek(A_stream_index);
+  for (int br = 0; br < m / (2 * r); br++) {
+    // Persistent sliding B stream per block row (16 pops per block).
+    BStream b_stream(pB_in);
+    {
+      CPtr pC = pC_base + br * (n / (2 * t)) * (4 * r * t);
 
-      aie::accum<accfloat, 64> chess_storage(dm1)
-          acc0_data(aie::load_v<64>(pC));
-      aie::accum<accfloat, 64> chess_storage(dm2)
-          acc1_data(aie::load_v<64>(pC + 64));
-      aie::accum<accfloat, 64> chess_storage(dm3)
-          acc2_data(aie::load_v<64>(pC + 128));
-      aie::accum<accfloat, 64> chess_storage(dm4)
-          acc3_data(aie::load_v<64>(pC + 192));
+      aie::vector<bfloat16, r * t> c0 = aie::load_v<r * t>(pC);
+      aie::vector<bfloat16, r * t> c1 = aie::load_v<r * t>(pC + r * t);
+      for (int blk = 0; blk < n / (2 * t); blk++) {
+        // C blocks are stored block-linearly (4*r*t bf16 per 2rx2t block).
+        CPtr pCb = pC + blk * (4 * r * t);
+        CPtr pNext = (blk < n / (2 * t) - 1) ? pCb + 4 * r * t : pCb;
 
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex0) A0_data_bfp;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex1) A1_data_bfp;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex2) B0_data_bfp;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex3) B1_data_bfp;
+        MMUL acc0((aie::accum<accfloat, r * t>(c0)));
+        MMUL acc1((aie::accum<accfloat, r * t>(c1)));
+        MMUL acc2(
+            (aie::accum<accfloat, r * t>(aie::load_v<r * t>(pCb + 2 * r * t))));
+        MMUL acc3(
+            (aie::accum<accfloat, r * t>(aie::load_v<r * t>(pCb + 3 * r * t))));
 
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex4) A0_data_bfp_pong;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex6) A1_data_bfp_pong;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex5) B0_data_bfp_pong;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex7) B1_data_bfp_pong;
+        // Prefetch next block's first C pair while this block computes.
+        c0 = aie::load_v<r * t>(pNext);
+        c1 = aie::load_v<r * t>(pNext + r * t);
 
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex8) A0_data_bfp_2;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex9) A1_data_bfp_2;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex10) B0_data_bfp_2;
-      aie::block_vector<bfp16ebs8, 64> chess_storage(ex11) B1_data_bfp_2;
+        // Fresh A stream per block: re-reads this block row's 16-block band
+        // (fills constant-fold before pops 0 and 8).
+        AStream a_stream(pA_base);
+        a_stream.seek(br * (2 * k / s));
 
-      A0_data_bfp = pA_stream.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream.pop();
-      B1_data_bfp = pB_stream.pop();
+        // One k-step: 2 A pops + 2 B pops + 4 8x8x8 MACs. On fill steps
+        // (B pops 0 and 8 of each 16-pop buffer) B pops come first so the
+        // fifo_ld_fill emits ahead of the A-stream ops.
+        auto kstep = [&]<bool BFILL>() __attribute__((always_inline)) {
+          aie::block_vector<bfp16ebs8, r * s> A0, A1; // r x s A panels
+          aie::block_vector<bfp16ebs8, s * t> B0, B1; // s x t B panels
+          if constexpr (BFILL) {
+            B0 = b_stream.pop();
+            B1 = b_stream.pop();
+            A0 = a_stream.pop();
+            A1 = a_stream.pop();
+          } else {
+            A0 = a_stream.pop();
+            A1 = a_stream.pop();
+            B0 = b_stream.pop();
+            B1 = b_stream.pop();
+          }
+          acc0.mac(A0, aie::op_transpose(B0));
+          acc1.mac(A0, aie::op_transpose(B1));
+          acc2.mac(A1, aie::op_transpose(B0));
+          acc3.mac(A1, aie::op_transpose(B1));
+        };
+        kstep.operator()<true>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
+        kstep.operator()<true>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
+        kstep.operator()<false>();
 
-      A0_data_bfp_pong = pA_stream.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream2(pA);
-      pA_stream2.seek(A_stream_index);
-
-      A0_data_bfp_2 = pA_stream2.pop();
-      B0_data_bfp_2 = pB_stream.pop();
-      A1_data_bfp_2 = pA_stream2.pop();
-      B1_data_bfp_2 = pB_stream.pop();
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream2.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream2.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-
-      aie::store_v(pC, acc0_data.template to_vector<bfloat16>());
-      acc0_data = aie::load_v<64>(pC + 256);
-      aie::store_v(pC + 64, acc1_data.template to_vector<bfloat16>());
-      acc1_data = aie::load_v<64>(pC + 320);
-      aie::store_v(pC + 128, acc2_data.template to_vector<bfloat16>());
-      acc2_data = aie::load_v<64>(pC + 384);
-      aie::store_v(pC + 192, acc3_data.template to_vector<bfloat16>());
-      acc3_data = aie::load_v<64>(pC + 448);
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-      A0_data_bfp_2 = pA_stream2.pop();
-      B0_data_bfp_2 = pB_stream.pop();
-      A1_data_bfp_2 = pA_stream2.pop();
-      B1_data_bfp_2 = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream2.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream2.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-      A0_data_bfp_2 = pA_stream2.pop();
-      B0_data_bfp_2 = pB_stream.pop();
-      A1_data_bfp_2 = pA_stream2.pop();
-      B1_data_bfp_2 = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream2.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream2.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-      A0_data_bfp_2 = pA_stream2.pop();
-      B0_data_bfp_2 = pB_stream.pop();
-      A1_data_bfp_2 = pA_stream2.pop();
-      B1_data_bfp_2 = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream2.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream2.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_2, B0_data_bfp_2, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_2, B1_data_bfp_2, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_2, B0_data_bfp_2, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_2, B1_data_bfp_2, acc3_data);
-
-      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream3(pA);
-      pA_stream3.seek(A_stream_index);
-
-      A0_data_bfp = pA_stream3.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream3.pop();
-      B1_data_bfp = pB_stream.pop();
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream3.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream3.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-
-      aie::store_v(pC + 256, acc0_data.template to_vector<bfloat16>());
-      acc0_data = aie::load_v<64>(pC + 512);
-      aie::store_v(pC + 320, acc1_data.template to_vector<bfloat16>());
-      acc1_data = aie::load_v<64>(pC + 576);
-      aie::store_v(pC + 384, acc2_data.template to_vector<bfloat16>());
-      acc2_data = aie::load_v<64>(pC + 640);
-      aie::store_v(pC + 448, acc3_data.template to_vector<bfloat16>());
-      acc3_data = aie::load_v<64>(pC + 704);
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream3.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream3.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream3.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream3.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream3.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream3.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream3.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream3.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream3.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream3.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream3.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream3.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pA_stream4(pA);
-      pA_stream4.seek(A_stream_index);
-
-      A0_data_bfp = pA_stream4.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream4.pop();
-      B1_data_bfp = pB_stream.pop();
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream4.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream4.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-
-      aie::store_v(pC + 512, acc0_data.template to_vector<bfloat16>());
-      acc0_data = aie::load_v<64>(pC + 768);
-      aie::store_v(pC + 576, acc1_data.template to_vector<bfloat16>());
-      acc1_data = aie::load_v<64>(pC + 832);
-      aie::store_v(pC + 640, acc2_data.template to_vector<bfloat16>());
-      acc2_data = aie::load_v<64>(pC + 896);
-      aie::store_v(pC + 704, acc3_data.template to_vector<bfloat16>());
-      acc3_data = aie::load_v<64>(pC + 960);
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream4.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream4.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream4.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream4.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream4.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream4.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream4.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream4.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-      A0_data_bfp = pA_stream4.pop();
-      B0_data_bfp = pB_stream.pop();
-      A1_data_bfp = pA_stream4.pop();
-      B1_data_bfp = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      A0_data_bfp_pong = pA_stream4.pop();
-      B0_data_bfp_pong = pB_stream.pop();
-      A1_data_bfp_pong = pA_stream4.pop();
-      B1_data_bfp_pong = pB_stream.pop();
-      acc0_data = mac_8x8_8x8T(A0_data_bfp, B0_data_bfp, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp, B1_data_bfp, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp, B0_data_bfp, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp, B1_data_bfp, acc3_data);
-
-      acc0_data = mac_8x8_8x8T(A0_data_bfp_pong, B0_data_bfp_pong, acc0_data);
-      acc1_data = mac_8x8_8x8T(A0_data_bfp_pong, B1_data_bfp_pong, acc1_data);
-      acc2_data = mac_8x8_8x8T(A1_data_bfp_pong, B0_data_bfp_pong, acc2_data);
-      acc3_data = mac_8x8_8x8T(A1_data_bfp_pong, B1_data_bfp_pong, acc3_data);
-
-      aie::store_v(pC + 768, acc0_data.template to_vector<bfloat16>());
-      aie::store_v(pC + 832, acc1_data.template to_vector<bfloat16>());
-      aie::store_v(pC + 896, acc2_data.template to_vector<bfloat16>());
-      aie::store_v(pC + 960, acc3_data.template to_vector<bfloat16>());
-
-      pC += 256 * 4;
+        aie::store_v(pCb, acc0.template to_vector<bfloat16>());
+        aie::store_v(pCb + r * t, acc1.template to_vector<bfloat16>());
+        aie::store_v(pCb + 2 * r * t, acc2.template to_vector<bfloat16>());
+        aie::store_v(pCb + 3 * r * t, acc3.template to_vector<bfloat16>());
+      }
     }
   }
 
-  if (k_counter == (K_Problemsize / k) * DIV - 1) { // // K / k  *  DIV
+  // Full accumulation done: convert both bf16 halves to bfp16ebs8 blocks in
+  // place (reads stay ahead of writes: 128B/iter read vs 72B/iter written).
+  if (k_counter == (K_Problemsize / k) * rho - 1) {
     k_counter = 0;
-    // inplace convert the first half BF16 to pC_bfp16
-    aie::block_vector_output_buffer_stream<bfp16ebs8, 64> pCOut_stream_first(
-        pC_bfp16);
-    pCOut_stream_first.seek(0);
+    OutBufStream<bfp16ebs8, r * t, aie_dm_resource::c> out_stream(pC_bfp16);
 
-    bfloat16 *pC_bf16;
-    pC_bf16 = (bfloat16 *)pC_bfp16;
-    for (int i = 0; i < m * DIV * n / 2 / 64; i++) {
-      aie::accum<accfloat, 64> acc_data(aie::load_v<64>(pC_bf16));
-      pC_bf16 += 64;
-      pCOut_stream_first.push(acc_data.template to_vector<bfp16ebs8>());
+    CPtr pC_bf16 = (CPtr)pC_bfp16;
+    for (int i = 0; i < m * rho * n / 2 / vec; i++) {
+      aie::accum<accfloat, vec> acc_data(aie::load_v<vec>(pC_bf16 + i * vec));
+      out_stream.push(acc_data.template to_vector<bfp16ebs8>());
     }
-
-    bfloat16 *c_bf16_2nd_half_ptr = c_bf16_2nd_half;
-    for (int i = 0; i < m * DIV * n / 2 / 64; i++) {
-      aie::accum<accfloat, 64> acc_data(aie::load_v<64>(c_bf16_2nd_half_ptr));
-      c_bf16_2nd_half_ptr += 64;
-      pCOut_stream_first.push(acc_data.template to_vector<bfp16ebs8>());
+    CPtr pC_2nd = (CPtr)c_bf16_2nd_half;
+    for (int i = 0; i < m * rho * n / 2 / vec; i++) {
+      aie::accum<accfloat, vec> acc_data(aie::load_v<vec>(pC_2nd + i * vec));
+      out_stream.push(acc_data.template to_vector<bfp16ebs8>());
     }
   } else {
     k_counter += 1;
   }
+  event1();
 }
 
 void zero_kernel(bfp16ebs8 *__restrict cOut) {
-  zero_vectorized_v64bfp16ebs8<DIM_M, DIM_N>(cOut);
+  const aie::vector<bfloat16, vec> zeros = aie::zeros<bfloat16, vec>();
+  bfloat16 __aie_dm_resource_c *__restrict p0 =
+      (bfloat16 __aie_dm_resource_c *)cOut;
+  for (int i = 0; i < m * rho * n / vec / 2; i++)
+    aie::store_v(p0 + i * vec, zeros);
+  bfloat16 *__restrict p1 = c_bf16_2nd_half;
+  for (int i = 0; i < m * rho * n / vec / 2; i++)
+    aie::store_v(p1 + i * vec, zeros);
 }
 }

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/n32_core.py
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/n32_core.py
@@ -8,7 +8,7 @@
 
 Same shape family as config2 (all-bfp16 inputs/outputs, 32 cores) but
 with asymmetry ratio DIV=4 and an alternate hand-tuned microkernel
-schedule. Strix-only; chess-built kernel.
+schedule (bf16-staged C accumulation). Strix-only; Peano-built kernel.
 """
 
 import argparse
@@ -67,15 +67,12 @@ def n32_core_gemm(
     C_l1_ty = np.ndarray[(m, n // 8), np.dtype[v8bfp16ebs8]]
 
     kernel_flags = [
-        f"-DDIM_M={m}",
-        f"-DDIM_K={k}",
-        f"-DDIM_N={n}",
         f"-I{_AIE_KERNELS_INC}",
     ]
 
     # mm_bfp_mixed.cc keeps a TU-local staging buffer that matmul and
     # zero share, so we point both ExternalFunctions at the same .o
-    # (one chess compile, both symbols emitted, link picks each per call).
+    # (one compile, both symbols emitted, link picks each per call).
     _SHARED_OBJ = "mm_bfp_mixed.o"
     zero_kernel = ExternalFunction(
         "zero_kernel",
@@ -83,7 +80,6 @@ def n32_core_gemm(
         source_file=str(_KERNEL_SRC),
         arg_types=[C_l1_ty],
         compile_flags=kernel_flags,
-        use_chess=True,
     )
     matmul_kernel = ExternalFunction(
         "matmul_vectorized_bfp16",
@@ -91,7 +87,6 @@ def n32_core_gemm(
         source_file=str(_KERNEL_SRC),
         arg_types=[A_l1_ty, B_l1_ty, C_l1_ty],
         compile_flags=kernel_flags,
-        use_chess=True,
     )
 
     A_l3l2_fifos: list[ObjectFifo] = []
@@ -156,6 +151,11 @@ def n32_core_gemm(
                 matmul_kernel,
             ],
             stack_size=0xF00,
+            # Reserve the kernel's static data explicitly: mm_bfp_mixed.cc
+            # holds the bf16 C staging buffer (c_bf16_2nd_half, 16384 B) plus
+            # two counters in .bss. Buffer allocation leaves < 14 KB
+            # contiguous on each core, so the link fails without this.
+            data_size=m * n // 2 * 2 + 8,
         ),
     )
 

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/run_strix_makefile.lit
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/run_strix_makefile.lit
@@ -1,11 +1,11 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai_npu2, chess
+// REQUIRES: ryzen_ai_npu2, peano
 // REQUIRES: makefile_examples
 //
-// RUN: mkdir -p test_stx_chess
-// RUN: cd test_stx_chess
+// RUN: mkdir -p test_stx
+// RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2
 // RUN: %run_on_npu2% make -f %S/Makefile devicename=npu2 run

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/lit.local.cfg
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/lit.local.cfg
@@ -1,4 +1,0 @@
-# Copyright (C) 2026 Advanced Micro Devices, Inc.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-config.parallelism_group = "atb_chess"


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Key notes:
- This is an autoresearch-style rewrite. Peano kernels are II-maxxed for current Peano version. To further increase II, some extra changes outside of this repository needed (https://github.com/Xilinx/aie_api/issues/14 and more, maybe https://github.com/Xilinx/llvm-aie/issues/1066 as well). Going into intrinsic level allows to shave more cycles, but such solution barely helps the infra (I'd better see all these missing bank remarks addressed elsewhere)
- The rewrite is a round-trip from non-XRT stack, where it is represented as jinja2 template - https://gist.github.com/AngryLoki/fe72777d9754942e834e12498c23c640 (which served as a testbed)
- While seemingly it removes some `constexpr` variables (M/K/N, r/s/t), practically there are no functionality changes. These variables were unused and non-tweakable (kernels rolled out for the best k, r/s/t is hardcoded in `mac_8x8_8x8T` function name).
- New kernels were checked with the modern stack (head mlir-aie, llvm-aie, nightly xrt and xdna-driver) and compared to [2511.16041v1 Evaluation](https://arxiv.org/html/2511.16041v1#S6); Peano is on par or faster than Nov 2025 chess stack. This comparison might be not exactly fair, but seems to be ok for migration
- All kernels are zero-spill (which was essential to achieve a working result). Apart of that, all kernels apply workaround for https://github.com/Xilinx/llvm-aie/issues/1232 by switching into byte arithmetic (i. e. `bfp16ebs8 *a; a++` increments by byte, not block). This will break if llvm-aie fixes bfp16ebs8 sizing (for good)
- This reverts f1e60f02fd06856be04f2d1c6c330f77316b1e20

Closes: #3408

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
