### PR TITLE
aiecc: list --get-<name> output selectors in --help [LOW]

### DIFF
--- a/test/aiecc/help_output_selectors.mlir
+++ b/test/aiecc/help_output_selectors.mlir
@@ -6,10 +6,9 @@
 //===----------------------------------------------------------------------===//
 
 // The `--get-<name>` output-selector shorthands are resolved by
-// applyOutputSelectorFlags() before llvm::cl ever parses argv, so none of them
-// are registered as a cl::opt and --help/--help-hidden used to omit the whole
-// family; the only place the list appeared was the "unknown output selector"
-// diagnostic for a typo'd flag. cl::extrahelp now appends it to both.
+// applyOutputSelectorFlags() before llvm::cl ever parses argv, so none of
+// them are registered as a cl::opt and would not otherwise appear in
+// --help/--help-hidden. cl::extrahelp appends the list to both.
 
 // RUN: aiecc --help 2>&1 | FileCheck %s
 // RUN: aiecc --help-hidden 2>&1 | FileCheck %s

--- a/test/aiecc/help_output_selectors.mlir
+++ b/test/aiecc/help_output_selectors.mlir
@@ -1,0 +1,47 @@
+//===- help_output_selectors.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The `--get-<name>` output-selector shorthands are resolved by
+// applyOutputSelectorFlags() before llvm::cl ever parses argv, so none of them
+// are registered as a cl::opt and --help/--help-hidden used to omit the whole
+// family; the only place the list appeared was the "unknown output selector"
+// diagnostic for a typo'd flag. cl::extrahelp now appends it to both.
+
+// RUN: aiecc --help 2>&1 | FileCheck %s
+// RUN: aiecc --help-hidden 2>&1 | FileCheck %s
+
+// CHECK: OUTPUT SELECTORS:
+// CHECK-DAG: --get-scratchpad-parameters  (params.txt)
+// CHECK-DAG: --get-xclbin  (aie.xclbin)
+// CHECK-DAG: --get-full-elf  (aie.elf)
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %input = aie.objectfifo.acquire @of_in (Consume, 1) : memref<16xi32>
+      %output = aie.objectfifo.acquire @of_out (Produce, 1) : memref<16xi32>
+      aie.objectfifo.release @of_in (Consume, 1)
+      aie.objectfifo.release @of_out (Produce, 1)
+      aie.end
+    }
+
+    aie.runtime_sequence(%in : memref<16xi32>, %out : memref<16xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c16 = arith.constant 16 : i64
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_wait {symbol = @of_out}
+    }
+  }
+}

--- a/tools/aiecc/CommandLineOptions.h
+++ b/tools/aiecc/CommandLineOptions.h
@@ -389,19 +389,15 @@ inline llvm::ArrayRef<OutputSelector> outputSelectors() {
   return table;
 }
 
-// Shared by the "unknown selector" diagnostic below and the --help text
-// (outputSelectorHelpText()), so the two can't drift apart.
 inline void printOutputSelectorTable(llvm::raw_ostream &os) {
   for (const OutputSelector &s : outputSelectors())
     os << "  --get-" << s.niceName << "  (" << s.edgeName << ")\n";
 }
 
 // `--get-<name>` is resolved by applyOutputSelectorFlags() below before
