### PR TITLE
[python] trace: account for Event_Sync's cycle-delta carry in mode-0 decode [HIGH]

### DIFF
--- a/python/utils/trace/parse.py
+++ b/python/utils/trace/parse.py
@@ -43,6 +43,12 @@ logger = logging.getLogger(__name__)
 
 NUM_EVENTS = 8  # number of events we can view per trace
 
+# Single2/Multiple2 carry an 18-bit cycle delta (utils.py convert_to_commands). Event_Sync is
+# the hardware's marker that the field wrapped once, so decoding it as a no-op undercounts by
+# one full range per occurrence -- 6.9x on a measured capture whose real per-tile interval was
+# 306746 cycles against 44602 decoded.
+EVENT_SYNC_CYCLES = 1 << 18
+
 DEFAULT_KERNEL = "main:sequence"
 
 
@@ -484,6 +490,10 @@ def convert_commands_to_json(trace_events, commands, pid_events, events_module):
                                     trace_events,
                                     events_module,
                                 )
+
+                elif t == "Event_Sync":
+                    # Advances the clock only; no event starts or ends here.
+                    timer = timer + EVENT_SYNC_CYCLES
 
 
 def process_name_metadata(trace_events, pid, trace_type, loc):

--- a/test/python/test_trace_event_sync_carry.py
+++ b/test/python/test_trace_event_sync_carry.py
@@ -13,10 +13,10 @@ exceeded that field's range, so add one full field range (2**18) before applying
 command's own (remainder) delta. convert_commands_to_json() had no case for it, so every
 Event_Sync was silently dropped -- the running `timer` neither advanced nor emitted anything.
 
