### PR TITLE
[AIEX] Look inside nested regions when materializing runtime sequences

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
@@ -182,14 +182,19 @@ collectReferencedSSAValues(Operation *op, const IRMapping &argMap,
   for (Region &region : op->getRegions()) {
     region.walk([&](Operation *nestedOp) {
       for (Value operand : nestedOp->getOperands()) {
+        // `continue`, not `return`: skipping an operand must not abandon the
+        // rest of the same operation's operands. Returning here means an op
+        // whose first operand is already mapped never has its later operands
+        // examined, so a genuine external reference beside a mapped one is
+        // silently dropped.
         if (argMap.contains(operand)) {
-          return;
+          continue;
         }
 
         // Check if defined within the parent operation.
         if (Operation *defOp = operand.getDefiningOp()) {
           if (op->isProperAncestor(defOp)) {
-            return;
+            continue;
           }
         } else if (auto blockArg = llvm::dyn_cast<BlockArgument>(operand)) {
           // A block argument has no defining op, so the check above cannot see
@@ -200,7 +205,7 @@ collectReferencedSSAValues(Operation *op, const IRMapping &argMap,
           // fail with "Referenced value is not defined by an operation".
           Operation *owner = blockArg.getOwner()->getParentOp();
           if (owner && (owner == op || op->isProperAncestor(owner))) {
-            return;
+            continue;
           }
         }
 

--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
@@ -182,11 +182,6 @@ collectReferencedSSAValues(Operation *op, const IRMapping &argMap,
   for (Region &region : op->getRegions()) {
     region.walk([&](Operation *nestedOp) {
       for (Value operand : nestedOp->getOperands()) {
-        // `continue`, not `return`: skipping an operand must not abandon the
-        // rest of the same operation's operands. Returning here means an op
-        // whose first operand is already mapped never has its later operands
-        // examined, so a genuine external reference beside a mapped one is
-        // silently dropped.
         if (argMap.contains(operand)) {
           continue;
         }
@@ -532,13 +527,7 @@ struct InlineRuntimeCallsPattern : RewritePattern {
       Operation *clonedOp = rewriter.clone(op, argMap);
       clonedOpInsertionPoint = rewriter.saveInsertionPoint();
 
-      // Symbol references are not only on the top-level op: an
-      // aiex.dma_configure_task_for naming a shim DMA allocation commonly sits
-      // inside an scf.for in the callee sequence. Those definitions need the
-      // same inlining and renaming, or the reference survives into the caller
-      // device pointing at a symbol that was left behind in the callee, and a
-      // later pass fails with "no shim DMA allocation found for symbol".
-      // walk() visits clonedOp itself as well as its nested ops.
+      // Inline symbol references in all nested ops.
       WalkResult symbolWalk = clonedOp->walk([&](Operation *nestedOp) {
         if (failed(inlineReferencedSymbolDefinitions(
                 rewriter, nestedOp, calleeRuntimeSequence.getOperation(),

--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
@@ -536,8 +536,8 @@ struct InlineRuntimeCallsPattern : RewritePattern {
       WalkResult symbolWalk = clonedOp->walk([&](Operation *nestedOp) {
         if (failed(inlineReferencedSymbolDefinitions(
                 rewriter, nestedOp, calleeRuntimeSequence.getOperation(),
-                argMap, previouslyInlinedSymbolMap, callerDevice,
-                clonedDefs, symbolDefInsertPoint, allSymbolNames))) {
+                argMap, previouslyInlinedSymbolMap, callerDevice, clonedDefs,
+                symbolDefInsertPoint, allSymbolNames))) {
           return WalkResult::interrupt();
         }
         return WalkResult::advance();

--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeRuntimeSequences.cpp
@@ -186,10 +186,22 @@ collectReferencedSSAValues(Operation *op, const IRMapping &argMap,
           return;
         }
 
-        // Check if defined within the parent operation
-        Operation *defOp = operand.getDefiningOp();
-        if (defOp && op->isProperAncestor(defOp)) {
-          return;
+        // Check if defined within the parent operation.
+        if (Operation *defOp = operand.getDefiningOp()) {
+          if (op->isProperAncestor(defOp)) {
+            return;
+          }
+        } else if (auto blockArg = llvm::dyn_cast<BlockArgument>(operand)) {
+          // A block argument has no defining op, so the check above cannot see
+          // it. One belonging to a region nested inside `op` -- an scf.for
+          // induction variable, most commonly -- is nonetheless defined within
+          // `op` and must not be collected as an external reference: it would
+          // reach copyReferencedSSAValues, whose getDefiningOp() is null, and
+          // fail with "Referenced value is not defined by an operation".
+          Operation *owner = blockArg.getOwner()->getParentOp();
+          if (owner && (owner == op || op->isProperAncestor(owner))) {
+            return;
+          }
         }
 
         processValue(operand);
@@ -515,10 +527,23 @@ struct InlineRuntimeCallsPattern : RewritePattern {
       Operation *clonedOp = rewriter.clone(op, argMap);
       clonedOpInsertionPoint = rewriter.saveInsertionPoint();
 
-      if (failed(inlineReferencedSymbolDefinitions(
-              rewriter, clonedOp, calleeRuntimeSequence.getOperation(), argMap,
-              previouslyInlinedSymbolMap, callerDevice, symbolDefInsertPoint,
-              allSymbolNames))) {
+      // Symbol references are not only on the top-level op: an
+      // aiex.dma_configure_task_for naming a shim DMA allocation commonly sits
+      // inside an scf.for in the callee sequence. Those definitions need the
+      // same inlining and renaming, or the reference survives into the caller
+      // device pointing at a symbol that was left behind in the callee, and a
+      // later pass fails with "no shim DMA allocation found for symbol".
+      // walk() visits clonedOp itself as well as its nested ops.
+      WalkResult symbolWalk = clonedOp->walk([&](Operation *nestedOp) {
+        if (failed(inlineReferencedSymbolDefinitions(
+                rewriter, nestedOp, calleeRuntimeSequence.getOperation(),
+                argMap, previouslyInlinedSymbolMap, callerDevice,
+                symbolDefInsertPoint, allSymbolNames))) {
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      if (symbolWalk.wasInterrupted()) {
         return failure();
       }
     }

--- a/test/Passes/materialize-runtime-sequences/inline_loop_block_arg.mlir
+++ b/test/Passes/materialize-runtime-sequences/inline_loop_block_arg.mlir
@@ -1,0 +1,54 @@
+//===- inline_loop_block_arg.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences %s | FileCheck %s
+
+// A callee sequence whose body contains an scf.for, with the induction
+// variable used inside the loop.
+//
+// The induction variable is a block argument, so it has no defining op and the
+// "is this value defined inside the op being inlined?" test in
+// collectReferencedSSAValues cannot see it that way. Without treating block
+// arguments explicitly it is collected as an *external* reference, reaches
+// copyReferencedSSAValues, and fails there on its null getDefiningOp() check
+// with "Referenced value is not defined by an operation".
+
+module {
+  aie.device(npu2) @main {
+    %tile00 = aie.tile(0, 0)
+
+    // CHECK-LABEL: aie.runtime_sequence @main_seq
+    aie.runtime_sequence @main_seq(%arg0: memref<64xi32>) {
+      // CHECK: aiex.npu.load_pdi {device_ref = @loop_device}
+      // The loop is inlined intact, and the induction variable stays the
+      // loop's own -- it must not have been hoisted into the caller.
+      // CHECK: scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+      // CHECK:   %[[C:.*]] = arith.index_cast %[[IV]] : index to i32
+      // CHECK:   aiex.npu.rtp_write({{.*}}, 0, %[[C]])
+      // CHECK: }
+      aiex.configure @loop_device {
+        aiex.run @loop_seq(%arg0) : (memref<64xi32>)
+      }
+    }
+  }
+
+  // CHECK: aie.device(npu2) @loop_device
+  aie.device(npu2) @loop_device {
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp_0_0 = aie.buffer(%tile_0_2) {sym_name = "rtp_0_0", address = 0xDEADBEEF : i32} : memref<1xi32>
+
+    aie.runtime_sequence @loop_seq(%arg0: memref<64xi32>) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      scf.for %i = %c0 to %c4 step %c1 {
+        %v = arith.index_cast %i : index to i32
+        aiex.npu.rtp_write(@rtp_0_0, 0, %v) : i32
+      }
+    }
+  }
+}

--- a/test/Passes/materialize-runtime-sequences/inline_symbols_in_loop.mlir
+++ b/test/Passes/materialize-runtime-sequences/inline_symbols_in_loop.mlir
@@ -21,15 +21,21 @@
 // and it working while the in-loop one did not is what the bug looked like.
 
 module {
+  // Anchor on the caller device, so the CHECK-DAGs below cannot be satisfied
+  // by the callee's own definitions. The pass emits the rewritten caller
+  // without a sym name, so the trailing brace is what distinguishes it from
+  // @config_with_symbols -- `@main` does not survive into the output.
+  // CHECK: aie.device(npu2) {
   aie.device(npu2) @main {
     %tile00 = aie.tile(0, 0)
 
     // Both definitions have to be inlined into the caller device, not just
-    // the top-level one. They are placed ahead of the sequence that uses them.
-    // CHECK: aie.shim_dma_allocation @buffer_top
-    // CHECK: aie.shim_dma_allocation @buffer_in_loop
+    // the top-level one. They are placed ahead of the sequence that uses
+    // them; the order between the two is not part of the contract.
+    // CHECK-DAG: aie.shim_dma_allocation @buffer_top
+    // CHECK-DAG: aie.shim_dma_allocation @buffer_in_loop
 
-    // CHECK-LABEL: aie.runtime_sequence @main_seq
+    // CHECK: aie.runtime_sequence @main_seq
     aie.runtime_sequence @main_seq(%arg0: memref<64xi32>) {
       // CHECK: aiex.npu.load_pdi {device_ref = @config_with_symbols}
       // CHECK: aiex.npu.dma_memcpy_nd
@@ -45,8 +51,8 @@ module {
 
   // The originals stay put in the callee device.
   // CHECK: aie.device(npu2) @config_with_symbols
-  // CHECK: aie.shim_dma_allocation @buffer_top
-  // CHECK: aie.shim_dma_allocation @buffer_in_loop
+  // CHECK-DAG: aie.shim_dma_allocation @buffer_top
+  // CHECK-DAG: aie.shim_dma_allocation @buffer_in_loop
   aie.device(npu2) @config_with_symbols {
     %tile20 = aie.tile(2, 0)
     %tile30 = aie.tile(3, 0)

--- a/test/Passes/materialize-runtime-sequences/inline_symbols_in_loop.mlir
+++ b/test/Passes/materialize-runtime-sequences/inline_symbols_in_loop.mlir
@@ -1,0 +1,66 @@
+//===- inline_symbols_in_loop.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-materialize-runtime-sequences %s | FileCheck %s
+
+// The symbol-inlining companion to inline_symbols.mlir: same shim DMA
+// allocation, but referenced from an op *nested* in an scf.for rather than at
+// the top level of the callee sequence.
+//
+// inlineReferencedSymbolDefinitions reads only the attributes of the op it is
+// handed, and it was called once per top-level op of the callee body, so a
+// reference inside a loop was never visited. The definition was then left
+// behind in the callee while the reference travelled into the caller, and a
+// later pass failed with "no shim DMA allocation found for symbol".
+//
+// Both allocations are checked deliberately: the top-level one already worked,
+// and it working while the in-loop one did not is what the bug looked like.
+
+module {
+  aie.device(npu2) @main {
+    %tile00 = aie.tile(0, 0)
+
+    // Both definitions have to be inlined into the caller device, not just
+    // the top-level one. They are placed ahead of the sequence that uses them.
+    // CHECK: aie.shim_dma_allocation @buffer_top
+    // CHECK: aie.shim_dma_allocation @buffer_in_loop
+
+    // CHECK-LABEL: aie.runtime_sequence @main_seq
+    aie.runtime_sequence @main_seq(%arg0: memref<64xi32>) {
+      // CHECK: aiex.npu.load_pdi {device_ref = @config_with_symbols}
+      // CHECK: aiex.npu.dma_memcpy_nd
+      // CHECK-SAME: metadata = @buffer_top
+      // CHECK: scf.for
+      // CHECK:   aiex.npu.dma_memcpy_nd
+      // CHECK-SAME: metadata = @buffer_in_loop
+      aiex.configure @config_with_symbols {
+        aiex.run @seq_with_dma(%arg0) : (memref<64xi32>)
+      }
+    }
+  }
+
+  // The originals stay put in the callee device.
+  // CHECK: aie.device(npu2) @config_with_symbols
+  // CHECK: aie.shim_dma_allocation @buffer_top
+  // CHECK: aie.shim_dma_allocation @buffer_in_loop
+  aie.device(npu2) @config_with_symbols {
+    %tile20 = aie.tile(2, 0)
+    %tile30 = aie.tile(3, 0)
+    aie.shim_dma_allocation @buffer_top(%tile20, S2MM, 0)
+    aie.shim_dma_allocation @buffer_in_loop(%tile30, S2MM, 1)
+
+    aie.runtime_sequence @seq_with_dma(%arg0: memref<64xi32>) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) { metadata = @buffer_top, id = 0 : i64 } : memref<64xi32>
+      scf.for %i = %c0 to %c2 step %c1 {
+        aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) { metadata = @buffer_in_loop, id = 1 : i64 } : memref<64xi32>
+      }
+    }
+  }
+}


### PR DESCRIPTION
`AIEMaterializeRuntimeSequences` inlines an `aiex.run` call into the calling device, and in two places it only considered the top level of the callee's body. Any runtime sequence containing an `scf.for` hits one or both. Both are reachable today through `aircc --output-format elf` on an AIR design whose `air.segment` sequence has a loop in it.

## Values defined inside a nested region

`collectReferencedSSAValues` decides whether a value used in a nested region is defined within the op being inlined:

```cpp
Operation *defOp = operand.getDefiningOp();
if (defOp && op->isProperAncestor(defOp)) return;
```

A block argument has no defining op, so this never fires for one. An `scf.for` induction variable is therefore collected as an *external* reference, reaches `copyReferencedSSAValues`, and fails its null `getDefiningOp()` check:

```
error: Referenced value is not defined by an operation
error: 'aiex.run' op expects parent op 'aiex.configure'
```

The second error is misleading — the op *is* inside an `aiex.configure`, and `ConfigureOp` is not `IsolatedFromAbove`, so the operands are legally visible. The first is the real one. Fixed by extending the "defined within" test to a block argument whose owning region is nested inside the op.

## Symbol references in nested regions

`inlineReferencedSymbolDefinitions` reads only the attributes of the op it is given, and was called once per *top-level* op of the callee body. An `aiex.dma_configure_task_for` naming a shim DMA allocation commonly sits inside an `scf.for`, so its symbol was never visited: the definition stayed in the callee while the reference travelled into the caller, and a later pass failed with

```
error: 'aiex.dma_configure_task_for' op no shim DMA allocation found for symbol @air_outD_15
```

Top-level allocations inlined correctly, which is why only the in-loop ones failed. Fixed by walking the cloned op so nested references get the same inlining and renaming.

The two are sequential: the first fix is what exposes the second, so splitting them would ship a change that turns one error into another.

## Tests

Two tests, one per fix, in the existing `test/Passes/materialize-runtime-sequences` suite:

- **`inline_loop_block_arg.mlir`** — an induction variable used in the loop body. Errors out before the fix.
- **`inline_symbols_in_loop.mlir`** — a shim DMA allocation referenced from inside a loop alongside one referenced at top level. Before the fix the pass *succeeds* but silently leaves the in-loop allocation behind in the callee, so this is a FileCheck failure rather than an error. That catches the bug where it is introduced instead of in a downstream pass, and the top-level allocation is checked alongside deliberately: it working while the in-loop one did not is what the bug looked like.

The other eight tests in the suite are unaffected.

Also verified on hardware (NPU2 / Strix), since the second fix concerns IR that is wrong rather than IR that is rejected:

- mlir-air's `int4_q4nx` matrix-vector example builds an ELF whose output is **bitwise identical** to the `golden.elf` the example ships (0 of 2048 elements differ).
- A 16-layer fused decode superkernel builds an ELF whose logits are **bitwise identical** to the xclbin built from the same module.

Validation ran against `af819a802f4` (the commit `mlir-air/utils/clone-mlir-aie.sh` pins), where `AIEMaterializeRuntimeSequences.cpp` and `test/Passes/materialize-runtime-sequences/` are byte-identical to `main`. CI is the check on `main` itself.

## Known follow-up, not addressed here

With the second fix in place, a caller that inlines many `aiex.run` calls — 23, in a decode compiled with shim-DMA BD tiling — fails with `redefinition of symbol named '__air_herd_lock_2_2'`. `allSymbolNames` is seeded once from the caller's top-level block while `previouslyInlinedSymbolMap` is local to each `matchAndRewrite`, so every call re-inlines the whole callee symbol set; that should still produce unique names, so one of the two is not holding across invocations. Stated as unresolved rather than guessed at — happy to file it separately.