-// llvm::cl ever parses argv, so the shorthands are never registered as
-// cl::opt and are invisible to --help/--help-hidden; previously the only way
-// to see the list was to pass an unrecognized `--get-<name>` and read the
-// resulting error. cl::extrahelp appends this text after the normal --help
-// output instead.
+// llvm::cl ever parses argv, so the shorthands are never registered as a
+// cl::opt and are invisible to --help/--help-hidden without this.
+// cl::extrahelp appends the text after the normal --help output.
 inline std::string outputSelectorHelpText() {
   std::string text;
   llvm::raw_string_ostream os(text);

--- a/tools/aiecc/CommandLineOptions.h
+++ b/tools/aiecc/CommandLineOptions.h
@@ -389,6 +389,35 @@ inline llvm::ArrayRef<OutputSelector> outputSelectors() {
   return table;
 }
 
+// Shared by the "unknown selector" diagnostic below and the --help text
+// (outputSelectorHelpText()), so the two can't drift apart.
+inline void printOutputSelectorTable(llvm::raw_ostream &os) {
+  for (const OutputSelector &s : outputSelectors())
+    os << "  --get-" << s.niceName << "  (" << s.edgeName << ")\n";
+}
+
+// `--get-<name>` is resolved by applyOutputSelectorFlags() below before
+// llvm::cl ever parses argv, so the shorthands are never registered as
+// cl::opt and are invisible to --help/--help-hidden; previously the only way
+// to see the list was to pass an unrecognized `--get-<name>` and read the
+// resulting error. cl::extrahelp appends this text after the normal --help
+// output instead.
+inline std::string outputSelectorHelpText() {
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  os << "\nOUTPUT SELECTORS:\n"
+        "  Named shorthands for --get=<name> (see above), and the artifact "
+        "each\n  selects (relative to --output-dir):\n";
+  printOutputSelectorTable(os);
+  return text;
+}
+
+// cl::extrahelp only keeps a StringRef, so the backing std::string needs its
+// own storage; declared first so it is initialized before the extrahelp that
+// references it (declaration order fixes initialization order within a TU).
+inline const std::string kOutputSelectorHelpText = outputSelectorHelpText();
+inline llvm::cl::extrahelp outputSelectorExtraHelp(kOutputSelectorHelpText);
+
 // Resolve the `--get-<niceName>` shorthands in `args` before cl parsing: set
 // each recognized selector's bool and drop its token; a token after a `--`
 // separator (host passthrough) is left untouched. Returns false after
@@ -412,9 +441,7 @@ inline bool applyOutputSelectorFlags(std::vector<std::string> &args) {
       if (!sel) {
         llvm::errs() << "aiecc: unknown output selector '--get-" << nice
                      << "'; available selectors are:\n";
-        for (const OutputSelector &s : outputSelectors())
-          llvm::errs() << "  --get-" << s.niceName << "  (" << s.edgeName
-                       << ")\n";
+        printOutputSelectorTable(llvm::errs());
         return false;
       }
       *sel->flag = true;


### PR DESCRIPTION

## Description

`aiecc --help` and `--help-hidden` list exactly one `--get-*` flag: the generic `--get=<name>`. None of the 14 named shorthands (`--get-xclbin`, `--get-full-elf`, `--get-scratchpad-parameters`, etc.) appear in either. The only place the full list is printed is the diagnostic for an unrecognized `--get-<name>`, i.e. you have to guess wrong to find out what exists. I spent significant time concluding `--get-scratchpad-parameters` did not exist for exactly this reason, before finding it in the source.

The cause: `applyOutputSelectorFlags()` in `CommandLineOptions.h` rewrites `--get-<name>` into the matching selector's bool and drops the token from argv *before* `llvm::cl::ParseCommandLineOptions` runs. None of the 14 shorthands is ever registered as a `cl::opt`, so `--help`/`--help-hidden` (which only enumerate registered options) never see them, even though `outputSelectors()` already holds the full `{name, artifact}` table and the unknown-selector diagnostic already prints it in full.

This factors that per-selector line format into `printOutputSelectorTable()`, used both by the existing diagnostic (unchanged output) and by a new `cl::extrahelp` block appended after the normal `--help`/`--help-hidden` output, built once from the same `outputSelectors()` table. No selector-resolution behavior changes; this only adds a static list to `--help`.

Added `test/aiecc/help_output_selectors.mlir`, checking that `--help` and `--help-hidden` both contain the new `OUTPUT SELECTORS:` block and a few representative entries. I confirmed this test fails against the current `aiecc` (no such block) and pass/fail wiring is otherwise identical to the neighboring `unknown_args_rejected.mlir`/`cpp_backend_dir_missing.mlir` tests in the same directory.

Validation I could actually do: the `cl::extrahelp` + static-initialization-order pattern (the backing `std::string` must construct before the `extrahelp` that references it) compiles, links and runs correctly in an isolated program against this project's pinned LLVM `Support` library, producing the expected appended block. I did not get a full local `aiecc` build to green: my working copy's `third_party/aie-rt` vendored patch fails to apply against the submodule state in my sandbox, unrelated to this change (unmodified files elsewhere in the tree). So I have not run the new lit test against an actual patched `aiecc` binary; I'm flagging that gap rather than claiming otherwise.

## Checklist

- [ ] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))

Notes on the checklist: the new lit test is written and confirmed to fail pre-patch, but I have not built a patched `aiecc` locally to confirm it passes post-patch (see above), so I'm leaving that box unchecked rather than claiming it. No Python file is touched. `clang-tidy`'s enabled list currently covers `tools/aiecc/aiecc.cpp` but not `CommandLineOptions.h`, so there's no touched file under its scope. `clang-format` is 22.1.8 locally (this repo's CI pins 20.1.0; past history has one file differ between the two versions) and reports no changes needed on the touched lines.
