### PR TITLE
[python] Make ExternalFunction source-copy naming deterministic

### DIFF
--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -624,13 +624,10 @@ def compile_external_kernel(func, kernel_dir, target_arch):
         )
 
     elif func._source_file is not None:
-        # Named after the real source basename (not the entry point) so the
-        # embedded debug/.strtab filename is deterministic: with several
-        # ExternalFunctions sharing one object_file_name, only the first one
-        # visited in `ExternalFunction._instances` (a content-hashed set,
-        # so iteration order shifts whenever ANY registered kernel's content
-        # changes) actually compiles, and its naming used to leak into every
-        # sibling entry point's object.
+        # Named after the real source basename, not the entry point: entry
+        # points sharing one object_file_name compile only on the first
+        # visit, and `_instances` iteration order (a content-hashed set)
+        # shifts whenever any registered kernel's content changes.
         source_file = os.path.join(kernel_dir, os.path.basename(func._source_file))
         # Check if source file exists before copying
         if not os.path.exists(func._source_file):

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -603,9 +603,8 @@ def compile_external_kernel(func, kernel_dir, target_arch):
             _rename_symbol_in_object(output_file, func._original_name, func._name)
         return
 
-    original_name = getattr(func, "_original_name", func._name)
-
     if func._source_string is not None:
+        original_name = getattr(func, "_original_name", func._name)
         source_file = os.path.join(kernel_dir, f"{original_name}.cc")
         with open(source_file, "w") as f:
             f.write(func._source_string)
@@ -625,13 +624,21 @@ def compile_external_kernel(func, kernel_dir, target_arch):
         )
 
     elif func._source_file is not None:
-        source_file = os.path.join(kernel_dir, f"{original_name}.cc")
+        # Named after the real source basename (not the entry point) so the
+        # embedded debug/.strtab filename is deterministic: with several
+        # ExternalFunctions sharing one object_file_name, only the first one
+        # visited in `ExternalFunction._instances` (a content-hashed set,
+        # so iteration order shifts whenever ANY registered kernel's content
+        # changes) actually compiles, and its naming used to leak into every
+        # sibling entry point's object.
+        source_file = os.path.join(kernel_dir, os.path.basename(func._source_file))
         # Check if source file exists before copying
         if not os.path.exists(func._source_file):
             raise FileNotFoundError(
                 f"ExternalFunction '{func._name}': source file not found: {func._source_file}"
             )
-        shutil.copy2(func._source_file, source_file)
+        if os.path.abspath(source_file) != os.path.abspath(func._source_file):
+            shutil.copy2(func._source_file, source_file)
         # Include the original source file's directory so relative includes
         # (e.g. "../aie_kernel_utils.h") still resolve after the file is
         # copied into kernel_dir.

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -635,7 +635,10 @@ def compile_external_kernel(func, kernel_dir, target_arch):
                 f"ExternalFunction '{func._name}': source file not found: {func._source_file}"
             )
         if os.path.abspath(source_file) != os.path.abspath(func._source_file):
-            shutil.copy2(func._source_file, source_file)
+            try:
+                shutil.copy2(func._source_file, source_file)
+            except shutil.SameFileError:
+                pass
         # Include the original source file's directory so relative includes
         # (e.g. "../aie_kernel_utils.h") still resolve after the file is
         # copied into kernel_dir.

--- a/test/python/npu/test_jit_utils.py
+++ b/test/python/npu/test_jit_utils.py
@@ -108,6 +108,122 @@ def test_compile_external_kernel_source_file(npu_target_arch):
         assert os.path.getsize(obj) > 0
 
 
