### PR TITLE
ci: fix the aarch64 MLIR Distro wheel build

### DIFF
--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -271,6 +271,19 @@ jobs:
         ./scripts/apply_patches.sh
 
         pip install --upgrade pip
+        # This is the only leg that isn't routed through cibuildwheel, so
+        # it's also the only leg where `pip wheel .` would otherwise resolve
+        # [build-system].requires with build isolation on: fresh from PyPI,
+        # unpinned. That's how a same-day nanobind release (e.g. 3.0.x) can
+        # break find_package(nanobind 2.9) overnight even though nothing in
+        # this repo changed. Install the hash-pinned lock up front, plus
+        # mlir-native-tools (not in the lock: it's resolved via
+        # PIP_FIND_LINKS, not PyPI, so pip-compile can't hash it), and build
+        # with --no-build-isolation so setup.py sees exactly these versions,
+        # matching what cibuildwheel's before-build already does for the
+        # other legs.
+        pip install --require-hashes -r requirements.lock
+        pip install mlir-native-tools
 
         CIBW_ARCHS=${{ matrix.ARCH }} \
         CMAKE_GENERATOR=Ninja \
@@ -278,7 +291,7 @@ jobs:
         LLVM_PROJECT_COMMIT=${{ needs.get_llvm_project_commit.outputs.LLVM_PROJECT_COMMIT }} \
         MATRIX_OS=${{ matrix.OS }} \
         PARALLEL_LEVEL=2 \
-        pip wheel . -v -w wheelhouse
+        pip wheel . -v -w wheelhouse --no-build-isolation
 
     - name: Clean llvm-project
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}

--- a/utils/mlir_wheels/pyproject.toml
+++ b/utils/mlir_wheels/pyproject.toml
@@ -5,14 +5,14 @@
 requires = [
     "setuptools>=84.0.0",
     "wheel",
-    "ninja",
+    "ninja!=1.13.0",
     # i have no clue why but 3.28 will cause cmake to segfault when detecting ABI compatibility
     "cmake==4.4.2",
     "pybind11[global]>=3.1.0",
-    "numpy",
-    "dataclasses",
+    "numpy>=2.4.6,<2.5; python_version == '3.11'",
+    "numpy>=2.5.2; python_version >= '3.12'",
     "mlir-native-tools",
-    "nanobind",
+    "nanobind==2.12.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/utils/mlir_wheels/requirements.in
+++ b/utils/mlir_wheels/requirements.in
@@ -1,20 +1,18 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Build-time dependencies for the mlir distro wheel.
-# Mirror of [build-system].requires in pyproject.toml.
-#
-# Source for utils/mlir_wheels/requirements.lock. After editing this file,
-# regenerate the .lock with:
-#   utils/regenerate_lockfiles.sh
+# GENERATED from pyproject.toml's [build-system].requires by
+# utils/regenerate_lockfiles.sh. Do not hand-edit: edit pyproject.toml
+# instead and rerun that script, which regenerates both this file and
+# requirements.lock.
 setuptools>=84.0.0
 wheel
 ninja!=1.13.0
 cmake==4.4.2
 pybind11[global]>=3.1.0
-numpy>=2.4.6,<2.5; python_version == "3.11"
-numpy>=2.5.2; python_version >= "3.12"
-# mlir-native-tools is intentionally NOT hash-pinned here: it lives on an
-# internal index reached via PIP_FIND_LINKS at build time, not on PyPI, so
-# pip-compile can't resolve it. mlirDistro.yml installs it separately.
+numpy>=2.4.6,<2.5; python_version == '3.11'
+numpy>=2.5.2; python_version >= '3.12'
 nanobind==2.12.0
+# mlir-native-tools is intentionally dropped above: it lives on an internal
+# index reached via PIP_FIND_LINKS at build time, not on PyPI, so
+# pip-compile can't resolve it. mlirDistro.yml installs it separately.

--- a/utils/mlir_wheels/setup.py
+++ b/utils/mlir_wheels/setup.py
@@ -89,9 +89,17 @@ def get_cross_cmake_args():
             # static mlir-opt/mlir-translate binaries, causing "relocation
             # truncated to fit: R_AARCH64_CALL26" inside libstdc++.a itself.
             # lld handles arbitrarily large binaries correctly.
-            cmake_args["CMAKE_EXE_LINKER_FLAGS_INIT"] = "-fuse-ld=lld"
-            cmake_args["CMAKE_MODULE_LINKER_FLAGS_INIT"] = "-fuse-ld=lld"
-            cmake_args["CMAKE_SHARED_LINKER_FLAGS_INIT"] = "-fuse-ld=lld"
+            #
+            # -B/usr/bin is required alongside -fuse-ld=lld: for a *cross*
+            # gcc, collect2's search for ld.lld doesn't include /usr/bin (the
+            # directory apt actually installs it into) the way it would for a
+            # native compiler, and fails with a misleading "collect2: fatal
+            # error: cannot find 'ld'" even though ld.lld is right there.
+            # -B explicitly adds it to collect2's subprogram search path.
+            _LLD_LINKER_FLAGS = "-fuse-ld=lld -B/usr/bin"
+            cmake_args["CMAKE_EXE_LINKER_FLAGS_INIT"] = _LLD_LINKER_FLAGS
+            cmake_args["CMAKE_MODULE_LINKER_FLAGS_INIT"] = _LLD_LINKER_FLAGS
+            cmake_args["CMAKE_SHARED_LINKER_FLAGS_INIT"] = _LLD_LINKER_FLAGS
             native_tools()
         elif ARCH == "X86":
             cmake_args["LLVM_DEFAULT_TARGET_TRIPLE"] = "x86_64-unknown-linux-gnu"

--- a/utils/regenerate_lockfiles.sh
+++ b/utils/regenerate_lockfiles.sh
@@ -17,6 +17,11 @@
 # uv version is pinned so the resolution (and the generated header comment)
 # stays deterministic across machines and CI.
 #
+# utils/mlir_wheels/requirements.in is itself generated here from
+# utils/mlir_wheels/pyproject.toml's [build-system].requires, so that list
+# can't drift from the one pip-compile actually locks against (see
+# generate_requirements_in below). Edit pyproject.toml, not requirements.in.
+#
 # Usage:  utils/regenerate_lockfiles.sh
 #
 # Exits non-zero if uv is missing or any compile fails.
@@ -70,6 +75,50 @@ compile() {
       "$src_name" -o "$lock_name" --quiet
   )
 }
