### PR TITLE
[AIE] Reject a flow declared twice in DeviceOp::verify

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -25,6 +25,10 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 
+#include <map>
+#include <tuple>
+#include <vector>
+
 using namespace mlir;
 using namespace xilinx::AIE;
 
@@ -1907,6 +1911,120 @@ LogicalResult GetCascadeOp::verify() {
 // DeviceOp
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+// A flow endpoint reduced to a comparable key: resolved tile coordinates plus
+// the stream-switch port, as (col, row, bundle, channel). Only used for
+// equality and ordering, so the raw WireBundle enum value is a fine component.
+using PortKey = std::tuple<int, int, int, int>;
+
+// Returns the key for the port (`tileValue`, `bundle`, `channel`), or nullopt
+// when the tile's coordinates are not known yet -- an aie.logical_tile that
+// --aie-place-tiles has not placed. Two such endpoints cannot be compared
+// until placement runs, at which point the caller's check runs again on the
+// resulting aie.tile coordinates.
+std::optional<PortKey> tryGetPortKey(Value tileValue, WireBundle bundle,
+                                     int channel) {
+  auto tile = llvm::dyn_cast_or_null<TileLike>(tileValue.getDefiningOp());
+  if (!tile)
+    return std::nullopt;
+  std::optional<int> col = tile.tryGetCol();
+  std::optional<int> row = tile.tryGetRow();
+  if (!col || !row)
+    return std::nullopt;
+  return PortKey{*col, *row, static_cast<int>(bundle), channel};
+}
+
+std::string to_string(const PortKey &key) {
+  auto [col, row, bundle, channel] = key;
+  return "(" + std::to_string(col) + ", " + std::to_string(row) + ") " +
+         stringifyWireBundle(static_cast<WireBundle>(bundle)).str() + " : " +
+         std::to_string(channel);
+}
+
+// Rejects two aie.flow ops that declare the same source and destination port.
+// A repeated flow is not a harmless redundancy: Pathfinder::addFlow folds a
+// flow into any existing flow with the same source, so the duplicate lands in
+// that flow's destination list a second time and the router is asked to
+// broadcast to the same endpoint twice.
+LogicalResult verifyNoDuplicateFlows(DeviceOp device) {
+  std::map<std::pair<PortKey, PortKey>, FlowOp> flowSeen;
+  WalkResult result = device.walk([&](FlowOp flow) {
+    std::optional<PortKey> src = tryGetPortKey(
+        flow.getSource(), flow.getSourceBundle(), flow.getSourceChannel());
+    std::optional<PortKey> dst = tryGetPortKey(
+        flow.getDest(), flow.getDestBundle(), flow.getDestChannel());
+    if (!src || !dst)
+      return WalkResult::advance();
+    auto [it, inserted] = flowSeen.try_emplace({*src, *dst}, flow);
+    if (!inserted) {
+      InFlightDiagnostic diag = flow.emitOpError()
+                                << "duplicates an earlier flow; "
+                                << to_string(*src) << " -> " << to_string(*dst)
+                                << " is already declared";
+      diag.attachNote(it->second.getLoc()) << "the other flow is here";
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+// Rejects two aie.packet_flow ops that carry the same ID between the same set
+// of sources and destinations. Declaring the flow twice makes the routing
+// problem look more congested than it is and gives the two copies conflicting
+// keep_pkt_header/priority_route settings when their attributes disagree.
+LogicalResult verifyNoDuplicatePacketFlows(DeviceOp device) {
+  using PacketFlowKey =
+      std::tuple<int, std::vector<PortKey>, std::vector<PortKey>>;
+  std::map<PacketFlowKey, PacketFlowOp> packetFlowSeen;
+  WalkResult result = device.walk([&](PacketFlowOp packetFlow) {
+    Region &body = packetFlow.getPorts();
+    if (body.empty())
+      return WalkResult::advance();
+    // Sources and destinations are unordered within a packet flow, so sort
+    // both to give permutations of the same flow the same key.
+    std::vector<PortKey> sources, dests;
+    for (Operation &op : body.front()) {
+      std::vector<PortKey> *endpoints = nullptr;
+      std::optional<PortKey> port;
+      if (auto source = dyn_cast<PacketSourceOp>(op)) {
+        endpoints = &sources;
+        port = tryGetPortKey(source.getTile(), source.getBundle(),
+                             source.getChannel());
+      } else if (auto dest = dyn_cast<PacketDestOp>(op)) {
+        endpoints = &dests;
+        port =
+            tryGetPortKey(dest.getTile(), dest.getBundle(), dest.getChannel());
+      } else {
+        continue;
+      }
+      // One unplaced endpoint makes the whole flow incomparable.
+      if (!port)
+        return WalkResult::advance();
+      endpoints->push_back(*port);
+    }
+    if (sources.empty() || dests.empty())
+      return WalkResult::advance();
+    llvm::sort(sources);
+    llvm::sort(dests);
+    auto [it, inserted] = packetFlowSeen.try_emplace(
+        {packetFlow.IDInt(), std::move(sources), std::move(dests)}, packetFlow);
+    if (!inserted) {
+      InFlightDiagnostic diag =
+          packetFlow.emitOpError()
+          << "duplicates an earlier packet flow; ID " << packetFlow.IDInt()
+          << " is already declared between the same sources and destinations";
+      diag.attachNote(it->second.getLoc()) << "the other packet flow is here";
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+} // namespace
+
 LogicalResult DeviceOp::verify() {
   // A compute tile has exactly one core in hardware, so at most one aie.core
   // may resolve to any given (col, row). Cores whose tile is a logical_tile
@@ -1937,6 +2055,14 @@ LogicalResult DeviceOp::verify() {
   });
   if (result.wasInterrupted())
     return failure();
+
+  // A flow declared twice is always a mistake, and one that is otherwise only
+  // noticed (if at all) as unexplained routing pressure much later on.
+  if (failed(verifyNoDuplicateFlows(*this)))
+    return failure();
+  if (failed(verifyNoDuplicatePacketFlows(*this)))
+    return failure();
+
   return success();
 }
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -26,7 +26,10 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <map>
+#include <optional>
+#include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace mlir;

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -14,6 +14,8 @@
 #include <optional>
 #include <set>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 namespace xilinx::AIE {
 #define GEN_PASS_DEF_AIEFINDFLOWS

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -11,6 +11,9 @@
 
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
+#include <optional>
+#include <set>
+#include <tuple>
 
 namespace xilinx::AIE {
 #define GEN_PASS_DEF_AIEFINDFLOWS
@@ -226,8 +229,63 @@ public:
   }
 };
 
+// Identifies a flow by its two endpoints -- tile coordinates plus port -- and
+// the packet ID it carries, using kCircuitFlow for circuit-switched flows.
+// Coordinates rather than SSA values, so flows written against different
+// aie.tile ops for the same tile still compare equal.
+static constexpr int kCircuitFlow = -1;
+using FlowKey = std::tuple<int, int, int, int, int, int, int, int, int>;
+using FlowKeySet = std::set<FlowKey>;
+
+// Returns nullopt when either endpoint's coordinates are unknown, in which
+// case the caller cannot tell the flow apart from any other and must not
+// dedupe it away.
+static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
+                                            Operation *destOp, Port destPort,
+                                            int packetID) {
+  auto coords = [](Operation *op) -> std::optional<std::pair<int, int>> {
+    auto tile = llvm::dyn_cast_or_null<TileLike>(op);
+    if (!tile)
+      return std::nullopt;
+    std::optional<int> col = tile.tryGetCol();
+    std::optional<int> row = tile.tryGetRow();
+    if (!col || !row)
+      return std::nullopt;
+    return std::make_pair(*col, *row);
+  };
+  std::optional<std::pair<int, int>> src = coords(srcOp);
+  std::optional<std::pair<int, int>> dest = coords(destOp);
+  if (!src || !dest)
+    return std::nullopt;
+  return FlowKey{src->first,
+                 src->second,
+                 static_cast<int>(srcPort.bundle),
+                 srcPort.channel,
+                 dest->first,
+                 dest->second,
+                 static_cast<int>(destPort.bundle),
+                 destPort.channel,
+                 packetID};
+}
+
+// Drops the flows the device already declares. This pass recovers the logical
+// flows a routed design implements, so the flows it writes are the answer --
+// leaving the originals in place next to them would just describe the same
+// routing twice, which DeviceOp::verify now rejects. It really does happen:
+// --aie-create-pathfinder-flows leaves behind every aie.flow it folded into an
+// earlier flow with the same source, and it never consumes aie.packet_flow.
+static void eraseExistingFlows(DeviceOp device) {
+  SmallVector<Operation *> toErase;
+  for (FlowOp flow : device.getOps<FlowOp>())
+    toErase.push_back(flow);
+  for (PacketFlowOp packetFlow : device.getOps<PacketFlowOp>())
+    toErase.push_back(packetFlow);
+  for (Operation *op : toErase)
+    op->erase();
+}
+
 static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
-                          OpBuilder &rewriter) {
+                          OpBuilder &rewriter, FlowKeySet &seen) {
   Operation *Op = op.getOperation();
   rewriter.setInsertionPoint(Op->getBlock()->getTerminator());
 
@@ -246,6 +304,15 @@ static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
         MaskValue maskValue = c.mv;
         Operation *destOp = portConnection.op;
         Port destPort = portConnection.port;
+        // The traversal can reach the same endpoint more than once, for
+        // instance when a broadcast re-converges on it. Those repeats all
+        // describe one logical flow, and a flow declared twice is rejected by
+        // DeviceOp::verify.
+        std::optional<FlowKey> key =
+            tryGetFlowKey(Op, {bundle, (int)i}, destOp, destPort,
+                          maskValue.mask == 0 ? kCircuitFlow : maskValue.value);
+        if (key && !seen.insert(*key).second)
+          continue;
         if (maskValue.mask == 0) {
           FlowOp::create(rewriter, Op->getLoc(), Op->getResult(0), bundle, i,
                          destOp->getResult(0), destPort.bundle,
@@ -280,9 +347,14 @@ struct AIEFindFlowsPass
     ConnectivityAnalysis analysis(d);
     d.getTargetModel().validate();
 
+    // The analysis above reads only the switchboxes and shim muxes, so the
+    // flows can be cleared before rebuilding them from that routing.
+    eraseExistingFlows(d);
+
     OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
+    FlowKeySet seen;
     for (auto tile : d.getOps<TileOp>()) {
-      findFlowsFrom(tile, analysis, builder);
+      findFlowsFrom(tile, analysis, builder, seen);
     }
   }
 };

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallSet.h"
 
 #include <map>
+#include <optional>
 #include <tuple>
 
 namespace xilinx::AIE {
@@ -380,30 +381,40 @@ struct AIEGenerateColumnControlOverlayPass
 
   // A one-source, one-destination packet flow reduced to a comparable key:
   // the packet ID plus both endpoints as (col, row, bundle, channel). This is
-  // the shape every control flow below has, and it matches what
-  // DeviceOp::verify calls a duplicate.
+  // the shape every control flow below has, and keying on coordinates rather
+  // than on the defining op is what makes it match DeviceOp::verify's notion
+  // of a duplicate.
   using CtrlFlowKey = std::tuple<int, int, int, int, int, int, int, int, int>;
 
-  static CtrlFlowKey getCtrlFlowKey(int id, TileOp srcTile,
-                                    WireBundle srcBundle, int srcChan,
-                                    TileOp destTile, WireBundle destBundle,
-                                    int destChan) {
-    return {id,
-            srcTile.colIndex(),
-            srcTile.rowIndex(),
-            static_cast<int>(srcBundle),
-            srcChan,
-            destTile.colIndex(),
-            destTile.rowIndex(),
-            static_cast<int>(destBundle),
-            destChan};
+  // Nullopt when either endpoint's coordinates are not known yet -- an
+  // aie.logical_tile that --aie-place-tiles has not placed. Such a flow cannot
+  // be told apart from the one about to be created, and the verifier skips it
+  // for the same reason. A pinned aie.logical_tile does have coordinates, so
+  // this goes through TileLike rather than TileOp to catch it.
+  static std::optional<CtrlFlowKey>
+  tryGetCtrlFlowKey(int id, Value srcTileValue, WireBundle srcBundle,
+                    int srcChan, Value destTileValue, WireBundle destBundle,
+                    int destChan) {
+    auto srcTile = dyn_cast_or_null<TileLike>(srcTileValue.getDefiningOp());
+    auto destTile = dyn_cast_or_null<TileLike>(destTileValue.getDefiningOp());
+    if (!srcTile || !destTile)
+      return std::nullopt;
+    std::optional<int> srcCol = srcTile.tryGetCol();
+    std::optional<int> srcRow = srcTile.tryGetRow();
+    std::optional<int> destCol = destTile.tryGetCol();
+    std::optional<int> destRow = destTile.tryGetRow();
+    if (!srcCol || !srcRow || !destCol || !destRow)
+      return std::nullopt;
+    return CtrlFlowKey{
+        id,      *srcCol,  *srcRow,  static_cast<int>(srcBundle),
+        srcChan, *destCol, *destRow, static_cast<int>(destBundle),
+        destChan};
   }
 
   // The packet flows `device` already declares in the shape this pass emits,
   // keyed so one can be recognised before it is created a second time. A flow
-  // with more than one source or destination, or one on a tile
-  // --aie-place-tiles has not placed yet, cannot be told apart from what is
-  // about to be created and is left out.
+  // with more than one source or destination is a different shape and is left
+  // out.
   static std::map<CtrlFlowKey, AIE::PacketFlowOp>
   collectExistingCtrlFlows(DeviceOp device) {
     std::map<CtrlFlowKey, AIE::PacketFlowOp> flows;
@@ -414,14 +425,11 @@ struct AIEGenerateColumnControlOverlayPass
         continue;
       AIE::PacketSourceOp src = *sources.begin();
       AIE::PacketDestOp dest = *dests.begin();
-      auto srcTile = dyn_cast_or_null<TileOp>(src.getTile().getDefiningOp());
-      auto destTile = dyn_cast_or_null<TileOp>(dest.getTile().getDefiningOp());
-      if (!srcTile || !destTile)
-        continue;
-      flows.try_emplace(getCtrlFlowKey(flow.IDInt(), srcTile, src.getBundle(),
-                                       src.channelIndex(), destTile,
-                                       dest.getBundle(), dest.channelIndex()),
-                        flow);
+      std::optional<CtrlFlowKey> key = tryGetCtrlFlowKey(
+          flow.IDInt(), src.getTile(), src.getBundle(), src.channelIndex(),
+          dest.getTile(), dest.getBundle(), dest.channelIndex());
+      if (key)
+        flows.try_emplace(*key, flow);
     }
     return flows;
   }
@@ -525,28 +533,17 @@ struct AIEGenerateColumnControlOverlayPass
       auto keep_pkt_header = builder.getBoolAttr(true);
       auto ctrl_pkt_flow = builder.getBoolAttr(true);
       int shimChan = rowToShimChanMap[tOp.rowIndex()];
-      CtrlFlowKey key =
-          isShimMM2S
-              ? getCtrlFlowKey(ctrlPktFlowID, shimTile, shimWireBundle,
-                               shimChan, tOp, ctrlWireBundle, coreOrMemChanId)
-              : getCtrlFlowKey(ctrlPktFlowID, tOp, ctrlWireBundle,
-                               coreOrMemChanId, shimTile, shimWireBundle,
-                               shimChan);
+      std::optional<CtrlFlowKey> key =
+          isShimMM2S ? tryGetCtrlFlowKey(ctrlPktFlowID, shimTile,
+                                         shimWireBundle, shimChan, tOp,
+                                         ctrlWireBundle, coreOrMemChanId)
+                     : tryGetCtrlFlowKey(ctrlPktFlowID, tOp, ctrlWireBundle,
+                                         coreOrMemChanId, shimTile,
+                                         shimWireBundle, shimChan);
       // Only the flow itself is affected by this; the shim DMA allocation
       // below is emitted either way, guarded by its own name lookup.
-      auto [it, isNew] = existingCtrlFlows.try_emplace(key, nullptr);
-      if (isNew) {
-        it->second =
-            isShimMM2S
-                ? createPacketFlowOp(builder, tOp.getLoc(), ctrlPktFlowID,
-                                     shimTile, shimWireBundle, shimChan, tOp,
-                                     ctrlWireBundle, coreOrMemChanId,
-                                     keep_pkt_header, ctrl_pkt_flow)
-                : createPacketFlowOp(builder, tOp.getLoc(), ctrlPktFlowID, tOp,
-                                     ctrlWireBundle, coreOrMemChanId, shimTile,
-                                     shimWireBundle, shimChan, keep_pkt_header,
-                                     ctrl_pkt_flow);
-      } else {
+      auto it = key ? existingCtrlFlows.find(*key) : existingCtrlFlows.end();
+      if (it != existingCtrlFlows.end()) {
         // The device already declares this control flow -- written by hand, or
         // laid down by an earlier run of this pass over the same input, which
         // aiecc does whenever its input was already overlaid. Declaring it a
@@ -558,6 +555,22 @@ struct AIEGenerateColumnControlOverlayPass
         // them. Dropping them here would silently reroute the switchbox.
         it->second.setKeepPktHeader(keep_pkt_header.getValue());
         it->second.setPriorityRoute(ctrl_pkt_flow.getValue());
+      } else {
+        AIE::PacketFlowOp created =
+            isShimMM2S
+                ? createPacketFlowOp(builder, tOp.getLoc(), ctrlPktFlowID,
+                                     shimTile, shimWireBundle, shimChan, tOp,
+                                     ctrlWireBundle, coreOrMemChanId,
+                                     keep_pkt_header, ctrl_pkt_flow)
+                : createPacketFlowOp(builder, tOp.getLoc(), ctrlPktFlowID, tOp,
+                                     ctrlWireBundle, coreOrMemChanId, shimTile,
+                                     shimWireBundle, shimChan, keep_pkt_header,
+                                     ctrl_pkt_flow);
+        // Both endpoints are placed tiles here, so the key is always present;
+        // guarded rather than asserted so an unplaced one just means no
+        // deduplication, never a dropped flow.
+        if (key)
+          existingCtrlFlows.try_emplace(*key, created);
       }
 
       // Generate shim dma alloc ops as handle for runtime sequence to pickup,

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -15,6 +15,9 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
 
+#include <map>
+#include <tuple>
+
 namespace xilinx::AIE {
 #define GEN_PASS_DEF_AIEGENERATECOLUMNCONTROLOVERLAY
 #define GEN_PASS_DEF_AIEASSIGNTILECTRLIDS
@@ -375,6 +378,54 @@ struct AIEGenerateColumnControlOverlayPass
     return attr && !attr.getValue();
   }
 
+  // A one-source, one-destination packet flow reduced to a comparable key:
+  // the packet ID plus both endpoints as (col, row, bundle, channel). This is
+  // the shape every control flow below has, and it matches what
+  // DeviceOp::verify calls a duplicate.
+  using CtrlFlowKey = std::tuple<int, int, int, int, int, int, int, int, int>;
+
+  static CtrlFlowKey getCtrlFlowKey(int id, TileOp srcTile,
+                                    WireBundle srcBundle, int srcChan,
+                                    TileOp destTile, WireBundle destBundle,
+                                    int destChan) {
+    return {id,
+            srcTile.colIndex(),
+            srcTile.rowIndex(),
+            static_cast<int>(srcBundle),
+            srcChan,
+            destTile.colIndex(),
+            destTile.rowIndex(),
+            static_cast<int>(destBundle),
+            destChan};
+  }
+
+  // The packet flows `device` already declares in the shape this pass emits,
+  // keyed so one can be recognised before it is created a second time. A flow
+  // with more than one source or destination, or one on a tile
+  // --aie-place-tiles has not placed yet, cannot be told apart from what is
+  // about to be created and is left out.
+  static std::map<CtrlFlowKey, AIE::PacketFlowOp>
+  collectExistingCtrlFlows(DeviceOp device) {
+    std::map<CtrlFlowKey, AIE::PacketFlowOp> flows;
+    for (auto flow : device.getOps<AIE::PacketFlowOp>()) {
+      auto sources = flow.getOps<AIE::PacketSourceOp>();
+      auto dests = flow.getOps<AIE::PacketDestOp>();
+      if (!llvm::hasSingleElement(sources) || !llvm::hasSingleElement(dests))
+        continue;
+      AIE::PacketSourceOp src = *sources.begin();
+      AIE::PacketDestOp dest = *dests.begin();
+      auto srcTile = dyn_cast_or_null<TileOp>(src.getTile().getDefiningOp());
+      auto destTile = dyn_cast_or_null<TileOp>(dest.getTile().getDefiningOp());
+      if (!srcTile || !destTile)
+        continue;
+      flows.try_emplace(getCtrlFlowKey(flow.IDInt(), srcTile, src.getBundle(),
+                                       src.channelIndex(), destTile,
+                                       dest.getBundle(), dest.channelIndex()),
+                        flow);
+    }
+    return flows;
+  }
+
   AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, Location loc,
                                        int &flowID, Value source,
                                        xilinx::AIE::WireBundle sourceBundle,
@@ -446,6 +497,12 @@ struct AIEGenerateColumnControlOverlayPass
     // available
     auto availableShimChans =
         getAvailableShimChans(device, shimTile, shimWireBundle, isShimMM2S);
+    // The overlay a device already carries -- from a user-written control flow,
+    // or from an earlier run of this pass, which aiecc does whenever the input
+    // was already overlaid -- must not be laid down a second time. A flow
+    // declared twice is rejected by DeviceOp::verify.
+    std::map<CtrlFlowKey, AIE::PacketFlowOp> existingCtrlFlows =
+        collectExistingCtrlFlows(device);
 
     builder.setInsertionPoint(device.getBody()->getTerminator());
     for (auto tOp : ctrlTiles) {
@@ -467,16 +524,41 @@ struct AIEGenerateColumnControlOverlayPass
 
       auto keep_pkt_header = builder.getBoolAttr(true);
       auto ctrl_pkt_flow = builder.getBoolAttr(true);
-      if (isShimMM2S)
-        (void)createPacketFlowOp(
-            builder, tOp.getLoc(), ctrlPktFlowID, shimTile, shimWireBundle,
-            rowToShimChanMap[tOp.rowIndex()], tOp, ctrlWireBundle,
-            coreOrMemChanId, keep_pkt_header, ctrl_pkt_flow);
-      else
-        (void)createPacketFlowOp(
-            builder, tOp.getLoc(), ctrlPktFlowID, tOp, ctrlWireBundle,
-            coreOrMemChanId, shimTile, shimWireBundle,
-            rowToShimChanMap[tOp.rowIndex()], keep_pkt_header, ctrl_pkt_flow);
+      int shimChan = rowToShimChanMap[tOp.rowIndex()];
+      CtrlFlowKey key =
+          isShimMM2S
+              ? getCtrlFlowKey(ctrlPktFlowID, shimTile, shimWireBundle,
+                               shimChan, tOp, ctrlWireBundle, coreOrMemChanId)
+              : getCtrlFlowKey(ctrlPktFlowID, tOp, ctrlWireBundle,
+                               coreOrMemChanId, shimTile, shimWireBundle,
+                               shimChan);
+      // Only the flow itself is affected by this; the shim DMA allocation
+      // below is emitted either way, guarded by its own name lookup.
+      auto [it, isNew] = existingCtrlFlows.try_emplace(key, nullptr);
+      if (isNew) {
+        it->second =
+            isShimMM2S
+                ? createPacketFlowOp(builder, tOp.getLoc(), ctrlPktFlowID,
+                                     shimTile, shimWireBundle, shimChan, tOp,
+                                     ctrlWireBundle, coreOrMemChanId,
+                                     keep_pkt_header, ctrl_pkt_flow)
+                : createPacketFlowOp(builder, tOp.getLoc(), ctrlPktFlowID, tOp,
+                                     ctrlWireBundle, coreOrMemChanId, shimTile,
+                                     shimWireBundle, shimChan, keep_pkt_header,
+                                     ctrl_pkt_flow);
+      } else {
+        // The device already declares this control flow -- written by hand, or
+        // laid down by an earlier run of this pass over the same input, which
+        // aiecc does whenever its input was already overlaid. Declaring it a
+        // second time is the duplicate DeviceOp::verify rejects, so adopt the
+        // overlay's attributes onto the flow that is already there instead.
+        // They are what tells --aie-create-pathfinder-flows this is a control
+        // flow; that pass takes the last writer per destination port, so
+        // before this pass deduplicated, the copy it appended is what set
+        // them. Dropping them here would silently reroute the switchbox.
+        it->second.setKeepPktHeader(keep_pkt_header.getValue());
+        it->second.setPriorityRoute(ctrl_pkt_flow.getValue());
+      }
 
       // Generate shim dma alloc ops as handle for runtime sequence to pickup,
       // when issuing control packets

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -14,13 +14,18 @@
 // CHECK1:    %[[VAL_2:.*]] = aie.tile(0, 3)
 // CHECK1:    %[[VAL_3:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[VAL_4:.*]] = aie.tile(0, 5)
-// CHECK1:    aie.packet_flow(0) {
-// CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
-// CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 0>
-// CHECK1:    }
+// The flows below are the ones --aie-find-flows recovers from the routing, in
+// the order it walks the tiles and their packet rules; the flows this file
+// declares up front are replaced by them rather than kept alongside. Both
+// flows out of tile (0, 2) share a source port, so their relative order comes
+// from the routed switchbox rather than from this file.
 // CHECK1:    aie.packet_flow(4) {
 // CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 4>
+// CHECK1:    }
+// CHECK1:    aie.packet_flow(0) {
+// CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
+// CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 0>
 // CHECK1:    }
 // CHECK1:    aie.packet_flow(1) {
 // CHECK1:      aie.packet_source<%[[VAL_2:.*]], DMA : 0>

--- a/test/create-packet-flows/test_congestion1.mlir
+++ b/test/create-packet-flows/test_congestion1.mlir
@@ -16,15 +16,18 @@
 // CHECK1:    %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK1:    %[[TILE_1_0:.*]] = aie.tile(1, 0)
-// CHECK1:    aie.packet_flow(0) {
-// CHECK1:      aie.packet_source<%[[TILE_0_5]], DMA : 1>
-// CHECK1:      aie.packet_dest<%[[TILE_0_1]], DMA : 4>
-// CHECK1:    }
+// The flows below are the ones --aie-find-flows recovers from the routing, in
+// the order it walks the tiles; the flows this file declares up front are
+// replaced by them rather than kept alongside.
 // CHECK1:    aie.flow(%[[TILE_0_1]], DMA : 0, %[[TILE_0_0]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_2]], DMA : 0, %[[TILE_0_1]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_3]], DMA : 0, %[[TILE_0_1]], DMA : 1)
 // CHECK1:    aie.flow(%[[TILE_0_4]], DMA : 0, %[[TILE_0_1]], DMA : 2)
 // CHECK1:    aie.flow(%[[TILE_0_5]], DMA : 0, %[[TILE_0_1]], DMA : 3)
+// CHECK1:    aie.packet_flow(0) {
+// CHECK1:      aie.packet_source<%[[TILE_0_5]], DMA : 1>
+// CHECK1:      aie.packet_dest<%[[TILE_0_1]], DMA : 4>
+// CHECK1:    }
 
 // CHECK2: "total_path_length": 19
 

--- a/test/dialect/AIE/column_control_overlay_idempotent.mlir
+++ b/test/dialect/AIE/column_control_overlay_idempotent.mlir
@@ -1,0 +1,58 @@
+//===- column_control_overlay_idempotent.mlir ------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The control overlay has to be idempotent, because it is routinely asked to
+// run over a design that already carries one. `route-shim-to-tct` defaults to
+// `shim-only`, so aiecc lays down the shim's TCT flow on every invocation --
+// including for input a caller already overlaid by hand, and including for
+// input that declares that flow itself. A second copy is not harmless: it is
+// the duplicate `DeviceOp::verify` rejects, so the pass would no longer
+// round-trip its own output.
+
+// RUN: aie-opt %s --split-input-file -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" | aie-opt --split-input-file -aie-generate-column-control-overlay | FileCheck %s
+
+// Overlaying twice leaves exactly one TCT flow out of the shim's control port.
+// CHECK-LABEL: module {
+// CHECK: %[[tile_0_0:.*]] = aie.tile(0, 0)
+// CHECK: aie.packet_flow(15) {
+// CHECK-NEXT: aie.packet_source<%[[tile_0_0]], TileControl : 0>
+// CHECK-NEXT: aie.packet_dest<%[[tile_0_0]], South : 0>
+// CHECK-NEXT: }
+// CHECK-NOT: aie.packet_dest<%{{.*}}, South : 0>
+
+aie.device(npu1_1col) {
+  %tile_0_0 = aie.tile(0, 0)
+  %tile_0_2 = aie.tile(0, 2)
+}
+
+// -----
+
+// Same, for a design that declares the flow the pass would emit. The ID has to
+// match for this to be the same flow, so the tile pins its controller_id.
+//
+// The surviving flow carries the overlay's attributes even though the input
+// declared it without them. keep_pkt_header and priority_route are what mark a
+// flow as control to --aie-create-pathfinder-flows, and that pass takes the
+// last writer per destination port -- so before this pass deduplicated, the
+// copy it appended is what set them. Merely dropping the duplicate would
+// change the switchbox this routes into.
+// CHECK-LABEL: module {
+// CHECK: %[[tile_0_0:.*]] = aie.tile(0, 0)
+// CHECK: aie.packet_flow(3) {
+// CHECK-NEXT: aie.packet_source<%[[tile_0_0]], TileControl : 0>
+// CHECK-NEXT: aie.packet_dest<%[[tile_0_0]], South : 0>
+// CHECK-NEXT: } {keep_pkt_header = true, priority_route = true}
+// CHECK-NOT: aie.packet_dest<%{{.*}}, South : 0>
+
+aie.device(npu1_1col) {
+  %tile_0_0 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
+  %tile_0_2 = aie.tile(0, 2)
+  aie.packet_flow(0x3) {
+    aie.packet_source<%tile_0_0, TileControl : 0>
+    aie.packet_dest<%tile_0_0, South : 0>
+  }
+}

--- a/test/dialect/AIE/column_control_overlay_idempotent.mlir
+++ b/test/dialect/AIE/column_control_overlay_idempotent.mlir
@@ -56,3 +56,27 @@ aie.device(npu1_1col) {
     aie.packet_dest<%tile_0_0, South : 0>
   }
 }
+
+// -----
+
+// The flow the pass would emit, declared against a *pinned* aie.logical_tile
+// rather than the aie.tile. Its coordinates are known, so DeviceOp::verify sees
+// it as the same port and would reject a second copy -- matching that means
+// recognising the existing flow through TileLike, not just TileOp.
+// CHECK-LABEL: module {
+// CHECK: %[[shim:.*]] = aie.logical_tile<ShimNOCTile>(0, 0)
+// CHECK: aie.packet_flow(3) {
+// CHECK-NEXT: aie.packet_source<%[[shim]], TileControl : 0>
+// CHECK-NEXT: aie.packet_dest<%[[shim]], South : 0>
+// CHECK-NEXT: } {keep_pkt_header = true, priority_route = true}
+// CHECK-NOT: aie.packet_dest<%{{.*}}, South : 0>
+
+aie.device(npu1_1col) {
+  %tile_0_0 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
+  %tile_0_2 = aie.tile(0, 2)
+  %shim = aie.logical_tile<ShimNOCTile>(0, 0)
+  aie.packet_flow(0x3) {
+    aie.packet_source<%shim, TileControl : 0>
+    aie.packet_dest<%shim, South : 0>
+  }
+}

--- a/test/dialect/AIE/duplicate_flow.mlir
+++ b/test/dialect/AIE/duplicate_flow.mlir
@@ -1,0 +1,163 @@
+//===- duplicate_flow.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// DeviceOp::verify rejects a flow that is declared twice. For aie.flow the key
+// is the (tile, bundle, channel) pair of endpoints; for aie.packet_flow it is
+// the ID together with the sets of sources and destinations. Endpoints on an
+// aie.logical_tile that --aie-place-tiles has not placed are skipped, because
+// they cannot be compared until placement assigns coordinates -- at which
+// point this same check runs again on the resulting aie.tile coordinates.
+
+// RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
+
+// The same circuit-switched flow declared twice.
+// CHECK: error{{.*}}'aie.flow' op duplicates an earlier flow; (0, 0) DMA : 0 -> (0, 2) DMA : 0 is already declared
+// CHECK: note:{{.*}}the other flow is here
+module @flow_dup {
+  aie.device(npu2) {
+    %shim = aie.tile(0, 0)
+    %core = aie.tile(0, 2)
+    aie.flow(%shim, DMA : 0, %core, DMA : 0)
+    aie.flow(%shim, DMA : 0, %core, DMA : 0)
+  }
+}
+
+// -----
+
+// Duplicate endpoints reached through two distinct aie.tile ops at the same
+// coordinate, as a frontend that did not merge tiles by coordinate emits.
+// CHECK: error{{.*}}'aie.flow' op duplicates an earlier flow; (0, 0) DMA : 1 -> (0, 2) DMA : 1 is already declared
+module @flow_dup_distinct_tiles {
+  aie.device(npu2) {
+    %shim0 = aie.tile(0, 0)
+    %shim1 = aie.tile(0, 0)
+    %core0 = aie.tile(0, 2)
+    %core1 = aie.tile(0, 2)
+    aie.flow(%shim0, DMA : 1, %core0, DMA : 1)
+    aie.flow(%shim1, DMA : 1, %core1, DMA : 1)
+  }
+}
+
+// -----
+
+// Two pinned logical tiles at the same coordinate, caught before placement.
+// CHECK: error{{.*}}'aie.flow' op duplicates an earlier flow; (0, 2) DMA : 0 -> (0, 3) DMA : 0 is already declared
+module @flow_dup_logical {
+  aie.device(npu2) {
+    %c0 = aie.logical_tile<CoreTile>(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(0, 3)
+    aie.flow(%c0, DMA : 0, %c1, DMA : 0)
+    aie.flow(%c0, DMA : 0, %c1, DMA : 0)
+  }
+}
+
+// -----
+
+// The same packet flow declared twice, as reported in issue #3706.
+// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 0 is already declared between the same sources and destinations
+// CHECK: note:{{.*}}the other packet flow is here
+module @packet_flow_dup {
+  aie.device(npu2) {
+    %shim = aie.tile(2, 0)
+    %core = aie.tile(2, 2)
+    aie.packet_flow(0) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
+    } {keep_pkt_header = false}
+    aie.packet_flow(0) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
+    } {keep_pkt_header = false}
+  }
+}
+
+// -----
+
+// Sources and destinations are unordered within a packet flow, so listing the
+// same endpoints in a different order is still the same flow. Disagreeing
+// keep_pkt_header attributes make the redeclaration contradictory, not merely
+// redundant, so the attributes are deliberately not part of the key.
+// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 3 is already declared between the same sources and destinations
+module @packet_flow_dup_reordered {
+  aie.device(npu2) {
+    %shim = aie.tile(2, 0)
+    %c2 = aie.tile(2, 2)
+    %c3 = aie.tile(2, 3)
+    aie.packet_flow(3) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c2, DMA : 0>
+      aie.packet_dest<%c3, DMA : 0>
+    } {keep_pkt_header = false}
+    aie.packet_flow(3) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c3, DMA : 0>
+      aie.packet_dest<%c2, DMA : 0>
+    } {keep_pkt_header = true}
+  }
+}
+
+// -----
+
+// Distinct flows that only look similar must all be accepted: a shared source
+// broadcasting to different destinations, a shared destination fed from
+// different sources, the same endpoints on a different channel, and the same
+// endpoints in a different device.
+// CHECK-NOT: error
+module @flow_no_false_positives {
+  aie.device(npu2) @main {
+    %shim = aie.tile(0, 0)
+    %c2 = aie.tile(0, 2)
+    %c3 = aie.tile(0, 3)
+    aie.flow(%shim, DMA : 0, %c2, DMA : 0)
+    aie.flow(%shim, DMA : 0, %c3, DMA : 0)
+    aie.flow(%c2, DMA : 0, %c3, DMA : 1)
+    aie.flow(%shim, DMA : 1, %c3, DMA : 1)
+    aie.flow(%shim, DMA : 1, %c2, DMA : 1)
+  }
+  aie.device(npu2) @second {
+    %shim = aie.tile(0, 0)
+    %c2 = aie.tile(0, 2)
+    aie.flow(%shim, DMA : 0, %c2, DMA : 0)
+  }
+}
+
+// -----
+
+// Packet flows sharing an ID are legal as long as they connect different
+// endpoints, and unplaced logical tiles are skipped until placement runs.
+// CHECK-NOT: error
+module @packet_flow_no_false_positives {
+  aie.device(npu2) @main {
+    %shim = aie.tile(2, 0)
+    %c2 = aie.tile(2, 2)
+    %c3 = aie.tile(2, 3)
+    aie.packet_flow(0) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c2, DMA : 0>
+    }
+    aie.packet_flow(0) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c3, DMA : 0>
+    }
+    aie.packet_flow(1) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c2, DMA : 0>
+    }
+  }
+  aie.device(npu2) @unplaced {
+    %u0 = aie.logical_tile<CoreTile>(?, ?)
+    %u1 = aie.logical_tile<CoreTile>(?, ?)
+    aie.packet_flow(0) {
+      aie.packet_source<%u0, DMA : 0>
+      aie.packet_dest<%u1, DMA : 0>
+    }
+    aie.packet_flow(0) {
+      aie.packet_source<%u0, DMA : 0>
+      aie.packet_dest<%u1, DMA : 0>
+    }
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_spread_unanchored_tiles.mlir
+++ b/test/place-tiles/sequential_placer/test_place_spread_unanchored_tiles.mlir
@@ -31,6 +31,11 @@
 // memtile together, which is what ranking by direction-matched load buys: a
 // summed load would push each chain's read and write onto different
 // columns.
+//
+// Odd-indexed chains use channel 1: placement doesn't renumber a flow's
+// declared DMA channel, so two chains piled onto the same physical tile
+// pair on channel 0 would be the same flow twice over, which DeviceOp::verify
+// now rejects.
 
 // PILE-LABEL:     @anchorless_passthrough
 // PILE-DAG:       aie.tile(0, 0)
@@ -59,12 +64,12 @@ module @anchorless_passthrough {
     %mem3 = aie.logical_tile<MemTile>(?, ?)
     aie.flow(%shim0, DMA : 0, %mem0, DMA : 0)
     aie.flow(%mem0, DMA : 0, %shim0, DMA : 0)
-    aie.flow(%shim1, DMA : 0, %mem1, DMA : 0)
-    aie.flow(%mem1, DMA : 0, %shim1, DMA : 0)
+    aie.flow(%shim1, DMA : 1, %mem1, DMA : 1)
+    aie.flow(%mem1, DMA : 1, %shim1, DMA : 1)
     aie.flow(%shim2, DMA : 0, %mem2, DMA : 0)
     aie.flow(%mem2, DMA : 0, %shim2, DMA : 0)
-    aie.flow(%shim3, DMA : 0, %mem3, DMA : 0)
-    aie.flow(%mem3, DMA : 0, %shim3, DMA : 0)
+    aie.flow(%shim3, DMA : 1, %mem3, DMA : 1)
+    aie.flow(%mem3, DMA : 1, %shim3, DMA : 1)
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #3706.

`aie.flow` / `aie.packet_flow` could be declared twice with no diagnostic. This
adds the check to `DeviceOp::verify()`, alongside the existing duplicate-`aie.core`
check, so it runs on every device rather than needing a pass to be scheduled.

A repeated flow is not a harmless redundancy. `Pathfinder::addFlow` folds a flow
into any existing flow with the same source, so a duplicate `aie.flow` lands in
that flow's destination list a second time and the router is asked to broadcast
to the same endpoint twice. A duplicate `aie.packet_flow` makes the routing
problem look more congested than it is, and when the two copies' attributes
disagree they give the same flow conflicting `keep_pkt_header` / `priority_route`
settings. Today that surfaces, if at all, as unexplained routing pressure far
downstream of the file that caused it.

### What counts as a duplicate

- **`aie.flow`** — same source and destination port, where a port is
  `(col, row, bundle, channel)`. Coordinates rather than SSA values, so two flows
  written against different `aie.tile` ops for the same tile still compare equal.
- **`aie.packet_flow`** — same ID between the same set of sources and the same set
  of destinations. Sources and destinations are unordered within a packet flow, so
  both are sorted before comparing; permutations of one flow compare equal.

A flow with an endpoint whose coordinates are not known yet — an `aie.logical_tile`
that `--aie-place-tiles` has not placed — is skipped. It cannot be told apart from
any other unplaced flow, so flagging it would be a guess; once placed, the same
verifier runs against real coordinates.

The diagnostic names the offending ports and attaches a note at the earlier flow.

### `--aie-find-flows` had to change with it

Without this, the `--aie-create-pathfinder-flows --aie-find-flows` pipeline emitted
IR that failed the new verifier. Two reasons, both pre-existing:

- `--aie-create-pathfinder-flows` leaves behind every `aie.flow` it folded into an
  earlier flow with the same source (6 of 8 in one in-tree test), and it never
  consumes `aie.packet_flow` at all.
- `--aie-find-flows`' traversal can reach one endpoint more than once, e.g. when a
  broadcast re-converges on it, and wrote a flow per arrival.

`--aie-find-flows` recovers the logical flows a routed design implements, so the
flows it writes *are* the answer — leaving the originals next to them just describes
the same routing twice. It now erases the device's flows before rebuilding them from
the switchboxes and shim muxes (the analysis reads only those, never the flow ops),
and dedupes its own traversal with a device-wide seen-set keyed on endpoints + packet ID.

### Test changes

- New `test/dialect/AIE/duplicate_flow.mlir` — seven cases, including the exact IR
  from #3706, duplicates written against distinct `aie.tile` ops for one coordinate,
  pinned `aie.logical_tile` duplicates, reordered packet-flow destinations, and two
  `CHECK-NOT: error` negative modules (shared source/different dests, shared dest/
  different sources, differing channel, same ID across different endpoints, a second
  device, and unplaced logical tiles).
- `test/create-packet-flows/test_congestion{0,1}.mlir` — CHECK1 reordering only. The
  set of recovered flows is unchanged and `total_path_length` is unchanged; the flows
  now appear in `--aie-find-flows`' tile-walk order rather than the input file's
  declaration order, because the input flows are replaced rather than kept alongside.
  No CHECK line's content changed.

### The control overlay was not idempotent, and CI caught it

`--aie-generate-column-control-overlay` appended its control flows unconditionally,
so running it over a device that already carried an overlay produced two copies of
the same flow. Before this verifier that was tolerated silently; with it, every CI
job failed on

```
'aie.packet_flow' op duplicates an earlier packet flow; ID 15 is already declared
between the same sources and destinations
```

This is a real pre-existing bug, not a false positive. `route-shim-to-tct` defaults
to `shim-only`, so aiecc lays down the shim's TCT flow on *every* invocation —
including for input a caller has already overlaid by hand, which is exactly what
`test/aiecc/ctrlpkt_base_host_bo_count.mlir`, `cpp_ctrlpkt.mlir` and
`cpp_multi_device_sequence.mlir` do. Designs that declare that flow themselves, such
as `npu-xrt/shim_dma_bd_reuse`, hit the same thing. The pass could not round-trip its
own output.

The pass now keys the one-source/one-destination control flows a device already
declares and skips creating one that is already there. Flows with several sources or
destinations, or on tiles `--aie-place-tiles` has not placed, cannot be told apart
from what is about to be created and are ignored. Shim DMA allocations are
unaffected — they were already guarded by their own symbol lookup.

**Deduplicating alone would have been a silent behavior change.** `keep_pkt_header`
and `priority_route` are what mark a flow as control to
`--aie-create-pathfinder-flows`, and that pass takes the last writer per destination
port (`AIECreatePathFindFlows.cpp:527`). For a hand-written flow declared without
them, the copy this pass appended is what used to set them; dropping the duplicate
and nothing else changed `shim_dma_bd_reuse`'s switchbox from
`aie.amsel<5>(3)` / `masterset(South : 0, ...) {is_ctrl_pkt_overlay, keep_pkt_header = true}`
to `aie.amsel<0>(0)` / a bare `masterset`. So the surviving flow adopts the overlay's
attributes instead. With that, the routed switchbox and shim mux configuration are
bit-identical to main for all nine affected `npu-xrt` designs.

The existing flow is recognised through `TileLike::tryGetCol`/`tryGetRow`, the same
path `tryGetPortKey` takes in the verifier, so a control flow declared against a
pinned `aie.logical_tile` is matched too — going through `TileOp` alone missed it and
left a duplicate the verifier then rejected. That also subsumes the unplaced-tile
carve-out: an endpoint with unknown coordinates yields no key, which is the same
condition the verifier skips on, so the two stay in step by construction.

New `test/dialect/AIE/column_control_overlay_idempotent.mlir` covers all three shapes
— overlaying twice, overlaying a design that already declares the flow, and the same
declared against a pinned `aie.logical_tile` — and asserts the attributes survive on
the pre-declared flow.

### Follow-up, not fixed here

`lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp:99` does
`rewriter.eraseOp(Op); return failure();`. Under `applyPartialConversion` the
`failure()` rolls the erase back, which is why `--aie-create-pathfinder-flows` leaves
folded-away flow ops in the IR. Left alone here to keep this change scoped to the
verifier; worth a separate look.

### Testing

Full lit suite against this branch and against `main`, same build configuration:
identical failing-test sets (`comm` reports no lines unique to either side) — no
regressions and nothing newly passing. The failures on both sides are the
pre-existing pyxrt / xchesscc / hardware-dependent ones in this environment.

`aiecc/ctrlpkt_base_host_bo_count.mlir` — the one test that failed in *every* CI job
— passes locally. `cpp_ctrlpkt.mlir` and `cpp_multi_device_sequence.mlir` need peano,
so their overlay step was driven directly; both re-overlay cleanly now, with either
`route-shim-to-tile-ctrl` setting. For the nine `npu-xrt` control-packet designs the
routed `aie.switchbox` / `aie.shim_mux` output is byte-identical to `main`.

## Checklist
- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see CONTRIBUTING)
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths <!-- no Python touched -->
- [x] `clang-tidy` passes locally for any touched file on the enabled list


