### PR TITLE
[AIE] Align core-tile buffers to the widest vector access, not the bus width 

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -313,6 +313,22 @@ public:
   /// core.
   virtual uint32_t getComputeTileLoadStoreBusWidth() const = 0;
 
+  /// Return the alignment (in bits) required by the widest vector load/store a
+  /// compute core can issue.
+  ///
+  /// This is NOT the load/store bus width. From AIE2P on, a full-width
+  /// (512-bit) vector access requires 512-bit alignment even though the bus is
+  /// 256 bits wide. Mirrors `vector_ldst_align` in aie_api
+  /// (aie_api/detail/ld_st.hpp), which is the contract kernels compile against:
+  ///   AIE1  (__AIE_ARCH__ 10):        16B
+  ///   AIE2  (__AIE_ARCH__ 20):        32B
+  ///   AIE2P/AIE2PS (__AIE_ARCH__ 21/22): 64B
+  /// A buffer a core may access with a full-width vector must be aligned to
+  /// this, or the access silently touches the wrong memory.
+  virtual uint32_t getComputeTileMaxVectorAlignBits() const {
+    return getComputeTileLoadStoreBusWidth();
+  }
+
   // NOTE: Maybe this should be set to 4-byte alignment, since DMA on Memtile
   // seems to handle unaligned access.
   /// Return the data bus width (in bits) for load/store operations of a memory
@@ -603,6 +619,7 @@ public:
   uint32_t getProgramMemorySize() const override { return 0x00004000; }
   uint32_t getAccumulatorCascadeSize() const override { return 384; }
   uint32_t getComputeTileLoadStoreBusWidth() const override { return 128; }
+  uint32_t getComputeTileMaxVectorAlignBits() const override { return 128; }
 
   using AIETargetModel::getNumLocks;
   uint32_t getNumLocks(AIETileType tileType) const override {
@@ -737,6 +754,7 @@ public:
   uint32_t getProgramMemorySize() const override { return 0x00004000; }
   uint32_t getAccumulatorCascadeSize() const override { return 512; }
   uint32_t getComputeTileLoadStoreBusWidth() const override { return 256; }
+  uint32_t getComputeTileMaxVectorAlignBits() const override { return 256; }
 
   using AIETargetModel::getNumLocks;
   uint32_t getNumLocks(AIETileType tileType) const override {
@@ -857,6 +875,10 @@ public:
   }
 
   AIEArch getTargetArch() const override { return AIEArch::AIE2ps; }
+  // AIE2P/AIE2PS: a full-width (512-bit) vector access requires 512-bit
+  // alignment, stricter than the 256-bit load/store bus. See aie_api's
+  // vector_ldst_align for __AIE_ARCH__ 21/22.
+  uint32_t getComputeTileMaxVectorAlignBits() const override { return 512; }
 
   uint32_t getNumControllersPerColumn() const override { return 1; }
 
@@ -1059,6 +1081,10 @@ public:
   }
 
   AIEArch getTargetArch() const override;
