### PR TITLE
[AIEX] Derive verifyStridesWraps BD field widths from the target model [MED]

### DIFF
--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -143,6 +143,14 @@ AIEX::verifyStridesWraps(mlir::Operation *forOp,
   auto elemWidth =
       dataLayout.getTypeSizeInBits(referencedBufType.getElementType());
 
+  // ShimPLTiles have no ShimDMA, so BD field widths are meaningless here.
+  if (!targetModel.isCoreTile(tileCol, tileRow) &&
+      !targetModel.isMemTile(tileCol, tileRow) &&
+      !targetModel.isShimNOCTile(tileCol, tileRow))
+    return forOp->emitOpError(
+        "Unsupported tile type at (" + std::to_string(tileCol) + ", " +
+        std::to_string(tileRow) + ") Must be ShimNOC, Mem or Core.");
+
   uint32_t wrap_bits = targetModel.getDmaBdWrapBits(tileCol, tileRow);
   uint32_t step_bits = targetModel.getDmaBdStepBits(tileCol, tileRow);
   uint32_t iter_bits = targetModel.getDmaBdIterBits(tileCol, tileRow);

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -143,23 +143,9 @@ AIEX::verifyStridesWraps(mlir::Operation *forOp,
   auto elemWidth =
       dataLayout.getTypeSizeInBits(referencedBufType.getElementType());
 
-  uint32_t wrap_bits = 0;
-  uint32_t step_bits = 0;
+  uint32_t wrap_bits = targetModel.getDmaBdWrapBits(tileCol, tileRow);
+  uint32_t step_bits = targetModel.getDmaBdStepBits(tileCol, tileRow);
   uint32_t iter_bits = targetModel.getDmaBdIterBits(tileCol, tileRow);
-  if (targetModel.isShimNOCTile(tileCol, tileRow)) {
-    step_bits = 20; // XAIEMLGBL_NOC_MODULE_DMA_BD0_3_D0_STEPSIZE_WIDTH
-    wrap_bits = 10; // XAIEMLGBL_NOC_MODULE_DMA_BD0_3_D0_WRAP_WIDTH
-  } else if (targetModel.isMemTile(tileCol, tileRow)) {
-    step_bits = 17; // XAIEMLGBL_MEM_TILE_MODULE_DMA_BD0_2_D0_STEPSIZE_WIDTH
-    wrap_bits = 10; // XAIEMLGBL_MEM_TILE_MODULE_DMA_BD0_2_D0_WRAP_WIDTH
-  } else if (targetModel.isCoreTile(tileCol, tileRow)) {
-    step_bits = 13; // XAIEMLGBL_MEMORY_MODULE_DMA_BD0_2_D0_STEPSIZE_WIDTH
-    wrap_bits = 8;  // XAIEMLGBL_MEMORY_MODULE_DMA_BD0_3_D0_WRAP_WIDTH
-  } else {
-    return forOp->emitOpError(
-        "Unsupported tile type at (" + std::to_string(tileCol) + ", " +
-        std::to_string(tileRow) + ") Must be ShimNOC, Mem or Core.");
-  }
 
   for (int i = 0; i < 4; i++) {
     if (inputSizes[i] <= 0) {

--- a/test/dialect/AIEX/bd_verify_shim_pl_tile_rejected.mlir
+++ b/test/dialect/AIEX/bd_verify_shim_pl_tile_rejected.mlir
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// verifyStridesWraps must reject tiles with no DMA hardware instead of
+// silently deriving BD field widths for them. xcvc1902 row 0 outside the
+// nocColumns set is ShimPLTile (AIETargetModel.h: "tiles with connections to
+// the PL, no ShimDMA"), and --aie-dma-tasks-to-npu is one of the call sites
+// with no AIE1 architecture gate.
+
+// RUN: aie-opt --verify-diagnostics --split-input-file --aie-dma-tasks-to-npu %s
+
+module {
+  aie.device(xcvc1902) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence(%arg0: memref<64xi32>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        // expected-error@+1 {{Unsupported tile type at (0, 0) Must be ShimNOC, Mem or Core.}}
+        aie.dma_bd(%arg0 : memref<64xi32> offset = 0 len = 64 sizes = [1, 1, 1, 64] strides = [0, 0, 0, 1]) {bd_id = 0 : i32}
+        aie.end
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`verifyStridesWraps` hardcodes the DMA BD stride and wrap field widths as literals. They are per-target properties the target model already knows, so the literals are a second, unchecked source of truth: a target whose BD fields differ silently gets the wrong bounds, and nothing in the build catches it.

## Fix

Two commits, the second fixing a regression the first introduced (kept separate so the sequence is readable):

1. Derive the widths from the target model instead of the literals.
2. Restore the else-branch that rejects `ShimPLTile` (no ShimDMA), which the first commit dropped when switching to accessors -- now expressed with boolean target-model accessors, with the original diagnostic text preserved.

## Test

Adds the missing `test/dialect/AIEX/bd_verify_shim_pl_tile_rejected.mlir` (xcvc1902, `tile(0,0)` outside `nocColumns`, via `--aie-dma-tasks-to-npu`), which had no coverage before.

Gate re-run independently: **182 tests across `test/dialect/AIEX` and `test/dialect/AIE` -- 181 PASS, 1 pre-existing unrelated XFAIL, 0 unexpected failures.**

A negative control confirms the restored guard is load-bearing rather than cosmetic: without it, the rejected case reaches a **hard SIGABRT** instead of a diagnostic.