### PR TITLE
[AIEX] aie-expand-load-pdi: reset only the registers the outgoing device left [LOW]

### DIFF
--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -561,6 +561,12 @@ def AIEExpandLoadPdi : Pass<"aie-expand-load-pdi", "mlir::ModuleOp"> {
               "If true, lower each load_pdi to an @ctrl_pkt_overlay load_pdi "
               "followed by aiex.npu.control_packet ops instead of write32/"
               "blockwrite ops with an empty-device reset.">,
+       Option<"clRegisterReset", "register-reset", "bool", /*default=*/"false",
+              "Replace each empty-device firmware reset with writes restoring "
+              "exactly the registers the outgoing device wrote and the incoming "
+              "one does not, using reset values from the register database. A "
+              "boundary carrying an address the database does not know keeps "
+              "its firmware reset.">,
   ];
 }
 

--- a/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
@@ -22,9 +22,11 @@
 
 #include "aie/Conversion/AIEToConfiguration/AIEToConfiguration.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/Util/AIERegisterDatabase.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Pass/Pass.h"
 
@@ -193,17 +195,195 @@ static LogicalResult transformLoadPdi(NpuLoadPdiOp loadPdiOp, ModuleOp moduleOp,
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Differential reset
+//===----------------------------------------------------------------------===//
+//
+// A device's configuration writes only the registers that device needs. Between
+// two devices, a register the outgoing one wrote and the incoming one does not
+// keeps the outgoing value: the `@empty` firmware reset is what has been
+// clearing it. Resetting by resource kind (cores, objectFIFOs, ...) cannot
+// cover this in general, because the leftover set is a property of the two
+// configurations, not of a fixed list of resource kinds. Routing is the case
+// that shows it: two devices that connect different switchbox ports write
+// disjoint slave-config registers, so neither disables the other's.
+//
+// So take the difference directly. The pass generates both configurations, so
+// the set is available to it exactly:
+//
+//     stale = addresses written by the outgoing device
+//           - addresses written by the incoming device
+//
+// Each stale address is restored to the reset value the register database
+// documents for it. An address the database does not know is not guessed at:
+// that boundary keeps its firmware reset.
+
+namespace {
+
+/// Absolute addresses one configuration segment writes, plus whether the
+/// segment contained a write whose addresses could not be determined. A segment
+/// that is not fully readable cannot be differenced: the leftover set would be
+/// missing entries, and the boundary would under-reset.
+struct ConfigSegment {
+  llvm::DenseSet<uint32_t> addresses;
+  bool opaque = false;
+};
+
+/// Collect the absolute addresses written by `op`, if it is a configuration
+/// write with a compile-time address. A blockwrite covers one word per data
+/// element from its base.
+static void collectWrittenAddresses(Operation *op, ConfigSegment &out) {
+  if (auto w = dyn_cast<AIEX::NpuWrite32Op>(op)) {
+    if (auto addr = w.getAbsoluteAddress())
+      out.addresses.insert(*addr);
+    else
+      out.opaque = true;
+    return;
+  }
+  if (auto b = dyn_cast<AIEX::NpuBlockWriteOp>(op)) {
+    auto addr = b.getAbsoluteAddress();
+    if (!addr) {
+      out.opaque = true;
+      return;
+    }
+    auto words = b.getDataWords();
+    for (unsigned i = 0, e = words.getNumElements(); i < e; ++i)
+      out.addresses.insert(*addr + 4 * i);
+    return;
+  }
+  // Any other op that configures the array is not modelled here. Writing
+  // through one and differencing anyway would under-reset the boundary.
+  if (isa<AIEX::NpuBlockWriteValuesOp, AIEX::NpuMaskWrite32Op,
+          AIEX::NpuAddressPatchOp>(op))
+    out.opaque = true;
+}
+
+/// The register-database module name for the tile `addr` lands in, or nullptr
+/// if the address does not resolve to a tile this target has.
+static const char *moduleForAddress(const AIE::AIETargetModel &tm,
+                                    uint32_t addr) {
+  int col = (addr >> tm.getColumnShift()) & 0xFF;
+  int row = (addr >> tm.getRowShift()) & 0xFF;
+  if (col >= (int)tm.columns() || row >= (int)tm.rows())
+    return nullptr;
+  if (tm.isCoreTile(col, row))
+    return "core";
+  if (tm.isMemTile(col, row))
+    return "memory_tile";
+  if (tm.isShimNOCTile(col, row) || tm.isShimPLTile(col, row))
+    return "shim";
+  return nullptr;
+}
+
+/// Reset value the database documents for `addr`, or nullopt when the address
+/// has no entry. Nullopt means "do not guess", not "zero".
+static std::optional<uint32_t> resetValueFor(const AIE::AIETargetModel &tm,
+                                             const AIE::RegisterDatabase &db,
+                                             uint32_t addr) {
+  const char *module = moduleForAddress(tm, addr);
+  if (!module)
+    return std::nullopt;
+  uint32_t offset = addr & ((1u << tm.getRowShift()) - 1);
+  const AIE::RegisterInfo *reg = db.lookupRegisterByOffset(offset, module);
+  if (!reg)
+    return std::nullopt;
+  uint32_t value = 0;
+  if (llvm::StringRef(reg->reset).trim().getAsInteger(0, value))
+    return std::nullopt;
+  return value;
+}
+
+} // namespace
+
+/// Replace each firmware reset with writes that restore exactly the registers
+/// the outgoing device left behind. A boundary whose leftover set contains an
+/// address the register database does not know keeps its firmware reset.
+static void applyDifferentialReset(ModuleOp module) {
+  std::unique_ptr<AIE::RegisterDatabase> db = AIE::RegisterDatabase::loadAIE2();
+  if (!db)
+    return;
+
+  module.walk([&](AIE::RuntimeSequenceOp seq) {
+    const AIE::AIETargetModel &tm = AIE::getTargetModel(seq.getOperation());
+
+    // Segment the sequence at each preload: everything up to the next preload
+    // is one device's configuration.
+    SmallVector<std::pair<NpuLoadPdiOp, ConfigSegment>> segments;
+    seq.walk([&](Operation *op) {
+      if (auto loadPdi = dyn_cast<NpuLoadPdiOp>(op)) {
+        segments.emplace_back(loadPdi, ConfigSegment{});
+        return;
+      }
+      if (!segments.empty())
+        collectWrittenAddresses(op, segments.back().second);
+    });
+
+    // The first preload has no predecessor to undo, so it stays a firmware
+    // reset. Later ones can be replaced.
+    for (unsigned i = 1; i < segments.size(); ++i) {
+      // Either side unreadable means the difference is not trustworthy.
+      if (segments[i - 1].second.opaque || segments[i].second.opaque)
+        continue;
+
+      SmallVector<uint32_t> stale;
+      for (uint32_t addr : segments[i - 1].second.addresses)
+        if (!segments[i].second.addresses.contains(addr))
+          stale.push_back(addr);
+      llvm::sort(stale);
+
+      SmallVector<std::pair<uint32_t, uint32_t>> resets;
+      bool resolvable = true;
+      for (uint32_t addr : stale) {
+        std::optional<uint32_t> value = resetValueFor(tm, *db, addr);
+        if (!value) {
+          resolvable = false;
+          break;
+        }
+        resets.emplace_back(addr, *value);
+      }
+      if (!resolvable)
+        continue;
+
+      NpuLoadPdiOp preload = segments[i].first;
+      OpBuilder builder(preload);
+      Location loc = preload.getLoc();
+      for (auto [addr, value] : resets) {
+        auto addrOp = arith::ConstantOp::create(
+            builder, loc,
+            builder.getI32IntegerAttr(static_cast<int32_t>(addr)));
+        auto valueOp = arith::ConstantOp::create(
+            builder, loc,
+            builder.getI32IntegerAttr(static_cast<int32_t>(value)));
+        NpuWrite32Op::create(builder, loc, addrOp, valueOp,
+                             /*buffer=*/nullptr, /*column=*/nullptr,
+                             /*row=*/nullptr);
+      }
+      preload.erase();
+    }
+  });
+}
+
 struct AIEExpandLoadPdiPass
     : public xilinx::AIEX::impl::AIEExpandLoadPdiBase<AIEExpandLoadPdiPass> {
   using AIEExpandLoadPdiBase::AIEExpandLoadPdiBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry
-        .insert<memref::MemRefDialect, AIE::AIEDialect, AIEX::AIEXDialect>();
+    registry.insert<arith::ArithDialect, memref::MemRefDialect, AIE::AIEDialect,
+                    AIEX::AIEXDialect>();
   }
 
   void runOnOperation() override {
     auto module = getOperation();
+
+    // ctrl-pkt emits its configuration as control packets, whose targets this
+    // pass does not read. Differencing over them would find nothing and would
+    // drop the overlay preload the mode depends on, so reject the combination
+    // before doing any work rather than silently mis-lowering.
+    if (clRegisterReset && clCtrlPkt) {
+      module.emitError("register-reset and ctrl-pkt are mutually exclusive");
+      signalPassFailure();
+      return;
+    }
 
     // Collect all load_pdi operations in program order;
     // need to collect once, then transform all collected ops;
@@ -294,6 +474,8 @@ struct AIEExpandLoadPdiPass
           /*expand_mode=*/
           AIEX::ExpandModeAttr::get(seq.getContext(), AIEX::ExpandMode::none));
     }