+
+# Regenerate utils/mlir_wheels/requirements.in from pyproject.toml's
+# [build-system].requires. mlir-native-tools is deliberately dropped: it
+# lives on an internal index reached via PIP_FIND_LINKS at build time, not
+# on PyPI, so pip-compile can't hash it; mlirDistro.yml installs it as a
+# separate, unpinned step instead.
+generate_requirements_in() {
+  local pyproject="$REPO_ROOT/utils/mlir_wheels/pyproject.toml"
+  local out="$REPO_ROOT/utils/mlir_wheels/requirements.in"
+
+  echo "regenerating utils/mlir_wheels/requirements.in from pyproject.toml"
+
+  {
+    cat <<'EOF'
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# GENERATED from pyproject.toml's [build-system].requires by
+# utils/regenerate_lockfiles.sh. Do not hand-edit: edit pyproject.toml
+# instead and rerun that script, which regenerates both this file and
+# requirements.lock.
+EOF
+    awk '
+      /^requires = \[/ { in_requires=1; next }
+      in_requires && /^\]/ { in_requires=0; next }
+      in_requires {
+        line=$0
+        sub(/^[ \t]+/, "", line)
+        sub(/,[ \t]*$/, "", line)
+        if (line == "" || line ~ /^#/) next
+        gsub(/"/, "", line)
+        if (line ~ /^mlir-native-tools/) next
+        print line
+      }
+    ' "$pyproject"
+    cat <<'EOF'
+# mlir-native-tools is intentionally dropped above: it lives on an internal
+# index reached via PIP_FIND_LINKS at build time, not on PyPI, so
+# pip-compile can't resolve it. mlirDistro.yml installs it separately.
+EOF
+  } > "$out"
+}
+
+generate_requirements_in
 
 compile python/requirements_dev.txt              python/requirements_dev.lock
 compile utils/mlir_aie_wheels/requirements.txt   utils/mlir_aie_wheels/requirements.lock


### PR DESCRIPTION
MLIR Distro for `ubuntu-24.04 aarch64` fails on `main`:


1. No aarch64 linker: `collect2: fatal error: cannot find 'ld'`. `setup.py` passes `-fuse-ld=lld`
   for the aarch64 cross build. The `lld` apt package only installs
   `/usr/bin/ld.lld`, and the compiler does not look there. This PR adds the flag `-B/usr/bin` puts `/usr/bin`, allowing the compiler to find lld.

2. Unpinned build-system requirements: The aarch64 leg is the only one not
   routed through cibuildwheel, so `pip wheel .` resolved
   `[build-system].requires` fresh from PyPI. A same-day nanobind 3.0.x release
   broke `find_package(nanobind 2.9)` with no change in this repo. Install the
   hash-pinned lock plus `mlir-native-tools` up front and build with
   `--no-build-isolation`, matching what cibuildwheel's `before-build` already
   does for the other legs. `utils/mlir_wheels/requirements.in` is generated from
   `pyproject.toml` by `regenerate_lockfiles.sh`, so the two lists cannot drift.

Both commits are cherry-picked unchanged from #3623 and keep their author. #3623
additionally builds `pull_request` runs against the recorded LLVM pin, which
requires bumping that pin, which in turn requires source changes for a
`SymbolOpInterface` rename (`getNameAttr` to `getSymNameAttr`). Splitting the two
commits out lands the aarch64 repair without waiting on that work. #3623 is
rebased on this branch.