### PR TITLE
aiecc: add AIECC_JOBS to cap compilation parallelism

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -184,6 +184,10 @@ jobs:
             LIT_OPTS="-j12 $LIT_OPTS"
           fi
 
+          # Cap aiecc's internal per-design scheduler independently of lit's
+          # test-level -j setting to stay within this runner's memory limit.
+          export AIECC_JOBS=1
+
           export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
 
           # Build from source, unless this is a narrowed retry: the build

--- a/test/aiecc/jobs_environment.mlir
+++ b/test/aiecc/jobs_environment.mlir
@@ -1,0 +1,20 @@
+//===- jobs_environment.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// These dry runs exercise option handling without compiling a design.
+
+// RUN: env AIECC_JOBS=1 aiecc --emit-dot > /dev/null
+// RUN: env AIECC_JOBS=invalid aiecc -j1 --emit-dot > /dev/null
+// RUN: env AIECC_JOBS=invalid aiecc --nthreads=1 --emit-dot > /dev/null
+
+// RUN: not env AIECC_JOBS= aiecc --emit-dot 2>&1 | FileCheck %s
+// RUN: not env AIECC_JOBS=-1 aiecc --emit-dot 2>&1 | FileCheck %s
+// RUN: not env AIECC_JOBS=' 1' aiecc --emit-dot 2>&1 | FileCheck %s
+// RUN: not env AIECC_JOBS=1x aiecc --emit-dot 2>&1 | FileCheck %s
+// RUN: not env AIECC_JOBS=4294967296 aiecc --emit-dot 2>&1 | FileCheck %s
+
+// CHECK: aiecc: invalid AIECC_JOBS value '{{.*}}': expected a non-negative integer that fits in an unsigned value

--- a/tools/aiecc/README.md
+++ b/tools/aiecc/README.md
@@ -48,6 +48,24 @@ You can override these output file names with `--npu-insts-name`,
 `--xclbin-name`, and `--full-elf-name`. You can filter which devices and 
 runtime sequences are compiled with `--device-name` and `--sequence-name`. 
 
+### Limiting parallel compilation
+
+`aiecc` compiles independent parts of a design, including its cores, in
+parallel. Use `-j N` (or `--nthreads=N`) to limit that parallelism. `-j 1` runs
+compilation sequentially; `-j 0` uses the machine's hardware concurrency and
+is the default.
+
+To apply a limit to every `aiecc` invocation without changing each caller, set
+the `AIECC_JOBS` environment variable:
+
+```bash
+AIECC_JOBS=1 ninja check-aie
+```
+
+An explicit `-j` or `--nthreads` takes precedence over `AIECC_JOBS`, which in
+turn takes precedence over the default. The environment variable accepts the
+same non-negative integer values as `-j`, including `0` for auto-detection.
+
 ### Seeing what the compiler will do / dry-running: `--emit-dot`
 
 The compiler builds its execution plan from the flags you pass.

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -71,6 +71,34 @@ using namespace xilinx::aiecc::cli;
 
 namespace {
 
+// Apply the process-wide parallelism cap only when the command line did not
+// select one explicitly. Keep the accepted syntax identical to -j: an
+// unsigned decimal value, including 0 for hardware auto-detection.
+bool applyJobsEnvironment() {
+  if (numThreads.getNumOccurrences() != 0)
+    return true;
+
+  const char *env = std::getenv("AIECC_JOBS");
+  if (!env)
+    return true;
+
+  llvm::StringRef value(env);
+  bool decimal = !value.empty();
+  for (char c : value)
+    decimal &= c >= '0' && c <= '9';
+
+  unsigned jobs = 0;
+  if (!decimal || value.getAsInteger(10, jobs)) {
+    llvm::errs() << "aiecc: invalid AIECC_JOBS value '" << value
+                 << "': expected a non-negative integer that fits in an "
+                    "unsigned value\n";
+    return false;
+  }
+
+  numThreads = jobs;
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // Shared subgraphs
 //===----------------------------------------------------------------------===//
@@ -1782,6 +1810,9 @@ int main(int argc, char **argv) {
     printVersion(llvm::outs());
     return 0;
   }
+
+  if (!applyJobsEnvironment())
+    return 1;
 
   // Resolve inter-option coupling once, up front: the Chess/Peano toolchain
   // selection (xchesscc/xbridge), the --get-aiesim implication, and the


### PR DESCRIPTION
Ported from @fifield -- stop our CI runners from OOMing

aiecc dispatches independent parts of a design, including its cores, to a thread pool sized by -j. lit's own -j multiplies that: a test-level -j12 can put twelve aiecc processes on the machine, each running its own pool. The Ryzen AI runners run out of memory under that product.

AIECC_JOBS sets the pool size for every aiecc invocation, so a caller can cap it without passing -j to each one. An explicit -j or --nthreads wins over the variable. The variable accepts the same values as -j, including 0 for hardware auto-detection. Set it to 1 in the Ryzen AI workflow, alongside the RAM-dependent lit -j.