+def test_compile_external_kernel_source_file_uses_true_basename(npu_target_arch):
+    """The copied/embedded source name must be the real file's basename, not
+    the entry point name, so it stays stable regardless of which entry point
+    of a multi-entry-point source file happens to compile first."""
+    with (
+        tempfile.TemporaryDirectory() as src_dir,
+        tempfile.TemporaryDirectory() as kernel_dir,
+    ):
+        src = os.path.join(src_dir, "conv.cc")
+        with open(src, "w") as f:
+            f.write("""extern "C" {
+                void conv_step(int* a, int* b, int n) {
+                    for (int i = 0; i < n; i++) b[i] = a[i] + 1;
+                }
+            }""")
+
+        func = ExternalFunction("conv_step", source_file=src)
+        compile_external_kernel(func, kernel_dir, target_arch=npu_target_arch)
+
+        assert os.path.exists(os.path.join(kernel_dir, "conv.cc"))
+        assert not os.path.exists(os.path.join(kernel_dir, "conv_step.cc"))
+
+
+def test_compile_external_kernel_shared_object_deterministic(npu_target_arch):
+    """Several ExternalFunctions with distinct entry points but a shared
+    ``object_file_name`` must produce a byte-identical object regardless of
+    which entry point is compiled first.
+
+    Regression: only the first-visited entry point actually compiles (the
+    rest hit the output-file-exists cache check), so its (previously
+    entry-point-derived) source naming used to leak into the shared object.
+    Since ``ExternalFunction._instances`` is a content-hashed set, the
+    "first-visited" entry point is perturbed by edits to unrelated kernels,
+    making the embedded name (and thus the object's bytes) nondeterministic.
+    """
+    with tempfile.TemporaryDirectory() as src_dir:
+        src = os.path.join(src_dir, "conv.cc")
+        with open(src, "w") as f:
+            f.write("""extern "C" {
+                void conv_begin(int* a, int* b, int n) {}
+                void conv_step(int* a, int* b, int n) {}
+            }""")
+
+        def build(order):
+            ExternalFunction._instances.clear()
+            funcs = {
+                "conv_begin": ExternalFunction(
+                    "conv_begin", object_file_name="conv.o", source_file=src
+                ),
+                "conv_step": ExternalFunction(
+                    "conv_step", object_file_name="conv.o", source_file=src
+                ),
+            }
+            with tempfile.TemporaryDirectory() as kernel_dir:
+                for name in order:
+                    compile_external_kernel(
+                        funcs[name], kernel_dir, target_arch=npu_target_arch
+                    )
+                with open(os.path.join(kernel_dir, "conv.o"), "rb") as f:
+                    return f.read()
+
+        first = build(["conv_begin", "conv_step"])
+        second = build(["conv_step", "conv_begin"])
+        assert first == second
+
+
+def test_compile_external_kernel_same_source_multiple_entries_no_collision(
+    npu_target_arch,
+):
+    """Two ExternalFunctions built from the SAME source file (different entry
+    points, different object_file_name) must compile cleanly -- this is the
+    normal "one .cc, several kernels" pattern (e.g. kernels.mm's matmul +
+    zero symbols)."""
+    with (
+        tempfile.TemporaryDirectory() as src_dir,
+        tempfile.TemporaryDirectory() as kernel_dir,
+    ):
+        src = os.path.join(src_dir, "mm.cc")
+        with open(src, "w") as f:
+            f.write("""extern "C" {
+                void zero_kernel(int* a) {}
+                void matmul_kernel(int* a) {}
+            }""")
+
+        zero = ExternalFunction("zero_kernel", source_file=src)
+        matmul = ExternalFunction("matmul_kernel", source_file=src)
+        compile_external_kernel(zero, kernel_dir, target_arch=npu_target_arch)
+        compile_external_kernel(matmul, kernel_dir, target_arch=npu_target_arch)
+
+        assert os.path.exists(os.path.join(kernel_dir, "mm.cc"))
+        assert os.path.exists(os.path.join(kernel_dir, "zero_kernel.o"))
+        assert os.path.exists(os.path.join(kernel_dir, "matmul_kernel.o"))
+
+
+def test_compile_external_kernel_source_file_already_in_kernel_dir(npu_target_arch):
+    """kernel_dir == the source file's own directory must not crash.
+
+    Naming the copy after the true basename means source_file and the
+    computed destination can be the literal same path (e.g. a caller that
+    compiles a design in place). shutil.copy2 raises SameFileError when src
+    and dst are identical, so compile_external_kernel must skip the copy
+    rather than attempt it unconditionally.
+    """
+    with tempfile.TemporaryDirectory() as kernel_dir:
+        src = os.path.join(kernel_dir, "in_place.cc")
+        with open(src, "w") as f:
+            f.write('extern "C" void in_place(int* a) {}')
+
+        func = ExternalFunction("in_place", source_file=src)
+        compile_external_kernel(func, kernel_dir, target_arch=npu_target_arch)
+
+        obj = os.path.join(kernel_dir, "in_place.o")
+        assert os.path.exists(obj)
+        assert os.path.getsize(obj) > 0
+
+
 def test_compile_external_kernel_marks_compiled(npu_target_arch):
     """compile_external_kernel must set func._compiled = True on success."""
     func = ExternalFunction(


### PR DESCRIPTION
<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

`compile_external_kernel()` named the copied/embedded kernel source after the entry-point name (`f"{original_name}.cc"`) instead of the real source file. When several entry points share one `object_file_name`, only the first-visited one actually compiles — and since `ExternalFunction._instances` is a content-hashed set, "first-visited" shifts whenever *any* registered kernel's content changes, flipping the embedded source name (and thus the object's bytes) even though codegen is unchanged. This defeats diffing compiled kernel objects to prove a refactor is codegen-neutral.

Fix: name the copied file after the real source basename, and skip the copy when source and destination are the same path (basename-naming can make them coincide for an in-place build, and `shutil.copy2` raises `SameFileError` on a self-copy).

A basename-collision guard was considered and dropped — it either has to trust `kernel_dir`'s on-disk contents (which can be a directory reused across separate builds, so a stale leftover reads as a false collision) or scan the global `ExternalFunction._instances` registry (which false-positives against this repo's own per-arch kernel convention, e.g.,  `aie_kernels/aie2/mm.cc` vs `aie_kernels/aie2p/mm.cc`). No in-tree design needs it today, so this ships the minimal, deterministic fix only.


## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
