### PR TITLE
[AIE] Mark assert-only loop variables maybe_unused

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -1110,13 +1110,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         llvm::dbgs() << '\n';
       });
 
-      for (int id : matchIds)
+      for ([[maybe_unused]] int id : matchIds)
         assert(llvm::any_of(cover,
                             [&](std::pair<int, int> c) {
                               return (id & c.first) == c.second;
                             }) &&
                "subcube cover misses a match id");
-      for (int id : avoidIds)
+      for ([[maybe_unused]] int id : avoidIds)
         assert(llvm::none_of(cover,
                              [&](std::pair<int, int> c) {
                                return (id & c.first) == c.second;


### PR DESCRIPTION
The two loops in `AIECreatePathFindFlows.cpp` that check the subcube cover use
their induction variable only inside `assert()`. In an `NDEBUG` build the
assert body disappears and the variable is reported as unused, which fails the
build under `-Werror`.

NFC.