+    if (clRegisterReset)
+      applyDifferentialReset(module);
   }
 };
 

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -46,6 +46,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIE
   MLIRAIEToConfiguration
   AIEXUtils
+  MLIRAIEUtil
   MLIRIR
   MLIRPass
   MLIRSCFToControlFlow

--- a/test/Passes/expand-load-pdi/register_reset_differential.mlir
+++ b/test/Passes/expand-load-pdi/register_reset_differential.mlir
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-expand-load-pdi=register-reset=true %s | FileCheck %s
+
+// dev1 enables slave port South_0 and dev2 enables North_0, so the two
+// configurations write disjoint slave-config registers and dev2's config leaves
+// dev1's port enabled. The boundary restores it instead of loading an empty
+// device: 0x23F114 is Stream_Switch_Slave_Config_South_0, reset value 0.
+
+// CHECK-LABEL: aie.runtime_sequence
+// The first boundary has no predecessor to undo, so it keeps its firmware reset.
+// CHECK:       aiex.npu.load_pdi {device_ref = @empty_0
+// CHECK:       aiex.npu.write32
+// CHECK:       aiex.npu.write32
+// The second is replaced by a write restoring dev1's slave port.
+// CHECK-NOT:   aiex.npu.load_pdi
+// CHECK:       %[[RA:.*]] = arith.constant 2355476 : i32
+// CHECK:       %[[RV:.*]] = arith.constant 0 : i32
+// CHECK:       aiex.npu.write32(%[[RA]], %[[RV]])
+
+module {
+    aie.device(npu2_1col) @dev1 {
+        %tile = aie.tile(0, 2)
+        aie.switchbox(%tile) { aie.connect<South : 0, Core : 0> }
+    }
+    aie.device(npu2_1col) @dev2 {
+        %tile = aie.tile(0, 2)
+        aie.switchbox(%tile) { aie.connect<North : 0, Core : 0> }
+    }
+    aie.device(npu2_1col) @main {
+        aie.runtime_sequence(%arg0: memref<1xi32>) {
+            aiex.npu.load_pdi { device_ref = @dev1 }
+            aiex.npu.load_pdi { device_ref = @dev2 }
+        }
+    }
+}