-Found via route_b_kernels/codec_block/trace_conv_dispatch.py on real hardware: its `--events
-sparse` run reported a per-tile INSTR_EVENT_0->INSTR_EVENT_1 cost of 44602 cycles, 6.9x below
-`--events dense`'s 306746 (independently confirmed against an untraced wall-clock measurement of
-the same dispatch). 306746 - 44602 == 262144 == 2**18 exactly, and the sparse capture carries
+Found on npu2 hardware in a downstream design: a `--events sparse` capture reported a per-tile
+INSTR_EVENT_0->INSTR_EVENT_1 cost of 44602 cycles, 6.9x below a `--events dense` capture's 306746
+(independently confirmed against an untraced wall-clock measurement of the same dispatch).
+306746 - 44602 == 262144 == 2**18 exactly, and the sparse capture carries
 exactly one Event_Sync per tile bracket. The bytes in test_event_sync_carried_across_bracket are
 that capture's tile 0, verbatim (loc "2,0"'s core byte stream, offset 27).
 """

--- a/test/python/test_trace_event_sync_carry.py
+++ b/test/python/test_trace_event_sync_carry.py
@@ -1,0 +1,58 @@
+# test_trace_event_sync_carry.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python -m pytest %s -v
+
+"""Regression test: convert_commands_to_json() must account for Event_Sync.
+
+Event_Sync is the carry marker for Single2/Multiple2's 18-bit cycle-delta field (max 0x3FFFF =
+262143, from convert_to_commands()'s byte layout): it means the true delta since the last packet
+exceeded that field's range, so add one full field range (2**18) before applying the following
+command's own (remainder) delta. convert_commands_to_json() had no case for it, so every
+Event_Sync was silently dropped -- the running `timer` neither advanced nor emitted anything.
+
+Found via route_b_kernels/codec_block/trace_conv_dispatch.py on real hardware: its `--events
+sparse` run reported a per-tile INSTR_EVENT_0->INSTR_EVENT_1 cost of 44602 cycles, 6.9x below
+`--events dense`'s 306746 (independently confirmed against an untraced wall-clock measurement of
+the same dispatch). 306746 - 44602 == 262144 == 2**18 exactly, and the sparse capture carries
+exactly one Event_Sync per tile bracket. The bytes in test_event_sync_carried_across_bracket are
+that capture's tile 0, verbatim (loc "2,0"'s core byte stream, offset 27).
+"""
+
+from aie.utils.trace.events import get_events_for_device
+from aie.utils.trace.parse import EVENT_SYNC_CYCLES, convert_commands_to_json
+from aie.utils.trace.utils import convert_to_commands
+
+EVENTS_MODULE = get_events_for_device("npu1_1col")
+
+# pid_events[trace_type][loc] = 8 event-slot codes + the assigned pid (index 8, NUM_EVENTS).
+# Slot 0 = INSTR_EVENT_0 (code 33), slot 1 = INSTR_EVENT_1 (code 34) -- matches
+# trace_conv_dispatch.py's CORETILE_EVENTS_SPARSE ordering.
+PID_EVENTS = [{"2,0": [33, 34, 0, 0, 0, 0, 0, 0, 0]}, {}, {}, {}]
+
+
+def test_event_sync_cycles_is_the_18_bit_field_range():
+    assert EVENT_SYNC_CYCLES == 1 << 18 == 262144
+
+
+def test_event_sync_carried_across_bracket():
+    # Real capture: Single0(event0, +9) Event_Sync Single2(event1, +44601).
+    byte_stream = [0x09, 0xFF, 0xA4, 0xAE, 0x39]
+    commands = convert_to_commands([{"2,0": byte_stream}, {}, {}, {}])
+
+    trace_events = []
+    convert_commands_to_json(trace_events, commands, PID_EVENTS, EVENTS_MODULE)
+
+    begins = {e["name"]: e["ts"] for e in trace_events if e["ph"] == "B"}
+    # Without the carry this is 44602 (1 + 9 skipped as the deactivate tick, then 1 + 44601) --
+    # a 6.9x undercount of the true, wall-clock-validated 306746.
+    assert begins["INSTR_EVENT_1"] - begins["INSTR_EVENT_0"] == 262144 + 44602 == 306746
+
+
+def test_event_sync_emits_no_trace_event():
+    commands = [{"2,0": [{"type": "Event_Sync"}]}, {}, {}, {}]
+    trace_events = []
+    convert_commands_to_json(trace_events, commands, PID_EVENTS, EVENTS_MODULE)
+    assert trace_events == []


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

`Single2`/`Multiple2` carry an 18-bit cycle delta (`convert_to_commands`, 2 bits + 2 bytes). When the
true interval since the previous packet exceeds that, the trace unit emits an `Event_Sync` to mark
that the field wrapped. `convert_commands_to_json` has no branch for it, so the packet is dropped and
every wrap loses exactly `2**18` cycles from the decoded timeline.

This is silent: the trace still parses and renders, the cycle numbers are just low. It bites captures
whose event rate is low enough for one inter-event gap to reach ~146 us at 1.8 GHz, which is the
normal case for a sparse event set on a long-running kernel. `convert_commands_to_json` is shared by
the core, mem, shim and memtile trace types, so all four are affected.

The uncalled `make_event_lists` below does handle `Event_Sync`, but adds `0x3FFFF`, the field's
maximum value where the carry needs its range, under its own `# Typo in spec` comment.

## Fix

Add `EVENT_SYNC_CYCLES = 1 << 18` and an `Event_Sync` branch that advances `timer` by it.

## Evidence

Two event sets on one AIE2P design disagreed 6.9x: a dense 8-slot set reporting 306746 cycles/tile
(but overflowing the host buffer after 2 of 384 tiles) against a sparse 5-slot set reporting 44602
across all 384. The sparse figure implies 1.286 MAC/cycle, which that kernel cannot reach.

`306746 - 44602 = 262144 = 2**18`, exactly. Decoding the capture confirms the mechanism: each of the
384 per-tile `INSTR_EVENT_0` to `INSTR_EVENT_1` brackets contains exactly one `Event_Sync`, because
the real interval needs one carry. Dense never wraps, its packets fire every ~1.83 cycles. Dense is
independently corroborated by untraced wall clock, 65.44 ms against 65.60 ms, 0.25%.

`test/python/test_trace_event_sync_carry.py` replays those captured bytes and asserts the 306746
delta, pinning the regression to real hardware output rather than a synthetic packet stream.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