+  // AIE2P/AIE2PS: a full-width (512-bit) vector access requires 512-bit
+  // alignment, stricter than the 256-bit load/store bus. See aie_api's
+  // vector_ldst_align for __AIE_ARCH__ 21/22.
+  uint32_t getComputeTileMaxVectorAlignBits() const override { return 512; }
 
   int rows() const override {
     return 6; /* 1 Shim row, 1 memtile row, and 4 Core rows. */

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -40,26 +40,51 @@ static int64_t getAlignedAddress(int64_t address, uint32_t alignBitWidth) {
   return ((address / alignByteWidth) + 1) * alignByteWidth;
 }
 
+// Return the alignment (in bits) `buffer` must satisfy.
+//
+// The load/store bus width is not sufficient on its own: from AIE2P on, a
+// full-width vector access needs 512-bit alignment while the bus is 256 bits
+// (see AIETargetModel::getComputeTileMaxVectorAlignBits and aie_api's
+// vector_ldst_align). A buffer big enough to hold such a vector may be accessed
+// by one -- we cannot see inside externally-compiled kernels -- so it gets the
+// stricter alignment. Buffers too small to hold one cannot be accessed that way
+// without going out of bounds, so the bus width still applies and they cost no
+// extra padding.
+static uint32_t getRequiredAlignBits(BufferOp buffer, uint32_t busAlignBits,
+                                     uint32_t maxVecAlignBits) {
+  if (maxVecAlignBits <= busAlignBits)
+    return busAlignBits;
+  int64_t sizeBits = static_cast<int64_t>(buffer.getAllocationSize()) * 8;
+  return sizeBits >= static_cast<int64_t>(maxVecAlignBits) ? maxVecAlignBits
+                                                           : busAlignBits;
+}
+
 // Check that every buffer in the list is properly aligned (when its
 // `aligned` attribute is set) and that no two buffers overlap. The input
 // vector must be sorted by ascending address. Emits an error on the first
 // offending buffer and returns false; returns true otherwise.
 static bool checkAndPrintBufferOverlap(SmallVector<BufferOp> &sortedBuffers,
-                                       uint32_t tileAlignBitWidth) {
-  uint32_t alignByteWidth = tileAlignBitWidth / 8;
+                                       uint32_t tileAlignBitWidth,
+                                       uint32_t maxVecAlignBits) {
   for (size_t i = 0; i < sortedBuffers.size(); ++i) {
     auto cur = sortedBuffers[i];
     auto curAddrOpt = cur.getAddress();
     assert(curAddrOpt.has_value() && "buffer must have address assigned");
     int64_t curAddr = *curAddrOpt;
 
-    // Alignment check.
+    // Alignment check. Buffers the user pinned are held only to the bus width
+    // (see checkAndAddBufferWithAddress); the stricter vector requirement
+    // applies to addresses this pass chose.
+    uint32_t reqAlignBits =
+        isBufferPreAllocated(cur)
+            ? tileAlignBitWidth
+            : getRequiredAlignBits(cur, tileAlignBitWidth, maxVecAlignBits);
+    uint32_t alignByteWidth = reqAlignBits / 8;
     if (cur.getAligned() && alignByteWidth != 0 &&
         curAddr % alignByteWidth != 0) {
       cur.emitOpError("buffer '")
           << cur.name() << "' at address 0x" << llvm::utohexstr(curAddr)
-          << " is not aligned to tile load/store bus width ("
-          << tileAlignBitWidth << " bits)";
+          << " is not aligned to the required " << reqAlignBits << " bits";
       return false;
     }
 
@@ -111,9 +136,8 @@ static bool checkAndPrintOverflow(TileOp tile, int address,
         tile.emitOpError("allocated buffers exceeded available memory\n");
     auto &note = error.attachNote() << "MemoryMap:\n";
     auto printbuffer = [&](StringRef name, int address, int size) {
-      note << "\t" << name << " \t"
-           << ": 0x" << llvm::utohexstr(address) << "-0x"
-           << llvm::utohexstr(address + size - 1) << " \t(" << size
+      note << "\t" << name << " \t" << ": 0x" << llvm::utohexstr(address)
+           << "-0x" << llvm::utohexstr(address + size - 1) << " \t(" << size
            << " bytes)\n";
     };
     if (stacksize > 0)
@@ -139,12 +163,17 @@ static bool basicAllocation(TileOp tile) {
   const auto &targetModel = getTargetModel(tile);
   int maxDataMemorySize = 0;
   uint32_t tileAlignBitWidth = 0;
+  // MemTile buffers are reached by DMA rather than by core vector load/stores,
+  // so only the bus width applies there.
+  uint32_t maxVecAlignBitWidth = 0;
   if (tile.isMemTile()) {
     maxDataMemorySize = targetModel.getMemTileSize();
     tileAlignBitWidth = targetModel.getMemTileLoadStoreBusWidth();
+    maxVecAlignBitWidth = tileAlignBitWidth;
   } else {
     maxDataMemorySize = targetModel.getLocalMemorySize();
     tileAlignBitWidth = targetModel.getComputeTileLoadStoreBusWidth();
+    maxVecAlignBitWidth = targetModel.getComputeTileMaxVectorAlignBits();
   }
 
   SmallVector<BufferOp> buffers;
@@ -192,9 +221,14 @@ static bool basicAllocation(TileOp tile) {
     auto bufferAddrOpt = buffer.getAddress();
     assert(bufferAddrOpt.has_value() &&
            "allocated_buffers only holds buffers with an address");
+    // An explicitly pinned address is the user's assertion, often dictated by
+    // an external ABI (e.g. RTP buffers a host writes at a fixed address). Hold
+    // it only to the bus width, as before: the allocator's job is to avoid
+    // *creating* misalignment, not to veto a supplied address on a requirement
+    // inferred from the buffer's size.
     if (buffer.getAligned() && *bufferAddrOpt % (tileAlignBitWidth / 8) != 0) {
-      buffer.emitOpError("pre-allocated address must be aligned to tile "
-                         "load/store bus width when aligned attribute is set");
+      buffer.emitOpError("pre-allocated address must be aligned to ")
+          << tileAlignBitWidth << " bits when the aligned attribute is set";
       return false;
     }
   }
@@ -209,15 +243,17 @@ static bool basicAllocation(TileOp tile) {
   auto *current_alloc = allocated_buffers.begin();
   for (auto buffer : buffers) {
     assert(!buffer.getAddress());
+    uint32_t reqAlignBits =
+        getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBitWidth);
     if (buffer.getAligned())
-      address = getAlignedAddress(address, tileAlignBitWidth);
+      address = getAlignedAddress(address, reqAlignBits);
     while (current_alloc != allocated_buffers.end() &&
            address + buffer.getAllocationSize() >
                current_alloc->getAddress().value()) {
       address = current_alloc->getAddress().value() +
                 current_alloc->getAllocationSize();
       if (buffer.getAligned())
-        address = getAlignedAddress(address, tileAlignBitWidth);
+        address = getAlignedAddress(address, reqAlignBits);
       current_alloc++;
     }
 
@@ -250,7 +286,8 @@ static bool basicAllocation(TileOp tile) {
 
   // Check if memory was exceeded or buffers overlap, and print debug info.
   return (checkAndPrintOverlapStackframe(stacksize, allBuffers_on_tile) &&
-          checkAndPrintBufferOverlap(allBuffers_on_tile, tileAlignBitWidth) &&
+          checkAndPrintBufferOverlap(allBuffers_on_tile, tileAlignBitWidth,
+                                     maxVecAlignBitWidth) &&
           checkAndPrintOverflow(tile, highWater, maxDataMemorySize, stacksize,
                                 allBuffers_on_tile));
 }
@@ -297,11 +334,10 @@ static void setAndUpdateAddressInBank(BufferOp buffer, int64_t start_addr,
 // returns true and if not, the function emits a warning that the address
 // will be overwritten and returns false (which will cause the buffer to be
 // added to the list of buffers without addresses, to be completed later on).
-static FailureOr<bool>
-checkAndAddBufferWithAddress(BufferOp buffer, int numBanks,
-                             uint32_t tileAlignBitWidth,
-                             std::vector<int64_t> &nextAddrInBanks,
-                             std::vector<BankLimits> &bankLimits) {
+static FailureOr<bool> checkAndAddBufferWithAddress(
+    BufferOp buffer, int numBanks, uint32_t tileAlignBitWidth,
+    uint32_t maxVecAlignBits, std::vector<int64_t> &nextAddrInBanks,
+    std::vector<BankLimits> &bankLimits) {
   auto addrAttr = buffer->getAttrOfType<IntegerAttr>("address");
   if (!addrAttr)
     return false;
@@ -309,10 +345,11 @@ checkAndAddBufferWithAddress(BufferOp buffer, int numBanks,
   auto memBankAttr = buffer->getAttrOfType<IntegerAttr>("mem_bank");
 
   int addr = addrAttr.getInt();
+  // As in basicAllocation: an explicitly pinned address is held only to the bus
+  // width, since it may be fixed by an external ABI.
   if (buffer.getAligned() && addr % (tileAlignBitWidth / 8) != 0) {
-    return buffer->emitOpError(
-        "address attribute value must be aligned to tile load/store bus width "
-        "when aligned attribute is set");
+    return buffer->emitOpError("address attribute value must be aligned to ")
+           << tileAlignBitWidth << " bits when the aligned attribute is set";
   }
   for (int i = 0; i < numBanks; i++) {
     // if the address is not within the bank, continue
@@ -345,11 +382,10 @@ checkAndAddBufferWithAddress(BufferOp buffer, int numBanks,
 // function emits a warning that the mem_bank will be overwritten and returns
 // false (which will cause the buffer to be added to the list of buffers
 // without addresses, to be completed later on).
-static FailureOr<bool>
-checkAndAddBufferWithMemBank(BufferOp buffer, int numBanks,
-                             uint32_t tileAlignBitWidth,
-                             std::vector<int64_t> &nextAddrInBanks,
-                             std::vector<BankLimits> &bankLimits) {
+static FailureOr<bool> checkAndAddBufferWithMemBank(
+    BufferOp buffer, int numBanks, uint32_t tileAlignBitWidth,
+    uint32_t maxVecAlignBits, std::vector<int64_t> &nextAddrInBanks,
+    std::vector<BankLimits> &bankLimits) {
   auto memBankAttr = buffer->getAttrOfType<IntegerAttr>("mem_bank");
   if (!memBankAttr)
     return false;
@@ -382,10 +418,8 @@ static void printMemMap(TileOp tile, SmallVector<BufferOp> &allocatedBuffers,
                << "Current configuration of buffers in bank(s) : ";
   note << "MemoryMap:\n";
   auto printbuffer = [&](StringRef name, int address, int size) {
-    note << "\t"
-         << "\t" << name << " \t"
-         << ": 0x" << llvm::utohexstr(address) << "-0x"
-         << llvm::utohexstr(address + size - 1) << " \t(" << size
+    note << "\t" << "\t" << name << " \t" << ": 0x" << llvm::utohexstr(address)
+         << "-0x" << llvm::utohexstr(address + size - 1) << " \t(" << size
          << " bytes)\n";
   };
   for (int i = 0; i < numBanks; i++) {
@@ -395,9 +429,8 @@ static void printMemMap(TileOp tile, SmallVector<BufferOp> &allocatedBuffers,
       else
         note << "(no stack allocated)\n";
     }
-    note << "\t"
-         << "bank : " << i << "\t"
-         << "0x" << llvm::utohexstr(bankLimits[i].startAddr) << "-0x"
+    note << "\t" << "bank : " << i << "\t" << "0x"
+         << llvm::utohexstr(bankLimits[i].startAddr) << "-0x"
          << llvm::utohexstr(bankLimits[i].endAddr - 1) << "\n";
     for (auto buffer : preAllocatedBuffers) {
       auto addrOpt = buffer.getAddress();
@@ -427,7 +460,8 @@ static void printMemMap(TileOp tile, SmallVector<BufferOp> &allocatedBuffers,
 // If no bank has enough space to accommodate the buffer, an error is emitted.
 
 static int setBufferAddress(BufferOp buffer, int numBanks,
-                            uint32_t tileAlignBitWidth, int &startBankIndex,
+                            uint32_t tileAlignBitWidth,
+                            uint32_t maxVecAlignBits, int &startBankIndex,
                             std::vector<int64_t> &nextAddrInBanks,
                             std::vector<BankLimits> &bankLimits) {
   assert(startBankIndex < numBanks &&
@@ -438,7 +472,9 @@ static int setBufferAddress(BufferOp buffer, int numBanks,
     int64_t startAddr = nextAddrInBanks[bankIndex];
 
     if (buffer.getAligned()) {
-      startAddr = getAlignedAddress(startAddr, tileAlignBitWidth);
+      startAddr = getAlignedAddress(
+          startAddr,
+          getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBits));
     }
 
     int64_t endAddr = startAddr + buffer.getAllocationSize();
@@ -484,16 +520,14 @@ static bool checkAndPrintOverflow(TileOp tile, int numBanks, int stacksize,
     note << "\n";
     note << "MemoryMap:\n";
     auto printbuffer = [&](StringRef name, int address, int size) {
-      note << "\t"
-           << "\t" << name << " \t"
-           << ": 0x" << llvm::utohexstr(address) << "-0x"
+      note << "\t" << "\t" << name << " \t" << ": 0x"
+           << llvm::utohexstr(address) << "-0x"
            << llvm::utohexstr(address + size - 1) << " \t(" << size
            << " bytes)\n";
     };
     for (int i = 0; i < numBanks; i++) {
-      note << "\t"
-           << "bank : " << i << "\t"
-           << "0x" << llvm::utohexstr(bankLimits[i].startAddr) << "-0x"
+      note << "\t" << "bank : " << i << "\t" << "0x"
+           << llvm::utohexstr(bankLimits[i].startAddr) << "-0x"
            << llvm::utohexstr(bankLimits[i].endAddr - 1) << "\n";
       if (i == 0) {
         if (stacksize > 0)
@@ -539,12 +573,17 @@ static bool simpleBankAwareAllocation(TileOp tile) {
   const auto &targetModel = getTargetModel(tile);
   int maxDataMemorySize = 0;
   uint32_t tileAlignBitWidth = 0;
+  // MemTile buffers are reached by DMA rather than by core vector load/stores,
+  // so only the bus width applies there.
+  uint32_t maxVecAlignBitWidth = 0;
   if (tile.isMemTile()) {
     maxDataMemorySize = targetModel.getMemTileSize();
     tileAlignBitWidth = targetModel.getMemTileLoadStoreBusWidth();
+    maxVecAlignBitWidth = tileAlignBitWidth;
   } else {
     maxDataMemorySize = targetModel.getLocalMemorySize();
     tileAlignBitWidth = targetModel.getComputeTileLoadStoreBusWidth();
+    maxVecAlignBitWidth = targetModel.getComputeTileMaxVectorAlignBits();
   }
 
   int numBanks = targetModel.getNumBanks(tile.getCol(), tile.getRow());
@@ -620,14 +659,16 @@ static bool simpleBankAwareAllocation(TileOp tile) {
   for (auto buffer : preAllocatedBuffers) {
 
     auto has_addr = checkAndAddBufferWithAddress(
-        buffer, numBanks, tileAlignBitWidth, nextAddrInBanks, bankLimits);
+        buffer, numBanks, tileAlignBitWidth, maxVecAlignBitWidth,
+        nextAddrInBanks, bankLimits);
     if (failed(has_addr))
       return false;
     // NOLINTNEXTLINE
     if (*has_addr)
       continue;
     auto has_bank = checkAndAddBufferWithMemBank(
-        buffer, numBanks, tileAlignBitWidth, nextAddrInBanks, bankLimits);
+        buffer, numBanks, tileAlignBitWidth, maxVecAlignBitWidth,
+        nextAddrInBanks, bankLimits);
     if (failed(has_bank))
       return false;
   }
@@ -650,8 +691,9 @@ static bool simpleBankAwareAllocation(TileOp tile) {
     // it prints the current memory map of the banks,
     // deallocates all the buffers, and
     // returns a failure.
-    if (!setBufferAddress(buffer, numBanks, tileAlignBitWidth, bankIndex,
-                          nextAddrInBanks, bankLimits)) {
+    if (!setBufferAddress(buffer, numBanks, tileAlignBitWidth,
+                          maxVecAlignBitWidth, bankIndex, nextAddrInBanks,
+                          bankLimits)) {
 
       printMemMap(tile, allocatedBuffers, preAllocatedBuffers, numBanks,
                   bankLimits, stacksize);
@@ -673,7 +715,8 @@ static bool simpleBankAwareAllocation(TileOp tile) {
             });
   // Check if memory was exceeded on any bank and print debug info.
   return checkAndPrintOverlapStackframe(stacksize, allBuffers_on_tile) &&
-         checkAndPrintBufferOverlap(allBuffers_on_tile, tileAlignBitWidth) &&
+         checkAndPrintBufferOverlap(allBuffers_on_tile, tileAlignBitWidth,
+                                    maxVecAlignBitWidth) &&
          checkAndPrintOverflow(tile, numBanks, stacksize, allBuffers_on_tile,
                                nextAddrInBanks, bankLimits);
 }

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -336,7 +336,8 @@ static void setAndUpdateAddressInBank(BufferOp buffer, int64_t start_addr,
 // added to the list of buffers without addresses, to be completed later on).
 static FailureOr<bool> checkAndAddBufferWithAddress(
     BufferOp buffer, int numBanks, uint32_t tileAlignBitWidth,
-    uint32_t maxVecAlignBits, std::vector<int64_t> &nextAddrInBanks,
+    [[maybe_unused]] uint32_t maxVecAlignBits,
+    std::vector<int64_t> &nextAddrInBanks,
     std::vector<BankLimits> &bankLimits) {
   auto addrAttr = buffer->getAttrOfType<IntegerAttr>("address");
   if (!addrAttr)
@@ -397,7 +398,9 @@ static FailureOr<bool> checkAndAddBufferWithMemBank(
 
   int64_t startAddr = nextAddrInBanks[mem_bank];
   if (buffer.getAligned()) {
-    startAddr = getAlignedAddress(startAddr, tileAlignBitWidth);
+    startAddr = getAlignedAddress(
+        startAddr,
+        getRequiredAlignBits(buffer, tileAlignBitWidth, maxVecAlignBits));
   }
 
   int64_t endAddr = startAddr + buffer.getAllocationSize();

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -334,11 +334,12 @@ static void setAndUpdateAddressInBank(BufferOp buffer, int64_t start_addr,
 // returns true and if not, the function emits a warning that the address
 // will be overwritten and returns false (which will cause the buffer to be
 // added to the list of buffers without addresses, to be completed later on).
-static FailureOr<bool> checkAndAddBufferWithAddress(
-    BufferOp buffer, int numBanks, uint32_t tileAlignBitWidth,
-    [[maybe_unused]] uint32_t maxVecAlignBits,
-    std::vector<int64_t> &nextAddrInBanks,
-    std::vector<BankLimits> &bankLimits) {
+static FailureOr<bool>
+checkAndAddBufferWithAddress(BufferOp buffer, int numBanks,
+                             uint32_t tileAlignBitWidth,
+                             [[maybe_unused]] uint32_t maxVecAlignBits,
+                             std::vector<int64_t> &nextAddrInBanks,
+                             std::vector<BankLimits> &bankLimits) {
   auto addrAttr = buffer->getAttrOfType<IntegerAttr>("address");
   if (!addrAttr)
     return false;

--- a/test/assign-buffer-addresses/bank_aware_vector_alignment.mlir
+++ b/test/assign-buffer-addresses/bank_aware_vector_alignment.mlir
@@ -1,0 +1,53 @@
+//===- bank_aware_vector_alignment.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Same requirement as vector_alignment.mlir, for the bank-aware allocator:
+// core-tile buffers must be aligned to the widest vector load/store the core can
+// issue (512b / 64B from AIE2P on), not to the 256b load/store bus.
+//
+// See AIETargetModel::getComputeTileMaxVectorAlignBits and aie_api's
+// vector_ldst_align (aie_api/detail/ld_st.hpp).
+
+// RUN: aie-opt --split-input-file --aie-assign-buffer-addresses="alloc-scheme=bank-aware" %s | FileCheck %s
+
+// Banks are round-robined, so `b4` is the first buffer to land in bank 0 behind
+// the 144B `pad`. Without the fix it is placed at 1184 (32 mod 64) and a 512-bit
+// vector store to it is torn; it must be bumped to 1216.
+// CHECK-LABEL: module @bank_aware_needs_64B
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "pad"} : memref<72xbf16>
+// CHECK: aie.buffer({{.*}}) {address = 1216 : i32, mem_bank = 0 : i32, sym_name = "b4"} : memref<32xbf16>
+module @bank_aware_needs_64B {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %pad = aie.buffer(%t) { sym_name = "pad" } : memref<72xbf16>   // 144 B
+    %b1 = aie.buffer(%t) { sym_name = "b1" } : memref<32xbf16>
+    %b2 = aie.buffer(%t) { sym_name = "b2" } : memref<32xbf16>
+    %b3 = aie.buffer(%t) { sym_name = "b3" } : memref<32xbf16>
+    %b4 = aie.buffer(%t) { sym_name = "b4" } : memref<32xbf16>
+    aie.core(%t) {
+      aie.end
+    } { stack_size = 1024 : i32 }
+  }
+}
+
+// -----
+
+// An explicitly pinned address is the user's assertion and is often fixed by an
+// external ABI (e.g. an RTP buffer a host writes at a known address). It is held
+// only to the bus width, so pinning a 64B buffer at a 32-mod-64 address stays
+// legal; only addresses this pass *chooses* get the stricter vector alignment.
+// CHECK-LABEL: module @bank_aware_pinned_address_not_vetoed
+// CHECK: aie.buffer({{.*}}) {address = 55328 : i32, {{.*}}sym_name = "rtp"} : memref<16xi32>
+module @bank_aware_pinned_address_not_vetoed {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %rtp = aie.buffer(%t) { sym_name = "rtp", address = 55328 : i32 } : memref<16xi32>
+    aie.core(%t) {
+      aie.end
+    } { stack_size = 1024 : i32 }
+  }
+}

--- a/test/assign-buffer-addresses/bank_aware_vector_alignment.mlir
+++ b/test/assign-buffer-addresses/bank_aware_vector_alignment.mlir
@@ -36,6 +36,27 @@ module @bank_aware_needs_64B {
 
 // -----
 
+// Same as @bank_aware_needs_64B, but both buffers are pre-allocated with only
+// a mem_bank attribute (no address): this goes through
+// checkAndAddBufferWithMemBank rather than setBufferAddress. Without also
+// applying the stricter alignment there, `vec` lands at 1184 (32 mod 64) and
+// a 512-bit vector store to it is torn; it must be bumped to 1216.
+// CHECK-LABEL: module @bank_aware_membank_only_needs_64B
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "pad"} : memref<72xbf16>
+// CHECK: aie.buffer({{.*}}) {address = 1216 : i32, mem_bank = 0 : i32, sym_name = "vec"} : memref<32xbf16>
+module @bank_aware_membank_only_needs_64B {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %pad = aie.buffer(%t) { sym_name = "pad", mem_bank = 0 : i32 } : memref<72xbf16>   // 144 B
+    %vec = aie.buffer(%t) { sym_name = "vec", mem_bank = 0 : i32 } : memref<32xbf16>   //  64 B
+    aie.core(%t) {
+      aie.end
+    } { stack_size = 1024 : i32 }
+  }
+}
+
+// -----
+
 // An explicitly pinned address is the user's assertion and is often fixed by an
 // external ABI (e.g. an RTP buffer a host writes at a known address). It is held
 // only to the bus width, so pinning a 64B buffer at a 32-mod-64 address stays

--- a/test/assign-buffer-addresses/basic_alloc_memtile_error.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_memtile_error.mlir
@@ -8,7 +8,7 @@
 // RUN: not aie-opt --split-input-file --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s 2>&1 | FileCheck %s
 // CHECK: error: 'aie.tile' op allocated buffers exceeded available memory
 // CHECK: error: 'aie.tile' op Basic sequential allocation failed.
-// CHECK: error: 'aie.buffer' op pre-allocated address must be aligned to tile load/store bus width when aligned attribute is set
+// CHECK: error: 'aie.buffer' op pre-allocated address must be aligned to 32 bits when the aligned attribute is set
 
 module @test {
   aie.device(xcve2302) {

--- a/test/assign-buffer-addresses/vector_alignment.mlir
+++ b/test/assign-buffer-addresses/vector_alignment.mlir
@@ -1,0 +1,123 @@
+//===- vector_alignment.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Core-tile buffers must be aligned to the widest vector load/store the core
+// can issue, which from AIE2P on is 512 bits (64B) -- stricter than the 256-bit
+// load/store bus. A buffer only 32B-aligned that is then written by a full
+// 512-bit vector store silently loses the half of the store past the 64B line.
+//
+// See AIETargetModel::getComputeTileMaxVectorAlignBits and aie_api's
+// vector_ldst_align (aie_api/detail/ld_st.hpp).
+
+// RUN: aie-opt --split-input-file --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s | FileCheck %s
+
+// AIE2P (npu2): `pad` is 144B, so without the fix the following 64B buffer
+// lands at 1184 (32-aligned but 32 mod 64) and a 512-bit store to it is torn.
+// It must be bumped to 1216.
+// CHECK-LABEL: module @aie2p_core_needs_64B
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, sym_name = "pad"} : memref<72xbf16>
+// CHECK: aie.buffer({{.*}}) {address = 1216 : i32, sym_name = "vec"} : memref<32xbf16>
+module @aie2p_core_needs_64B {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %pad = aie.buffer(%t) { sym_name = "pad" } : memref<72xbf16>   // 144 B
+    %vec = aie.buffer(%t) { sym_name = "vec" } : memref<32xbf16>   //  64 B
+    aie.core(%t) {
+      aie.end
+    } { stackSize = 1024 : i32 }
+  }
+}
+
+// -----
+
+// Buffers too small to hold a full-width vector cannot be accessed by one
+// without going out of bounds, so they keep the cheaper 32B bus alignment and
+// cost no extra padding.
+// CHECK-LABEL: module @aie2p_small_buffers_unpadded
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, sym_name = "s0"} : memref<8xbf16>
+// CHECK: aie.buffer({{.*}}) {address = 1056 : i32, sym_name = "s1"} : memref<8xbf16>
+module @aie2p_small_buffers_unpadded {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %s0 = aie.buffer(%t) { sym_name = "s0" } : memref<8xbf16>      // 16 B
+    %s1 = aie.buffer(%t) { sym_name = "s1" } : memref<8xbf16>      // 16 B
+    aie.core(%t) {
+      aie.end
+    } { stackSize = 1024 : i32 }
+  }
+}
+
+// -----
+
+// AIE2 (npu1) keeps 32B alignment: its widest vector access is 256 bits, so
+// this change must not perturb existing AIE2 layouts.
+// CHECK-LABEL: module @aie2_unchanged
+// CHECK: aie.buffer({{.*}}) {address = 1024 : i32, sym_name = "pad"} : memref<72xbf16>
+// CHECK: aie.buffer({{.*}}) {address = 1184 : i32, sym_name = "vec"} : memref<32xbf16>
+module @aie2_unchanged {
+  aie.device(npu1) {
+    %t = aie.tile(0, 2)
+    %pad = aie.buffer(%t) { sym_name = "pad" } : memref<72xbf16>
+    %vec = aie.buffer(%t) { sym_name = "vec" } : memref<32xbf16>
+    aie.core(%t) {
+      aie.end
+    } { stackSize = 1024 : i32 }
+  }
+}
+
+// -----
+
+// MemTile buffers are reached by DMA, not by core vector load/stores, so they
+// keep the 4B DMA alignment and gain no padding.
+// CHECK-LABEL: module @aie2p_memtile_unchanged
+// CHECK: aie.buffer({{.*}}) {address = 0 : i32, sym_name = "m0"} : memref<72xbf16>
+// CHECK: aie.buffer({{.*}}) {address = 144 : i32, sym_name = "m1"} : memref<32xbf16>
+module @aie2p_memtile_unchanged {
+  aie.device(npu2) {
+    %t = aie.tile(0, 1)
+    %m0 = aie.buffer(%t) { sym_name = "m0" } : memref<72xbf16>
+    %m1 = aie.buffer(%t) { sym_name = "m1" } : memref<32xbf16>
+  }
+}
+
+// -----
+
+// https://github.com/Xilinx/mlir-aie/issues/2579: buffers are placed after the
+// stack, so a stack_size that is not a multiple of 64 used to leave every
+// following buffer 32-aligned, silently breaking aie::load_v / aie::store_v.
+// The alignment must not depend on the stack size.
+// CHECK-LABEL: module @aie2p_unaligned_stack_size
+// CHECK: aie.buffer({{.*}}) {address = 1088 : i32, sym_name = "bufin"} : memref<32xi32>
+// CHECK: aie.buffer({{.*}}) {address = 1216 : i32, sym_name = "bufout"} : memref<32xi32>
+module @aie2p_unaligned_stack_size {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %in = aie.buffer(%t) { sym_name = "bufin" } : memref<32xi32>
+    %out = aie.buffer(%t) { sym_name = "bufout" } : memref<32xi32>
+    aie.core(%t) {
+      aie.end
+    } { stack_size = 1028 : i32 }
+  }
+}
+
+// -----
+
+// An explicitly pinned address is the user's assertion and is often fixed by an
+// external ABI (e.g. an RTP buffer a host writes at a known address). It is held
+// only to the bus width, so pinning a 64B buffer at a 32-mod-64 address stays
+// legal; only addresses this pass *chooses* get the stricter vector alignment.
+// CHECK-LABEL: module @aie2p_pinned_address_not_vetoed
+// CHECK: aie.buffer({{.*}}) {address = 55328 : i32, sym_name = "rtp"} : memref<16xi32>
+module @aie2p_pinned_address_not_vetoed {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %rtp = aie.buffer(%t) { sym_name = "rtp", address = 55328 : i32 } : memref<16xi32>
+    aie.core(%t) {
+      aie.end
+    } { stack_size = 1024 : i32 }
+  }
+}

--- a/test/assign-buffer-addresses/vector_alignment.mlir
+++ b/test/assign-buffer-addresses/vector_alignment.mlir
@@ -28,7 +28,7 @@ module @aie2p_core_needs_64B {
     %vec = aie.buffer(%t) { sym_name = "vec" } : memref<32xbf16>   //  64 B
     aie.core(%t) {
       aie.end
-    } { stackSize = 1024 : i32 }
+    } { stack_size = 1024 : i32 }
   }
 }
 

--- a/test/assign-buffer-addresses/vector_alignment.mlir
+++ b/test/assign-buffer-addresses/vector_alignment.mlir
@@ -47,7 +47,7 @@ module @aie2p_small_buffers_unpadded {
     %s1 = aie.buffer(%t) { sym_name = "s1" } : memref<8xbf16>      // 16 B
     aie.core(%t) {
       aie.end
-    } { stackSize = 1024 : i32 }
+    } { stack_size = 1024 : i32 }
   }
 }
 
@@ -65,7 +65,7 @@ module @aie2_unchanged {
     %vec = aie.buffer(%t) { sym_name = "vec" } : memref<32xbf16>
     aie.core(%t) {
       aie.end
-    } { stackSize = 1024 : i32 }
+    } { stack_size = 1024 : i32 }
   }
 }
 


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

Fixes #2579.                                                                                                                                                                                                       
                                                                                                                                                                                                                     
`AIEAssignBuffers` aligns buffers to `getComputeTileLoadStoreBusWidth()` (256b). That was correct for AIE2, whose widest vector access is also 256b, but AIE2P raised the widest access to 512b while leaving the bus at 256b. `aie_api`  encodes this exactly (`detail/ld_st.hpp`, `vector_ldst_align`): `__AIE_ARCH__` 21/22 need 64B for a >=512b access, vs 32B on 20. Currently, a buffer can be placed 32B-aligned and then written by a full-width 512b vector store.                                                                                                                                                                                                 
                                                                                                                                                                                                                     
The result is silent data corruption: the half of the store past the 64B line is not observed. It is address-dependent, not schedule-dependent and depends on the sizes of *neighbouring* buffers, so an unrelated size change can silently introduce or hide it.                                                                                                                                                           
                                                                                                                                                                                                                     
## Fix                                                                                                                                                                                                             
                                                                                                                                                                                                                     
Add `AIETargetModel::getComputeTileMaxVectorAlignBits()` mirroring aie_api's table (AIE1 128b, AIE2 256b, AIE2P/AIE2PS 512b), and use it for core-tile buffers in both allocators and in the pre-allocated / post-assignment checks.                                                                                                                                      
                                                                                                                                                                                                                     
Deliberately narrow:                                                                                                                                                                                               
- Buffers smaller than the widest vector can't be accessed by one without going out of bounds: they keep bus-width alignment and gain no padding.                                                                                                                                                
- MemTile buffers are DMA-reached, not vector-accessed: unchanged.                                                                                                                                                 
- AIE1/AIE2 unchanged, since their vector width equals their bus width.                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
## Impact                                                                                                                                                                                                          
                                                                                                                                                                                                                     
- No packing regression: across a set of AIE2P designs, peak memory per tile is byte-identical before and after, including one design at 100% occupancy.                                                                                                                                         
- Addresses can move on AIE2P. Designs depending on incidentally-placed buffers (e.g. RTPs a host writes at a fixed address) should pin them explicitly.                                                                                                                                         
- A few unrelated lines are reformatted by the pinned clang-format v22.1.8.               

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