--- a/test/Passes/expand-load-pdi/register_reset_first_load.mlir
+++ b/test/Passes/expand-load-pdi/register_reset_first_load.mlir
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-expand-load-pdi=register-reset=true %s | FileCheck %s
+
+// A single load_pdi has no previous device whose registers could survive, so
+// the firmware reset stays.
+
+// CHECK-LABEL: aie.runtime_sequence
+// CHECK:       aiex.npu.load_pdi {device_ref = @empty_0
+
+module {
+    aie.device(npu2_1col) @dev1 {
+        %tile = aie.tile(0, 2)
+        aie.switchbox(%tile) { aie.connect<South : 0, Core : 0> }
+    }
+    aie.device(npu2_1col) @main {
+        aie.runtime_sequence(%arg0: memref<1xi32>) {
+            aiex.npu.load_pdi { device_ref = @dev1 }
+        }
+    }
+}

--- a/test/Passes/expand-load-pdi/register_reset_mutually_exclusive.mlir
+++ b/test/Passes/expand-load-pdi/register_reset_mutually_exclusive.mlir
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aie-opt --pass-pipeline='builtin.module(aie-expand-load-pdi{register-reset=true ctrl-pkt=true})' %s 2>&1 | FileCheck %s
+
+// ctrl-pkt configures through control packets, whose targets this pass does not
+// read, so a difference over them would be empty and would drop the overlay
+// preload the mode depends on.
+
+// CHECK: register-reset and ctrl-pkt are mutually exclusive
+
+module {
+    aie.device(npu2_1col) @dev1 {
+        %tile = aie.tile(0, 2)
+        aie.switchbox(%tile) { aie.connect<South : 0, Core : 0> }
+    }
+    aie.device(npu2_1col) @dev2 {
+        %tile = aie.tile(0, 2)
+        aie.switchbox(%tile) { aie.connect<North : 0, Core : 0> }
+    }
+    aie.device(npu2_1col) @main {
+        aie.runtime_sequence(%arg0: memref<1xi32>) {
+            aiex.npu.load_pdi { device_ref = @dev1 }
+            aiex.npu.load_pdi { device_ref = @dev2 }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`aie-expand-load-pdi` currently precedes every device configuration with a `load_pdi` of an empty device, purely to trigger a firmware reset. That resets the whole device to clear whatever the outgoing configuration left behind, even though the set of registers that actually differ between two known devices is computable at compile time.

## Fix

Adds an opt-in `register-reset` option. When enabled, each empty-device reset is replaced with writes restoring exactly the registers the outgoing device wrote and the incoming one does not, using reset values from the register database.

A boundary carrying an address the database does not know **keeps its firmware reset**, so an incomplete database degrades to current behaviour rather than to a silently under-reset device.

## Test

Three lit tests covering the distinct cases:

- `register_reset_differential.mlir` -- dev1 enables slave port South_0 and dev2 enables North_0, so their configs write disjoint slave-config registers and dev2 leaves dev1's port enabled. The boundary restores `0x23F114` (`Stream_Switch_Slave_Config_South_0`, reset value 0) instead of loading an empty device.
- `register_reset_first_load.mlir` -- the first load has no outgoing device to differentiate against.
- `register_reset_mutually_exclusive.mlir` -- the option's interaction with `ctrl-pkt`.

## Scope

Off by default (`register-reset=false`), so no existing pipeline changes behaviour.