### PR TITLE
Make the routing passes idempotent and lift routed designs to flows

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -826,6 +826,17 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
     so that they always get allocated with the same master, slave
     ports, arbiters and master selects (msel).
 
+    The optional attribute mask, written after the ID in the parentheses,
+    states the packet-rule mask of the flow. A slave port accepts a packet
+    when `incoming & mask == ID`, so the flow claims every ID that agrees
+    with ID on the bits the mask selects. Routing derives a mask from the
+    IDs it knows when the attribute is absent. ID must have no bit outside
+    the mask, or no packet can match.
+
+    A design may compute a packet header at run time, so which IDs reach a
+    port is not decidable here. State the mask to claim a set of IDs that
+    routing cannot see.
+
     Example:
     ```
       %01 = aie.tile(0, 1)
@@ -833,18 +844,34 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
         aie.packet_source<%01, "Core" : 0>
         aie.packet_dest<%01, "Core" : 0>
       }
+      // Claims 0x10 through 0x13: the mask ignores the low two bits.
+      aie.packet_flow(0x10 mask 0x1c) {
+        aie.packet_source<%01, "Core" : 0>
+        aie.packet_dest<%01, "Core" : 0>
+      }
     ```
   }];
 
-  let arguments = (
-    ins AIEI8Attr:$ID,
-        OptionalAttr<BoolAttr>:$keep_pkt_header,
-        OptionalAttr<BoolAttr>:$priority_route
-  );
+  let arguments = (ins AIEI8Attr:$ID, OptionalAttr<AIEI8Attr>:$mask,
+      OptionalAttr<BoolAttr>:$keep_pkt_header,
+      OptionalAttr<BoolAttr>:$priority_route);
   let regions = (region AnyRegion:$ports);
 
-  let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
+  let assemblyFormat = [{ `(` $ID (`mask` $mask^)? `)` regions attr-dict }];
   let hasVerifier = 1;
+
+  let builders = [OpBuilder<(ins "uint8_t":$ID,
+                                "mlir::BoolAttr":$keep_pkt_header,
+                                "mlir::BoolAttr":$priority_route),
+                            [{
+      build($_builder, $_state, ID, nullptr, keep_pkt_header, priority_route);
+    }]>,
+                  OpBuilder<(ins "mlir::IntegerAttr":$ID,
+                                "mlir::BoolAttr":$keep_pkt_header,
+                                "mlir::BoolAttr":$priority_route),
+                            [{
+      build($_builder, $_state, ID, nullptr, keep_pkt_header, priority_route);
+    }]>];
 
   let extraClassDeclaration = [{
     int IDInt() { return getID(); }

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -325,14 +325,31 @@ def AIEFindFlows : Pass<"aie-find-flows", "DeviceOp"> {
     by aie.flow) or a packet-switched connection (represensted by
     aie.packetflow).  This pass is primarily used for testing automatic
     routing.
+
+    By default every configured connection is lifted, including partial flows
+    whose source or destination is a directional switchbox port rather than a
+    core or DMA (transit connections, PLIO/edge entries, and packet routes a
+    running design steers by packet id).  A physically routed design can
+    therefore drop its aie.switchbox configuration and recover it from the
+    lifted flows.  Set `keep-partial-flows=false` to restrict recovery to flows
+    that begin at a core/DMA and end on a core/DMA.
   }];
 
   let constructor = "xilinx::AIE::createAIEFindFlowsPass()";
-  let dependentDialects = [
-    "xilinx::AIE::AIEDialect",
+  let dependentDialects = ["xilinx::AIE::AIEDialect", ];
+
+  let options =
+      [Option<"clKeepPartialFlows", "keep-partial-flows", "bool",
+              /*default=*/"true",
+              "Also recover partial flows whose source or destination is a "
+              "directional/edge switchbox port rather than a core or DMA.">,
+       Option<
+           "clRemoveLifted", "remove-lifted", "bool", /*default=*/"true",
+           "Remove the interconnect configuration (connects, packet rules, "
+           "mastersets, amsels, wires) that was lifted into recovered flows, "
+           "leaving only configuration that could not be lifted.">,
   ];
 }
-
 
 def AIEVectorTransferLowering : Pass<"aie-vector-transfer-lowering", "DeviceOp"> {
   let summary = "Lower vector.transfer_read/write to vector.load/store for AIE";

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1974,12 +1974,18 @@ LogicalResult verifyNoDuplicateFlows(DeviceOp device) {
 }
 
 // Rejects two aie.packet_flow ops that carry the same ID between the same set
-// of sources and destinations. Declaring the flow twice makes the routing
-// problem look more congested than it is and gives the two copies conflicting
-// keep_pkt_header/priority_route settings when their attributes disagree.
+// of sources and destinations under the same mask. Declaring the flow twice
+// makes the routing problem look more congested than it is and gives the two
+// copies conflicting keep_pkt_header/priority_route settings when their
+// attributes disagree.
+//
+// The mask belongs in the key because it is half of what a flow claims: an ID
+// under two masks names two sets of packets, so the two flows carry different
+// traffic. A flow without the attribute claims its ID alone, which is what the
+// widest mask says, so both spellings key alike.
 LogicalResult verifyNoDuplicatePacketFlows(DeviceOp device) {
   using PacketFlowKey =
-      std::tuple<int, std::vector<PortKey>, std::vector<PortKey>>;
+      std::tuple<int, int, std::vector<PortKey>, std::vector<PortKey>>;
   std::map<PacketFlowKey, PacketFlowOp> packetFlowSeen;
   WalkResult result = device.walk([&](PacketFlowOp packetFlow) {
     Region &body = packetFlow.getPorts();
@@ -2011,12 +2017,17 @@ LogicalResult verifyNoDuplicatePacketFlows(DeviceOp device) {
       return WalkResult::advance();
     llvm::sort(sources);
     llvm::sort(dests);
+    int idBits =
+        llvm::Log2_32_Ceil(device.getTargetModel().getMaxPacketId() + 1);
+    int mask = packetFlow.getMask().value_or((1 << idBits) - 1);
     auto [it, inserted] = packetFlowSeen.try_emplace(
-        {packetFlow.IDInt(), std::move(sources), std::move(dests)}, packetFlow);
+        {packetFlow.IDInt(), mask, std::move(sources), std::move(dests)},
+        packetFlow);
     if (!inserted) {
       InFlightDiagnostic diag =
           packetFlow.emitOpError()
           << "duplicates an earlier packet flow; ID " << packetFlow.IDInt()
+          << " under mask 0x" << llvm::utohexstr(mask)
           << " is already declared between the same sources and destinations";
       diag.attachNote(it->second.getLoc()) << "the other packet flow is here";
       return WalkResult::interrupt();
@@ -2545,6 +2556,16 @@ LogicalResult PacketFlowOp::verify() {
     return emitOpError("must have at least one aie.packet_source");
   if (numDests < 1)
     return emitOpError("must have at least one aie.packet_dest");
+
+  // A slave port accepts a packet when `incoming & mask == ID`, so a bit set
+  // in ID and clear in the mask rejects every packet.
+  if (std::optional<uint8_t> mask = getMask()) {
+    uint8_t id = getID();
+    if ((id & *mask) != id)
+      return emitOpError("has ID 0x")
+             << llvm::utohexstr(id) << " outside mask 0x"
+             << llvm::utohexstr(*mask) << ", which no packet can match";
+  }
 
   return success();
 }

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <optional>
+#include <set>
 
 using namespace mlir;
 using namespace xilinx;
@@ -100,9 +101,16 @@ struct ConvertFlowsToInterconnect : OpConversionPattern<FlowOp> {
     TileID srcSbId = {srcCoords.col, srcCoords.row};
     PathEndPoint srcPoint = {srcSbId, srcPort};
     if (analyzer.processedFlows[srcPoint]) {
+      // This FlowOp is a broadcast sibling of a flow whose route was already
+      // materialized (the analyzer merges all destinations sharing a source
+      // into one net, so the first sibling emitted connections for every
+      // destination). Erase it and report success so the erase is committed;
+      // returning failure() here would roll the erase back and leave a stale
+      // aie.flow in the routed IR, breaking idempotency (re-running the pass
+      // would try to re-route an already-routed net and fail).
       LLVM_DEBUG(llvm::dbgs() << "Flow already processed!\n");
       rewriter.eraseOp(Op);
-      return failure();
+      return success();
     }
     // std::map<TileID, SwitchSetting>
     SwitchSettings settings = analyzer.flowSolutions[srcPoint];
@@ -254,6 +262,13 @@ bool AIEPathfinderPass::findPathToDest(const SwitchSettings &settings,
   }
 
   int neighbourSourceChannel = currDestChannel;
+  // The destination may itself be a fabric input port (e.g. a partial packet
+  // flow pinned to end at a switchbox port). Such a port is never the output of
+  // any switchbox setting, so it would otherwise never match; recognize arrival
+  // when the current output feeds the final tile's destination input directly.
+  if (neighbourTile == finalTile && neighbourSourceBundle == finalDestBundle &&
+      neighbourSourceChannel == finalDestChannel)
+    return true;
   for (const auto &[sbNode, setting] : settings) {
     TileID tile = {sbNode.col, sbNode.row};
     if (tile == neighbourTile) {
@@ -341,28 +356,42 @@ static void bnbMinCover(ArrayRef<CoverCube> cubes,
   }
 }
 
+// Two cubes share an id when they agree on every bit both of them check.
+// Testing the cubes answers that without walking the ids they match, which a
+// cube with several don't-care bits has too many of.
+static bool cubesIntersect(std::pair<int, int> a, std::pair<int, int> b) {
+  return ((a.second ^ b.second) & a.first & b.first) == 0;
+}
+
 // Cover `matchIds` (a group's packet ids) with the fewest (mask, value) rules
-// that match every specified id and no `avoidIds` (other ids on the same slave
-// port). A rule matches id x iff (x & mask) == value; ids in neither set are
-// don't-cares, free to over-claim.
+// that match every specified id and no cube in `avoidCubes` (what the other
+// groups on the same slave port claim). A rule matches id x iff
+// (x & mask) == value; ids no cube claims are don't-cares, free to over-claim.
+//
+// An avoid cube states a claim the cover must not touch. A group that derives
+// its rules contributes one cube per id. A group whose flows state a mask
+// contributes that one cube, which stands for every id the mask matches --
+// including ids no flow in this design mentions.
 //
 // Based on Quine-McCluskey:
 //   1. Enumerate prime implicants: maximal cubes (a cube is one (mask, value))
-//      that match >=1 matchIds and no avoidIds.
+//      that match >=1 matchIds and no avoid cube.
 //   2. Pick the fewest of those cubes that cover all match ids (bnbMinCover).
 //   3. Tighten each chosen cube to the smallest enclosing cube of the ids it
 //      took, so it claims no more don't-cares than necessary; the one-cube case
 //      reduces to the old common-bits mask.
 static SmallVector<std::pair<int, int>>
 computeSubcubeCover(const SmallVector<int, 4> &matchIds,
-                    const llvm::SmallSet<int, 8> &avoidIds, int idBits) {
+                    ArrayRef<std::pair<int, int>> avoidCubes, int idBits) {
 
   // id space and full mask, sized from the target's packet-id width.
   const int numIds = 1 << idBits;
   const int idMask = numIds - 1;
 
   auto hitsAvoid = [&](int mask, int value) {
-    return llvm::any_of(avoidIds, [&](int o) { return (o & mask) == value; });
+    return llvm::any_of(avoidCubes, [&](std::pair<int, int> c) {
+      return cubesIntersect({mask, value}, c);
+    });
   };
 
   llvm::SmallBitVector matchMask(numIds);
@@ -545,6 +574,11 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   DenseMap<std::pair<PhysPort, int>, DmaEndpoints> slaveFlowDmaEndpoints;
   // Aggregate of the above over all flows sharing a slave port.
   DenseMap<PhysPort, PortTraffic> slavePortTraffic;
+
+  // Packet-rule masks the flows state, keyed by the slave port the stream
+  // enters and the flow ID. One ID may reach a port under two masks, so the
+  // ID alone does not identify the claim.
+  std::map<std::pair<PhysPort, int>, int> pinnedMasks;
 
   for (auto tileOp : device.getOps<TileOp>()) {
     int col = tileOp.colIndex();
@@ -737,6 +771,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
                                       keep.value_or(false)))
                 traffic.spansConsumerBds = true;
             }
+            if (std::optional<uint8_t> mask = pktFlowOp.getMask())
+              pinnedMasks[{{currTile, {src.bundle, src.channel}}, flowID}] =
+                  *mask;
             // Assign "control packet flows" flag per switchbox, based on
             // packet flow op attribute
             auto ctrlPkt = pktFlowOp.getPriorityRoute();
@@ -808,6 +845,14 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
   // A map from Tile and master selectValue to the ports targetted by that
   // master select.
   std::map<std::pair<TileID, int>, SmallVector<Port, 4>> masterAMSels;
+
+  // <arbiter, msel> slots (per tile) that packet-switch configuration already
+  // present in the input IR occupies: a control overlay this run must not
+  // disturb, or any packet routing a previous run lowered. The allocator below
+  // starts from an empty state, so without this it can hand out a slot another
+  // master on the same tile holds, giving two independent flows one amsel.
+  // Kept apart from masterAMSels so this run does not re-emit those ops.
+  std::set<std::pair<TileID, int>> reservedAmsels;
 
   // Track which arbiter each port is assigned to (to prevent conflicts)
   std::map<PhysPort, int> portToArbiter;
@@ -977,7 +1022,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         int hazardous = INVALID_AMSEL_VALUE;
         ArbiterHazard worst{0, 0};
         for (int amsel : candidates) {
-          if (masterAMSels.count({tileId, amsel}))
+          if (masterAMSels.count({tileId, amsel}) ||
+              reservedAmsels.count({tileId, amsel}))
             continue;
           std::optional<ArbiterHazard> hazard =
               arbiterHazard(tileId, getArbiterIDFromAmsel(amsel), flow);
@@ -1004,10 +1050,12 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       [&](const std::map<std::pair<TileID, int>, SmallVector<Port, 4>>
               &masterAMSels,
           TileOp tileOp, int arbiter) {
-        for (int i = 0; i < numMselsPerArbiter; i++)
-          if (!masterAMSels.count({tileOp.getTileID(),
-                                   getAmselFromArbiterIDAndMsel(arbiter, i)}))
+        for (int i = 0; i < numMselsPerArbiter; i++) {
+          auto key = std::make_pair(tileOp.getTileID(),
+                                    getAmselFromArbiterIDAndMsel(arbiter, i));
+          if (!masterAMSels.count(key) && !reservedAmsels.count(key))
             return getAmselFromArbiterIDAndMsel(arbiter, i);
+        }
         tileOp->emitOpError("tile op arbiter ")
             << std::to_string(arbiter) << " has used up all its msels";
         return INVALID_AMSEL_VALUE;
@@ -1075,6 +1123,18 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
     return INVALID_ARBITER_VALUE;
   };
+
+  // Seed the reserved set from the packet-switch configuration the switchboxes
+  // already carry, so this run allocates around it instead of over it.
+  for (auto swboxOp : device.getOps<SwitchboxOp>()) {
+    TileID tileId = swboxOp.getTileOp().getTileID();
+    for (auto mtset : swboxOp.getConnections().getOps<MasterSetOp>())
+      for (Value amselVal : mtset.getAmsels())
+        if (auto amselOp = amselVal.getDefiningOp<AMSelOp>())
+          reservedAmsels.insert(
+              {tileId, getAmselFromArbiterIDAndMsel(amselOp.arbiterIndex(),
+                                                    amselOp.getMselValue())});
+  }
 
   // Check all multi-cast flows (same source, same ID). They should be
   // assigned the same arbiter and msel so that the flow can reach all the
@@ -1338,11 +1398,40 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
   }
 
-  // Ids on each slave port; a group covers its own and avoids the rest.
-  std::map<PhysPort, llvm::SmallSet<int, 8>> idsOnPort;
-  for (const auto &group : slaveGroups)
-    for (auto member : group)
-      idsOnPort[member.first].insert(member.second);
+  // What each group claims on its slave port, as cubes, split into the rules
+  // its flows state and the ids left for the cover to describe. A group may
+  // carry several rules, all pointing at its one arbiter slot, so a stated
+  // rule sits beside the derived ones rather than replacing them.
+  const uint32_t maxPacketId = device.getTargetModel().getMaxPacketId();
+  const int idBits = llvm::Log2_32_Ceil(maxPacketId + 1);
+  const int idMask = (1 << idBits) - 1;
+
+  SmallVector<SmallVector<std::pair<int, int>, 4>, 4> statedRules(
+      slaveGroups.size());
+  SmallVector<SmallVector<int, 4>, 4> derivedIds(slaveGroups.size());
+  for (size_t gi = 0; gi < slaveGroups.size(); ++gi) {
+    for (auto member : slaveGroups[gi]) {
+      auto it = pinnedMasks.find(member);
+      // A full-width mask selects the id alone, which the cover states just as
+      // well, so only a wider claim becomes a rule of its own.
+      if (it == pinnedMasks.end() || it->second == idMask) {
+        derivedIds[gi].push_back(member.second);
+        continue;
+      }
+      std::pair<int, int> cube = {it->second, member.second};
+      if (!llvm::is_contained(statedRules[gi], cube))
+        statedRules[gi].push_back(cube);
+    }
+  }
+
+  // Everything a group claims, for the other groups on its port to avoid.
+  auto claimsOf = [&](size_t gi) {
+    SmallVector<std::pair<int, int>, 8> claims(statedRules[gi].begin(),
+                                               statedRules[gi].end());
+    for (int id : derivedIds[gi])
+      claims.push_back({idMask, id});
+    return claims;
+  };
 
   // Realize the routes in MLIR
 
@@ -1425,7 +1514,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
 
     // Generate the packet rules
     DenseMap<Port, PacketRulesOp> slaveRules;
-    for (auto group : slaveGroups) {
+    for (size_t gi = 0; gi < slaveGroups.size(); ++gi) {
+      const auto &group = slaveGroups[gi];
       builder.setInsertionPoint(b.getTerminator());
 
       auto port = group.front().first;
@@ -1440,7 +1530,6 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       for (auto member : group)
         matchIds.push_back(member.second);
 
-      uint32_t maxPacketId = device.getTargetModel().getMaxPacketId();
       for (int id : matchIds)
         if (id > static_cast<int>(maxPacketId)) {
           return mlir::emitError(tileLoc)
@@ -1448,39 +1537,74 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
                  << maxPacketId;
         }
 
-      int idBits = llvm::Log2_32_Ceil(maxPacketId + 1);
-      llvm::SmallSet<int, 8> avoidIds = idsOnPort[port];
-      for (int id : matchIds)
-        avoidIds.erase(id);
-      SmallVector<std::pair<int, int>> cover =
-          computeSubcubeCover(matchIds, avoidIds, idBits);
+      SmallVector<std::pair<int, int>> avoidCubes;
+      for (size_t oi = 0; oi < slaveGroups.size(); ++oi)
+        if (oi != gi && slaveGroups[oi].front().first == port) {
+          auto claims = claimsOf(oi);
+          avoidCubes.append(claims.begin(), claims.end());
+        }
+
+      // A stated rule claims ids beyond the ones this design routes. Two
+      // claims that share an id give the port two routes for that id, and the
+      // group that loses it has no rule left to state.
+      for (std::pair<int, int> own : claimsOf(gi))
+        for (std::pair<int, int> other : avoidCubes)
+          if (cubesIntersect(own, other)) {
+            int witness = (own.second & own.first) |
+                          (other.second & other.first & ~own.first);
+            return mlir::emitError(tileLoc)
+                   << "packet flows through " << stringifyWireBundle(bundle)
+                   << channel << " claim rule (mask 0x"
+                   << llvm::utohexstr(own.first) << ", id 0x"
+                   << llvm::utohexstr(own.second) << ") and rule (mask 0x"
+                   << llvm::utohexstr(other.first) << ", id 0x"
+                   << llvm::utohexstr(other.second)
+                   << "), which both match id 0x" << llvm::utohexstr(witness)
+                   << "; widen one mask to carry both, or route them apart";
+          }
+
+      // The group keeps the rules its flows state, and the cover describes the
+      // ids that state none. A stated rule also constrains that cover, so the
+      // two never claim one id twice.
+      SmallVector<std::pair<int, int>> cover(statedRules[gi].begin(),
+                                             statedRules[gi].end());
+      if (!derivedIds[gi].empty()) {
+        SmallVector<std::pair<int, int>> derivedAvoid = avoidCubes;
+        derivedAvoid.append(statedRules[gi].begin(), statedRules[gi].end());
+        SmallVector<int, 4> ids(derivedIds[gi].begin(), derivedIds[gi].end());
+        SmallVector<std::pair<int, int>> derived =
+            computeSubcubeCover(ids, derivedAvoid, idBits);
+        cover.append(derived.begin(), derived.end());
+      }
 
       LLVM_DEBUG({
         llvm::dbgs() << "packet cover " << stringifyWireBundle(bundle)
                      << channel << ": matchIds {";
         for (int id : matchIds)
           llvm::dbgs() << ' ' << id;
-        llvm::dbgs() << " } avoidIds {";
-        for (int id : avoidIds)
-          llvm::dbgs() << ' ' << id;
+        llvm::dbgs() << " } avoid {";
+        for (auto [m, v] : avoidCubes)
+          llvm::dbgs() << " (" << m << ", " << v << ")";
         llvm::dbgs() << " } ->";
         for (auto [m, v] : cover)
           llvm::dbgs() << " rule(" << m << ", " << v << ")";
         llvm::dbgs() << '\n';
       });
 
+      // A stated rule takes part in the same constraints as a derived one, so
+      // both checks cover every group.
       for ([[maybe_unused]] int id : matchIds)
         assert(llvm::any_of(cover,
                             [&](std::pair<int, int> c) {
                               return (id & c.first) == c.second;
                             }) &&
-               "subcube cover misses a match id");
-      for ([[maybe_unused]] int id : avoidIds)
+               "packet rule cover misses a match id");
+      for ([[maybe_unused]] std::pair<int, int> other : avoidCubes)
         assert(llvm::none_of(cover,
                              [&](std::pair<int, int> c) {
-                               return (id & c.first) == c.second;
+                               return cubesIntersect(c, other);
                              }) &&
-               "subcube cover over-claims an avoid id");
+               "packet rule cover claims another group's ids");
 
       Value amsel = amselOps[slaveAMSels[group.front()]];
 
@@ -1515,8 +1639,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         return failure();
       }
 
-      // The cover avoids this port's avoidIds by construction; this catches a
-      // conflict only against rules from another source (e.g. hand-authored).
+      // The cover avoids what the other groups claim by construction; this
+      // catches a conflict only against rules from another source (e.g.
+      // hand-authored).
       for (auto rule : rules.getOps<PacketRuleOp>()) {
         auto verifyMask = rule.maskInt();
         auto verifyValue = rule.valueInt();
@@ -1633,7 +1758,14 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     }
   }
 
+  // Remove the packet_flow ops now that they have been lowered into
+  // masterset/amsel/packet_rules on the switchboxes. Leaving them in the IR
+  // would break idempotency: re-running this pass on its own routed output
+  // would re-lower them and emit duplicate masterset/packet_rules (illegal
+  // double-drivers on ports already claimed by the first lowering).
+  target.addIllegalOp<PacketFlowOp>();
   RewritePatternSet patterns(&getContext());
+  patterns.insert<AIEOpRemoval<PacketFlowOp>>(device.getContext());
 
   if (failed(applyPartialConversion(device, target, std::move(patterns))))
     return failure();
@@ -1663,8 +1795,32 @@ void AIEPathfinderPass::runOnOperation() {
     return;
   }
 
-  // Populate wires between switchboxes and tiles.
+  // Populate wires between switchboxes and tiles. Re-running the pass on
+  // already-routed IR must not duplicate the wires a previous run emitted, so
+  // key the wires already present and emit only the missing ones.
   builder.setInsertionPoint(d.getBody()->getTerminator());
+  llvm::DenseSet<std::tuple<Value, int, Value, int>> existingWires;
+  // aie.wire is a physical connection, so the IR may spell one adjacency in
+  // either operand order. Key both orders, or a reverse-oriented wire already
+  // present goes unnoticed and this run adds a duplicate in canonical order.
+  auto recordWire = [&](Value source, int sourceBundle, Value dest,
+                        int destBundle) {
+    bool absent =
+        !existingWires.contains({source, sourceBundle, dest, destBundle}) &&
+        !existingWires.contains({dest, destBundle, source, sourceBundle});
+    existingWires.insert({source, sourceBundle, dest, destBundle});
+    existingWires.insert({dest, destBundle, source, sourceBundle});
+    return absent;
+  };
+  for (auto wire : d.getOps<WireOp>())
+    recordWire(wire.getSource(), static_cast<int>(wire.getSourceBundle()),
+               wire.getDest(), static_cast<int>(wire.getDestBundle()));
+  auto wire = [&](Location loc, Value source, WireBundle sourceBundle,
+                  Value dest, WireBundle destBundle) {
+    if (recordWire(source, static_cast<int>(sourceBundle), dest,
+                   static_cast<int>(destBundle)))
+      WireOp::create(builder, loc, source, sourceBundle, dest, destBundle);
+  };
   for (int col = 0; col <= analyzer.getMaxCol(); col++) {
     for (int row = 0; row <= analyzer.getMaxRow(); row++) {
       TileOp tile;
@@ -1682,50 +1838,42 @@ void AIEPathfinderPass::runOnOperation() {
         // connections east-west between stream switches
         if (analyzer.coordToSwitchbox.count({col - 1, row})) {
           auto westsw = analyzer.coordToSwitchbox[{col - 1, row}];
-          WireOp::create(builder, loc, westsw, WireBundle::East, sw,
-                         WireBundle::West);
+          wire(loc, westsw, WireBundle::East, sw, WireBundle::West);
         }
       }
       if (row > 0) {
         // connections between abstract 'core' of tile
-        WireOp::create(builder, loc, tile, WireBundle::Core, sw,
-                       WireBundle::Core);
+        wire(loc, tile, WireBundle::Core, sw, WireBundle::Core);
         // connections between abstract 'dma' of tile
-        WireOp::create(builder, loc, tile, WireBundle::DMA, sw,
-                       WireBundle::DMA);
+        wire(loc, tile, WireBundle::DMA, sw, WireBundle::DMA);
         // connections north-south inside array ( including connection to shim
         // row)
         if (analyzer.coordToSwitchbox.count({col, row - 1})) {
           auto southsw = analyzer.coordToSwitchbox[{col, row - 1}];
-          WireOp::create(builder, loc, southsw, WireBundle::North, sw,
-                         WireBundle::South);
+          wire(loc, southsw, WireBundle::North, sw, WireBundle::South);
         }
       } else if (row == 0) {
         if (tile.isShimNOCTile()) {
           if (analyzer.coordToShimMux.count({col, 0})) {
             auto shimsw = analyzer.coordToShimMux[{col, 0}];
-            WireOp::create(
-                builder, loc, shimsw,
-                WireBundle::North, // Changed to connect into the north
-                sw, WireBundle::South);
+            wire(loc, shimsw,
+                 WireBundle::North, // Changed to connect into the north
+                 sw, WireBundle::South);
             // PLIO is attached to shim mux
             if (analyzer.coordToPLIO.count(col)) {
               auto plio = analyzer.coordToPLIO[col];
-              WireOp::create(builder, loc, plio, WireBundle::North, shimsw,
-                             WireBundle::South);
+              wire(loc, plio, WireBundle::North, shimsw, WireBundle::South);
             }
 
             // abstract 'DMA' connection on tile is attached to shim mux ( in
             // row 0 )
-            WireOp::create(builder, loc, tile, WireBundle::DMA, shimsw,
-                           WireBundle::DMA);
+            wire(loc, tile, WireBundle::DMA, shimsw, WireBundle::DMA);
           }
         } else if (tile.isShimPLTile()) {
           // PLIO is attached directly to switch
           if (analyzer.coordToPLIO.count(col)) {
             auto plio = analyzer.coordToPLIO[col];
-            WireOp::create(builder, loc, plio, WireBundle::North, sw,
-                           WireBundle::South);
+            wire(loc, plio, WireBundle::North, sw, WireBundle::South);
           }
         }
       }

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -17,6 +17,9 @@
 #include <utility>
 #include <vector>
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+
 namespace xilinx::AIE {
 #define GEN_PASS_DEF_AIEFINDFLOWS
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h.inc"
@@ -41,11 +44,17 @@ using PortConnection = struct PortConnection {
 using PortMaskValue = struct PortMaskValue {
   Port port;
   MaskValue mv;
+  // The interconnect ops that implement this hop (a circuit ConnectOp, or a
+  // packet PacketRuleOp + MasterSetOp + AMSelOp). Recorded so the flows that
+  // consume them can be lifted out of the physical IR.
+  llvm::SmallVector<Operation *, 3> ops;
 };
 
 using PacketConnection = struct PacketConnection {
   PortConnection portConnection;
   MaskValue mv;
+  // Interconnect ops traversed on the way to this endpoint.
+  llvm::SmallVector<Operation *, 8> usedOps;
 };
 
 class ConnectivityAnalysis {
@@ -93,7 +102,7 @@ private:
     for (auto connectOp : b.getOps<ConnectOp>()) {
       if (connectOp.sourcePort() == sourcePort) {
         MaskValue maskValue = {0, 0};
-        portSet.push_back({connectOp.destPort(), maskValue});
+        portSet.push_back({connectOp.destPort(), maskValue, {connectOp}});
         LLVM_DEBUG(llvm::dbgs()
                    << "To:" << stringifyWireBundle(connectOp.destPort().bundle)
                    << " " << connectOp.destPort().channel << "\n");
@@ -115,7 +124,10 @@ private:
                            << stringifyWireBundle(masterSetOp.destPort().bundle)
                            << " " << masterSetOp.destPort().channel << "\n");
                 MaskValue maskValue = {ruleOp.maskInt(), ruleOp.valueInt()};
-                portSet.push_back({masterSetOp.destPort(), maskValue});
+                portSet.push_back(
+                    {masterSetOp.destPort(),
+                     maskValue,
+                     {ruleOp, masterSetOp, amsel.getDefiningOp()}});
               }
             }
       }
@@ -123,10 +135,11 @@ private:
     return portSet;
   }
 
-  std::vector<PacketConnection>
-  maskSwitchboxConnections(Operation *switchOp,
-                           const std::vector<PortMaskValue> &nextPortMaskValues,
-                           MaskValue maskValue) const {
+  std::vector<PacketConnection> maskSwitchboxConnections(
+      Operation *switchOp, ArrayRef<Operation *> currentUsedOps,
+      const std::vector<PortMaskValue> &nextPortMaskValues, MaskValue maskValue,
+      bool keepPartialFlows,
+      std::vector<PacketConnection> &partialEndpoints) const {
     std::vector<PacketConnection> worklist;
     for (auto &nextPortMaskValue : nextPortMaskValues) {
       Port nextPort = nextPortMaskValue.port;
@@ -146,107 +159,146 @@ private:
       MaskValue newMaskValue = {maskValue.mask | nextMaskValue.mask,
                                 maskValue.value |
                                     (nextMaskValue.mask & nextMaskValue.value)};
+      SmallVector<Operation *, 8> newUsedOps(currentUsedOps.begin(),
+                                             currentUsedOps.end());
+      newUsedOps.append(nextPortMaskValue.ops.begin(),
+                        nextPortMaskValue.ops.end());
       auto nextConnection = getConnectionThroughWire(switchOp, nextPort);
 
-      // If there is no wire to follow then bail out.
-      if (!nextConnection)
+      if (!nextConnection) {
+        // The switchbox drives nextPort but no wire continues from it (an array
+        // edge or an off-fabric consumer). Under partial recovery this output
+        // port is itself the flow's endpoint.
+        if (keepPartialFlows)
+          partialEndpoints.push_back(
+              {{switchOp, nextPort}, newMaskValue, newUsedOps});
         continue;
+      }
 
-      worklist.push_back({*nextConnection, newMaskValue});
+      worklist.push_back({*nextConnection, newMaskValue, newUsedOps});
     }
     return worklist;
   }
 
 public:
-  // Get the tiles connected to the given tile, starting from the given
-  // output port of the tile.  This is 1:N relationship because each
-  // switchbox can broadcast.
-  std::vector<PacketConnection> getConnectedTiles(TileOp tileOp,
-                                                  Port port) const {
+  // Follow the single upstream wire out of an interconnect input port.
+  std::optional<PortConnection> upstreamOf(Operation *op, Port port) const {
+    return getConnectionThroughWire(op, port);
+  }
 
-    LLVM_DEBUG(llvm::dbgs()
-               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
-               << port.channel << ")");
-    LLVM_DEBUG(tileOp.dump());
+  // Whether `port` is driven (is the destination of a connect or masterset)
+  // inside the given interconnect op.
+  bool drivesPort(Operation *op, Port port) const {
+    Region *r = nullptr;
+    if (auto sb = dyn_cast<SwitchboxOp>(op))
+      r = &sb.getConnections();
+    else if (auto sm = dyn_cast<ShimMuxOp>(op))
+      r = &sm.getConnections();
+    if (!r)
+      return false;
+    Block &b = r->front();
+    for (auto connectOp : b.getOps<ConnectOp>())
+      if (connectOp.destPort() == port)
+        return true;
+    for (auto masterSetOp : b.getOps<MasterSetOp>())
+      if (masterSetOp.destPort() == port)
+        return true;
+    return false;
+  }
 
-    // The accumulated result;
+  // Traverse forward from switchbox/shim-mux input ports, collecting the
+  // endpoints each stream reaches: flow-endpoint tiles, or -- under
+  // keepPartialFlows -- driven interconnect ports that have no onward wire.
+  std::vector<PacketConnection> traverse(std::vector<PacketConnection> worklist,
+                                         bool keepPartialFlows) const {
     std::vector<PacketConnection> connectedTiles;
-    // A worklist of PortConnections to visit.  These are all input ports of
-    // some object (likely either a TileOp or a SwitchboxOp).
-    std::vector<PacketConnection> worklist;
-    // Start the worklist by traversing from the tile to its connected
-    // switchbox.
-    auto t = getConnectionThroughWire(tileOp.getOperation(), port);
-
-    // If there is no wire to traverse, then just return no connection
-    if (!t)
-      return connectedTiles;
-    worklist.push_back({*t, {0, 0}});
-
     while (!worklist.empty()) {
       PacketConnection t = worklist.back();
       worklist.pop_back();
-      PortConnection portConnection = t.portConnection;
+      Operation *other = t.portConnection.op;
+      Port otherPort = t.portConnection.port;
       MaskValue maskValue = t.mv;
-      Operation *other = portConnection.op;
-      Port otherPort = portConnection.port;
       if (other && other->hasTrait<IsFlowEndPoint>()) {
         // If we got to a tile, then add it to the result.
         connectedTiles.push_back(t);
-      } else if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other)) {
-        std::vector<PortMaskValue> nextPortMaskValues =
-            getConnectionsThroughSwitchbox(switchOp.getConnections(),
-                                           otherPort);
-        std::vector<PacketConnection> newWorkList =
-            maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
-        // append to the worklist
-        worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
-          // No rule matched some incoming packet.  This is likely a
-          // configuration error.
-          LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
-          LLVM_DEBUG(other->dump());
-        }
-      } else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other)) {
-        std::vector<PortMaskValue> nextPortMaskValues =
-            getConnectionsThroughSwitchbox(switchOp.getConnections(),
-                                           otherPort);
-        std::vector<PacketConnection> newWorkList =
-            maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
-        // append to the worklist
-        worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
-          // No rule matched some incoming packet.  This is likely a
-          // configuration error.
-          LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
-          LLVM_DEBUG(other->dump());
-        }
-      } else {
+        continue;
+      }
+      Region *connections = nullptr;
+      if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other))
+        connections = &switchOp.getConnections();
+      else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other))
+        connections = &switchOp.getConnections();
+      if (!connections) {
         LLVM_DEBUG(llvm::dbgs()
                    << "*** Connection Terminated at unknown operation: ");
+        LLVM_DEBUG(other->dump());
+        continue;
+      }
+      std::vector<PortMaskValue> nextPortMaskValues =
+          getConnectionsThroughSwitchbox(*connections, otherPort);
+      std::vector<PacketConnection> partialEndpoints;
+      std::vector<PacketConnection> newWorkList = maskSwitchboxConnections(
+          other, t.usedOps, nextPortMaskValues, maskValue, keepPartialFlows,
+          partialEndpoints);
+      worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
+      connectedTiles.insert(connectedTiles.end(), partialEndpoints.begin(),
+                            partialEndpoints.end());
+      if (!nextPortMaskValues.empty() && newWorkList.empty() &&
+          partialEndpoints.empty()) {
+        // No rule matched some incoming packet.  This is likely a
+        // configuration error.
+        LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
         LLVM_DEBUG(other->dump());
       }
     }
     return connectedTiles;
   }
+
+  // Get the tiles connected to the given tile, starting from the given
+  // output port of the tile.  This is 1:N relationship because each
+  // switchbox can broadcast.
+  std::vector<PacketConnection> getConnectedTiles(TileOp tileOp, Port port,
+                                                  bool keepPartialFlows) const {
+    LLVM_DEBUG(llvm::dbgs()
+               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
+               << port.channel << ")");
+    LLVM_DEBUG(tileOp.dump());
+    // Traverse from the tile to its connected switchbox.
+    auto t = getConnectionThroughWire(tileOp.getOperation(), port);
+    // If there is no wire to traverse, then just return no connection
+    if (!t)
+      return {};
+    return traverse({PacketConnection{*t, {0, 0}, {}}}, keepPartialFlows);
+  }
+
+  // Get the endpoints reached by a stream that enters the fabric at the given
+  // input port of an interconnect (switchbox / shim-mux).  Used to lift flows
+  // whose source is not a core or DMA.
+  std::vector<PacketConnection>
+  getConnectedTilesFromInput(Operation *switchOp, Port inputPort,
+                             bool keepPartialFlows) const {
+    return traverse(
+        {PacketConnection{PortConnection{switchOp, inputPort}, {0, 0}, {}}},
+        keepPartialFlows);
+  }
 };
 
 // Identifies a flow by its two endpoints -- tile coordinates plus port -- and
-// the packet ID it carries, using kCircuitFlow for circuit-switched flows.
+// the packet claim it carries, using kCircuitFlow for circuit-switched flows.
 // Coordinates rather than SSA values, so flows written against different
 // aie.tile ops for the same tile still compare equal.
 static constexpr int kCircuitFlow = -1;
-using FlowKey = std::tuple<int, int, int, int, int, int, int, int, int>;
+using FlowKey = std::tuple<int, int, int, int, int, int, int, int, int, int>;
 using FlowKeySet = std::set<FlowKey>;
 
 // Returns nullopt when either endpoint's coordinates are unknown, in which
 // case the caller cannot tell the flow apart from any other and must not
 // dedupe it away.
-static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
-                                            Operation *destOp, Port destPort,
-                                            int packetID) {
-  auto coords = [](Operation *op) -> std::optional<std::pair<int, int>> {
-    auto tile = llvm::dyn_cast_or_null<TileLike>(op);
+static std::optional<FlowKey> tryGetFlowKey(Value srcTileValue, Port srcPort,
+                                            Value destTileValue, Port destPort,
+                                            int packetID, int packetMask) {
+  auto coords = [](Value v) -> std::optional<std::pair<int, int>> {
+    auto tile = llvm::dyn_cast_or_null<TileLike>(v.getDefiningOp());
     if (!tile)
       return std::nullopt;
     std::optional<int> col = tile.tryGetCol();
@@ -255,8 +307,8 @@ static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
       return std::nullopt;
     return std::make_pair(*col, *row);
   };
-  std::optional<std::pair<int, int>> src = coords(srcOp);
-  std::optional<std::pair<int, int>> dest = coords(destOp);
+  std::optional<std::pair<int, int>> src = coords(srcTileValue);
+  std::optional<std::pair<int, int>> dest = coords(destTileValue);
   if (!src || !dest)
     return std::nullopt;
   return FlowKey{src->first,
@@ -267,27 +319,131 @@ static std::optional<FlowKey> tryGetFlowKey(Operation *srcOp, Port srcPort,
                  dest->second,
                  static_cast<int>(destPort.bundle),
                  destPort.channel,
-                 packetID};
+                 packetID,
+                 packetMask};
 }
 
-// Drops the flows the device already declares. This pass recovers the logical
-// flows a routed design implements, so the flows it writes are the answer --
-// leaving the originals in place next to them would just describe the same
-// routing twice, which DeviceOp::verify now rejects. It really does happen:
-// --aie-create-pathfinder-flows leaves behind every aie.flow it folded into an
-// earlier flow with the same source, and it never consumes aie.packet_flow.
-static void eraseExistingFlows(DeviceOp device) {
-  SmallVector<Operation *> toErase;
-  for (FlowOp flow : device.getOps<FlowOp>())
-    toErase.push_back(flow);
-  for (PacketFlowOp packetFlow : device.getOps<PacketFlowOp>())
-    toErase.push_back(packetFlow);
-  for (Operation *op : toErase)
-    op->erase();
+// The tile an endpoint of a lifted flow belongs to.
+//
+// aie.flow names tiles: --aie-create-pathfinder-flows casts both endpoints of
+// every flow to TileOp. A tile element such as an aie.shim_dma therefore has to
+// resolve to its owning tile, or the flow this pass emits crashes the router it
+// is meant to feed. TileElement covers every element that can end a flow, and
+// Interconnect extends it, so a switchbox or shim-mux port resolves the same
+// way.
+static Value resolveEndpointTile(Operation *op) {
+  if (isa<TileOp>(op))
+    return op->getResult(0);
+  if (auto element = dyn_cast<TileElement>(op))
+    return element.getTile();
+  return nullptr;
+}
+
+static void emitFlows(OpBuilder &rewriter, Location loc, Value srcTile,
+                      WireBundle srcBundle, int srcChannel,
+                      const std::vector<PacketConnection> &endpoints,
+                      bool dropIntraTile, int idMask, FlowKeySet &seen,
+                      llvm::DenseSet<Operation *> &consumed) {
+  for (const PacketConnection &c : endpoints) {
+    Operation *destOp = c.portConnection.op;
+    Port destPort = c.portConnection.port;
+    MaskValue maskValue = c.mv;
+    Value destTile = resolveEndpointTile(destOp);
+    if (!destTile)
+      continue;
+    // A control overlay stays materialized. Its switchbox configuration carries
+    // the is_ctrl_pkt_overlay marker, and a lifted flow cannot rebuild it.
+    bool keepMaterialized = false;
+    for (Operation *op : c.usedOps) {
+      Operation *rulesParent =
+          isa_and_nonnull<PacketRuleOp>(op) ? op->getParentOp() : nullptr;
+      if (op->hasAttr("is_ctrl_pkt_overlay") ||
+          (rulesParent && rulesParent->hasAttr("is_ctrl_pkt_overlay"))) {
+        keepMaterialized = true;
+        break;
+      }
+    }
+    if (keepMaterialized)
+      continue;
+    // A packet endpoint becomes a logical packet flow, and the pass reclaims
+    // its physical configuration.
+    //
+    // The rules decide this, not the mask: a rule may carry mask 0, which
+    // accepts every id, and a circuit path accumulates the same mask 0.
+    bool isPacket = llvm::any_of(c.usedOps, [](Operation *op) {
+      return isa_and_nonnull<PacketRuleOp>(op);
+    });
+    // The traversal reaches one endpoint more than once when a broadcast
+    // re-converges on it, and the three seeds can arrive at one route from
+    // different directions. Those repeats describe one flow, and
+    // DeviceOp::verify rejects a flow declared twice.
+    std::optional<FlowKey> key =
+        tryGetFlowKey(srcTile, {srcBundle, srcChannel}, destTile, destPort,
+                      isPacket ? maskValue.value : kCircuitFlow,
+                      isPacket ? maskValue.mask : 0);
+    if (key && !seen.insert(*key).second)
+      continue;
+    if (isPacket) {
+      for (Operation *op : c.usedOps)
+        if (op)
+          consumed.insert(op);
+      // The lowering stores keep_pkt_header on the master set that drives the
+      // destination. Carry it onto the recovered flow, or re-lowering strips
+      // the header and misroutes the packet downstream.
+      BoolAttr keepPktHeader;
+      for (Operation *op : c.usedOps)
+        if (auto ms = dyn_cast_or_null<MasterSetOp>(op))
+          if (ms.getDestBundle() == destPort.bundle &&
+              ms.getDestChannel() == destPort.channel)
+            keepPktHeader = ms.getKeepPktHeaderAttr();
+      // The rules along the path accept every id that agrees with value on the
+      // bits mask selects. Which of those a running design sends is not
+      // decidable here, so state the pair and let routing rebuild the same
+      // rules.
+      //
+      // A full-width mask selects one id, which the id states on its own.
+      // Leaving the attribute off keeps such a flow mergeable with the others
+      // that share its route, the way routing found it.
+      IntegerAttr mask;
+      if (maskValue.mask != idMask)
+        mask = rewriter.getI8IntegerAttr(maskValue.mask);
+      auto flowOp = PacketFlowOp::create(
+          rewriter, loc, rewriter.getI8IntegerAttr(maskValue.value), mask,
+          keepPktHeader, BoolAttr());
+      PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter, loc);
+      OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
+      PacketSourceOp::create(rewriter, loc, srcTile, srcBundle, srcChannel);
+      PacketDestOp::create(rewriter, loc, destTile, destPort.bundle,
+                           destPort.channel);
+      rewriter.restoreInsertionPoint(ip);
+      continue;
+    }
+    // A section that lifts no interconnect configuration carries no routing: it
+    // is the physical wire between two retained nodes. The wire is implicit and
+    // the switchboxes at both ends stay explicit, so a flow emitted for it
+    // would only fight their fixed connections on re-routing.
+    if (c.usedOps.empty())
+      continue;
+    // A flow seeded from a fabric entry that terminates on a real endpoint of
+    // the same tile never leaves that tile. It is a dead or orphan interconnect
+    // connection, such as an undriven shim-mux write path, so the pass leaves
+    // it alone.
+    if (dropIntraTile && destTile == srcTile && isa<TileOp>(destOp))
+      continue;
+    // Every interconnect op on this endpoint's path is lifted into the flow.
+    for (Operation *op : c.usedOps)
+      if (op)
+        consumed.insert(op);
+    FlowOp::create(rewriter, loc, srcTile, srcBundle, srcChannel, destTile,
+                   destPort.bundle, destPort.channel);
+  }
 }
 
 static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
-                          OpBuilder &rewriter, FlowKeySet &seen) {
+                          OpBuilder &rewriter, bool keepPartialFlows,
+                          int idMask, FlowKeySet &seen,
+                          llvm::DenseSet<Operation *> &consumed) {
   Operation *Op = op.getOperation();
   rewriter.setInsertionPoint(Op->getBlock()->getTerminator());
 
@@ -298,42 +454,80 @@ static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
                << op.getNumSourceConnections(bundle) << " Connections\n");
     for (size_t i = 0; i < op.getNumSourceConnections(bundle); i++) {
       std::vector<PacketConnection> tiles =
-          analysis.getConnectedTiles(op, {bundle, (int)i});
+          analysis.getConnectedTiles(op, {bundle, (int)i}, keepPartialFlows);
       LLVM_DEBUG(llvm::dbgs() << tiles.size() << " Flows\n");
-
-      for (PacketConnection &c : tiles) {
-        PortConnection portConnection = c.portConnection;
-        MaskValue maskValue = c.mv;
-        Operation *destOp = portConnection.op;
-        Port destPort = portConnection.port;
-        // The traversal can reach the same endpoint more than once, for
-        // instance when a broadcast re-converges on it. Those repeats all
-        // describe one logical flow, and a flow declared twice is rejected by
-        // DeviceOp::verify.
-        std::optional<FlowKey> key =
-            tryGetFlowKey(Op, {bundle, (int)i}, destOp, destPort,
-                          maskValue.mask == 0 ? kCircuitFlow : maskValue.value);
-        if (key && !seen.insert(*key).second)
-          continue;
-        if (maskValue.mask == 0) {
-          FlowOp::create(rewriter, Op->getLoc(), Op->getResult(0), bundle, i,
-                         destOp->getResult(0), destPort.bundle,
-                         destPort.channel);
-        } else {
-          auto flowOp = PacketFlowOp::create(rewriter, Op->getLoc(),
-                                             maskValue.value, nullptr, nullptr);
-          PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter,
-                                         Op->getLoc());
-          OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
-          rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
-          PacketSourceOp::create(rewriter, Op->getLoc(), Op->getResult(0),
-                                 bundle, i);
-          PacketDestOp::create(rewriter, Op->getLoc(), destOp->getResult(0),
-                               destPort.bundle, destPort.channel);
-          rewriter.restoreInsertionPoint(ip);
-        }
-      }
+      emitFlows(rewriter, Op->getLoc(), Op->getResult(0), bundle, (int)i, tiles,
+                /*dropIntraTile=*/false, idMask, seen, consumed);
     }
+  }
+}
+
+// Lift flows whose source is not a core/DMA.  Seed from every switchbox /
+// shim-mux input port that drives a connection but is not itself driven by an
+// upstream interconnect connection.  Ports driven by a core/DMA tile are
+// already covered by findFlowsFrom; ports driven by an upstream interconnect
+// are covered by that interconnect's own source, so both are skipped here to
+// avoid emitting a flow twice.
+static void findFlowsFromInterconnect(Operation *switchOp,
+                                      ConnectivityAnalysis &analysis,
+                                      OpBuilder &rewriter,
+                                      bool keepPartialFlows, int idMask,
+                                      FlowKeySet &seen,
+                                      llvm::DenseSet<Operation *> &consumed) {
+  Region *connections = nullptr;
+  if (auto sb = dyn_cast<SwitchboxOp>(switchOp))
+    connections = &sb.getConnections();
+  else if (auto sm = dyn_cast<ShimMuxOp>(switchOp))
+    connections = &sm.getConnections();
+  if (!connections)
+    return;
+  rewriter.setInsertionPoint(switchOp->getBlock()->getTerminator());
+
+  // Distinct source ports of this interconnect's connections and packet rules.
+  llvm::SmallVector<Port, 8> sourcePorts;
+  auto addPort = [&](Port p) {
+    if (!llvm::is_contained(sourcePorts, p))
+      sourcePorts.push_back(p);
+  };
+  Block &b = connections->front();
+  for (auto connectOp : b.getOps<ConnectOp>())
+    addPort(connectOp.sourcePort());
+  for (auto rulesOp : b.getOps<PacketRulesOp>())
+    addPort(rulesOp.sourcePort());
+
+  for (Port p : sourcePorts) {
+    Value srcTile;
+    WireBundle srcBundle = p.bundle;
+    int srcChannel = p.channel;
+    if (auto up = analysis.upstreamOf(switchOp, p)) {
+      Operation *upOp = up->op;
+      Port upPort = up->port;
+      if (upOp && upOp->hasTrait<IsFlowEndPoint>()) {
+        // Driven by a tile.  Core/DMA sources are handled by findFlowsFrom;
+        // recover the remaining tile-source bundles (e.g. PLIO) from here.
+        if (upPort.bundle == WireBundle::Core ||
+            upPort.bundle == WireBundle::DMA)
+          continue;
+        srcTile = upOp->getResult(0);
+        srcBundle = upPort.bundle;
+        srcChannel = upPort.channel;
+      } else if (analysis.drivesPort(upOp, upPort)) {
+        // Mid-chain: an upstream interconnect drives this port.
+        continue;
+      } else {
+        // Wire exists but nothing drives it: this input is a fabric entry.
+        srcTile = resolveEndpointTile(switchOp);
+      }
+    } else {
+      // No upstream wire: this input is a fabric entry (array edge).
+      srcTile = resolveEndpointTile(switchOp);
+    }
+    if (!srcTile)
+      continue;
+    std::vector<PacketConnection> tiles =
+        analysis.getConnectedTilesFromInput(switchOp, p, keepPartialFlows);
+    emitFlows(rewriter, switchOp->getLoc(), srcTile, srcBundle, srcChannel,
+              tiles, /*dropIntraTile=*/true, idMask, seen, consumed);
   }
 }
 
@@ -343,21 +537,106 @@ struct AIEFindFlowsPass
     registry.insert<func::FuncDialect>();
     registry.insert<AIEDialect>();
   }
+
+  // An interconnect whose region holds nothing but its terminator carries no
+  // configuration and can be dropped.
+  static bool isEmptyInterconnect(Region &connections) {
+    Block &b = connections.front();
+    return b.getOps<ConnectOp>().empty() && b.getOps<PacketRulesOp>().empty() &&
+           b.getOps<MasterSetOp>().empty() && b.getOps<AMSelOp>().empty();
+  }
+
   void runOnOperation() override {
 
     DeviceOp d = getOperation();
     ConnectivityAnalysis analysis(d);
     d.getTargetModel().validate();
 
-    // The analysis above reads only the switchboxes and shim muxes, so the
-    // flows can be cleared before rebuilding them from that routing.
-    eraseExistingFlows(d);
+    // Widest mask the target's packet ids can carry.
+    const int idMask =
+        (1 << llvm::Log2_32_Ceil(d.getTargetModel().getMaxPacketId() + 1)) - 1;
 
-    OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
+    llvm::DenseSet<Operation *> consumed;
     FlowKeySet seen;
+    OpBuilder builder = OpBuilder::atBlockTerminator(d.getBody());
     for (auto tile : d.getOps<TileOp>()) {
-      findFlowsFrom(tile, analysis, builder, seen);
+      findFlowsFrom(tile, analysis, builder, clKeepPartialFlows, idMask, seen,
+                    consumed);
     }
+    // Lift flows whose source is not a core/DMA (transit fills, packet routing
+    // steered at runtime, PLIO/edge entries) directly from the interconnect.
+    if (clKeepPartialFlows) {
+      for (auto switchOp : d.getOps<SwitchboxOp>())
+        findFlowsFromInterconnect(switchOp, analysis, builder,
+                                  clKeepPartialFlows, idMask, seen, consumed);
+      for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+        findFlowsFromInterconnect(shimMuxOp, analysis, builder,
+                                  clKeepPartialFlows, idMask, seen, consumed);
+    }
+
+    if (!clRemoveLifted)
+      return;
+
+    // Every recovered flow makes the interconnect ops it traversed redundant;
+    // drop exactly those, leaving any configuration that could not be lifted
+    // (e.g. an unreachable connect) in place.  Leaf routing ops go first;
+    // amsels that lose all users and now-empty rule containers follow.
+    for (Operation *op : consumed)
+      if (isa<ConnectOp, PacketRuleOp, MasterSetOp>(op))
+        op->erase();
+    auto cleanupInterconnect = [](Region &connections) {
+      for (auto amselOp :
+           llvm::make_early_inc_range(connections.getOps<AMSelOp>()))
+        if (amselOp.use_empty())
+          amselOp.erase();
+      for (auto rulesOp :
+           llvm::make_early_inc_range(connections.getOps<PacketRulesOp>()))
+        if (rulesOp.getRules().front().getOps<PacketRuleOp>().empty())
+          rulesOp.erase();
+    };
+    for (auto switchOp : d.getOps<SwitchboxOp>())
+      cleanupInterconnect(switchOp.getConnections());
+    for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+      cleanupInterconnect(shimMuxOp.getConnections());
+
+    // An interconnect still holding configuration was not lifted: a control
+    // overlay, a connect this pass could not reach, or -- under
+    // keep-partial-flows=false -- a partial route left in place. Routing
+    // regenerates a wire only for the flows it routes, so a wire reaching such
+    // an interconnect has to stay, or that configuration ends up unreachable.
+    llvm::DenseSet<Operation *> retained;
+    auto retainNonEmpty = [&](Operation *op, Region &connections) {
+      if (!isEmptyInterconnect(connections))
+        retained.insert(op);
+    };
+    for (auto switchOp : d.getOps<SwitchboxOp>())
+      retainNonEmpty(switchOp, switchOp.getConnections());
+    for (auto shimMuxOp : d.getOps<ShimMuxOp>())
+      retainNonEmpty(shimMuxOp, shimMuxOp.getConnections());
+
+    llvm::DenseSet<Operation *> wiredToRetained;
+    for (auto wireOp : llvm::make_early_inc_range(d.getOps<WireOp>())) {
+      Operation *src = wireOp.getSource().getDefiningOp();
+      Operation *dst = wireOp.getDest().getDefiningOp();
+      if (!retained.contains(src) && !retained.contains(dst)) {
+        wireOp.erase();
+        continue;
+      }
+      wiredToRetained.insert(src);
+      wiredToRetained.insert(dst);
+    }
+
+    // A surviving wire keeps its operands alive, so an empty interconnect one
+    // of them names outlives its configuration.
+    auto eraseIfUnused = [&](Operation *op, Region &connections) {
+      return isEmptyInterconnect(connections) && !wiredToRetained.contains(op);
+    };
+    for (auto switchOp : llvm::make_early_inc_range(d.getOps<SwitchboxOp>()))
+      if (eraseIfUnused(switchOp, switchOp.getConnections()))
+        switchOp.erase();
+    for (auto shimMuxOp : llvm::make_early_inc_range(d.getOps<ShimMuxOp>()))
+      if (eraseIfUnused(shimMuxOp, shimMuxOp.getConnections()))
+        shimMuxOp.erase();
   }
 };
 

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -155,6 +155,16 @@ struct AIEGenerateColumnControlOverlayPass
         }
         continue;
       }
+      // A device that already carries a control overlay -- e.g. a physically
+      // routed design recompiled through aiecc -- must not receive a second
+      // one, or the regenerated control flows would double-drive its shim
+      // control ports during routing.
+      if (deviceHasControlOverlay(dev)) {
+        if (clEmitStandaloneOverlay) {
+          dev->setAttr("has_ctrl_pkt_overlay", builder.getBoolAttr(true));
+        }
+        continue;
+      }
       participating.push_back(dev);
     }
 
@@ -432,6 +442,18 @@ struct AIEGenerateColumnControlOverlayPass
         flows.try_emplace(*key, flow);
     }
     return flows;
+  }
+
+  // Return true when `device` already contains a control-packet overlay,
+  // identified by the `is_ctrl_pkt_overlay` marker the overlay's routed
+  // switchbox configuration carries.
+  static bool deviceHasControlOverlay(DeviceOp device) {
+    return device
+        .walk([](Operation *op) {
+          return op->hasAttr("is_ctrl_pkt_overlay") ? WalkResult::interrupt()
+                                                    : WalkResult::advance();
+        })
+        .wasInterrupted();
   }
 
   AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, Location loc,

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_os_ostream.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 
 using namespace mlir;
@@ -385,27 +386,69 @@ bool Pathfinder::addFixedConnection(SwitchboxOp switchboxOp) {
   int row = switchboxOp.rowIndex();
   TileID coords = {col, row};
   auto &sb = graph[std::make_pair(coords, coords)];
+  // Validate every connect against the original connectivity before reserving
+  // any resource, so a broadcast (one source fanning out to several dests) does
+  // not invalidate its own sibling connects mid-scan. A destination port may be
+  // driven only once; a source port may legally recur across a broadcast.
+  llvm::SmallVector<std::pair<int, int>, 8> reserved;
+  llvm::SmallDenseSet<int, 8> claimedDsts;
   for (ConnectOp connectOp : switchboxOp.getOps<ConnectOp>()) {
-    bool found = false;
-    for (size_t i = 0; i < sb.srcPorts.size(); i++) {
-      if (sb.srcPorts[i] != connectOp.sourcePort())
-        continue;
-      // A circuit-switched ConnectOp monopolizes its entire source port;
-      // mark all connectivity[i][*] INVALID so the pathfinder cannot route
-      // any packet flow through this source port.
-      for (size_t j = 0; j < sb.dstPorts.size(); j++) {
-        if (sb.dstPorts[j] == connectOp.destPort() &&
-            sb.connectivity[i][j] == Connectivity::AVAILABLE)
-          found = true;
-        sb.connectivity[i][j] = Connectivity::INVALID;
+    int srcIdx = -1, dstIdx = -1;
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      if (sb.srcPorts[i] == connectOp.sourcePort()) {
+        srcIdx = static_cast<int>(i);
+        break;
       }
-    }
-    if (!found) {
-      // ConnectOp references a (srcPort, dstPort) pair absent from or already
-      // fully invalidated in the switchbox model; IR/graph mismatch.
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      if (sb.dstPorts[j] == connectOp.destPort()) {
+        dstIdx = static_cast<int>(j);
+        break;
+      }
+    // Reject an illegal pair (absent from the switchbox model) or a second
+    // driver on the same output port; a repeated source port is a broadcast.
+    if (srcIdx < 0 || dstIdx < 0 ||
+        sb.connectivity[srcIdx][dstIdx] != Connectivity::AVAILABLE ||
+        !claimedDsts.insert(dstIdx).second)
       return false;
-    }
+    reserved.emplace_back(srcIdx, dstIdx);
   }
+  // A pre-placed packet-switched output (an aie.masterset) also monopolizes its
+  // destination port. That stream-switch output is already configured for
+  // packet switching, so no circuit stream may drive it, and the router cannot
+  // emit a second masterset on the same port for another packet flow. The
+  // circuit pathfinder does not read packet ops, so without this reservation it
+  // may route a flow onto an output the masterset owns and produce two ops
+  // driving one destination.
+  llvm::SmallVector<int, 8> reservedMasterDsts;
+  for (MasterSetOp masterSetOp : switchboxOp.getOps<MasterSetOp>()) {
+    int dstIdx = -1;
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      if (sb.dstPorts[j] == masterSetOp.destPort()) {
+        dstIdx = static_cast<int>(j);
+        break;
+      }
+    // Reject an output port absent from the switchbox model or already driven
+    // by a circuit connect or another masterset.
+    if (dstIdx < 0 || !claimedDsts.insert(dstIdx).second)
+      return false;
+    reservedMasterDsts.push_back(dstIdx);
+  }
+  // A circuit-switched ConnectOp monopolizes both its source port (the stream
+  // switch input) and its destination port (the output): no other stream may
+  // inject on that input, and the output can carry only this one stream.
+  // Reserving the whole column also reserves the outgoing wire, since that wire
+  // is reachable only by driving this output port.
+  for (auto [srcIdx, dstIdx] : reserved) {
+    for (size_t j = 0; j < sb.dstPorts.size(); j++)
+      sb.connectivity[srcIdx][j] = Connectivity::INVALID;
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      sb.connectivity[i][dstIdx] = Connectivity::INVALID;
+  }
+  // A masterset fixes only its output port. Its inputs arrive through arbiters
+  // that packet flows share, so the source rows stay free.
+  for (int dstIdx : reservedMasterDsts)
+    for (size_t i = 0; i < sb.srcPorts.size(); i++)
+      sb.connectivity[i][dstIdx] = Connectivity::INVALID;
   return true;
 }
 

--- a/test/aiecc/checkpoint_resume_aiesim.mlir
+++ b/test/aiecc/checkpoint_resume_aiesim.mlir
@@ -10,33 +10,32 @@
 // The aiesim work-folder subgraph must round-trip through checkpoint/resume.
 // A straight-through `--get-aiesim` build (which assembles the whole `sim/`
 // folder from declarative graph edges) is compared against a build that is cut
-// at an aiesim IR edge (`sim/flows_physical.mlir`), snapshotted with
-// `--checkpoint`, and then completed with `--resume`. Resume reloads the routed
-// flows from the checkpoint and rebuilds everything downstream, so its `sim/`
-// descriptors must be byte-identical to the reference.
+// at the IR edge feeding that subgraph (`perDevice_{0}.mlir`), snapshotted with
+// `--checkpoint`, and then completed with `--resume`. Resume reloads the
+// per-device IR from the checkpoint and rebuilds every `sim/` descriptor, so
+// they must be byte-identical to the reference.
 
 // RUN: rm -rf %t && mkdir -p %t
 
 // Straight-through reference: assemble the whole sim/ folder in one go.
 // RUN: %aiecc --get-aiesim --xchesscc --xbridge --tmpdir=%t/ref.prj %s
 
-// Cut at the routed-flows IR edge and snapshot it. With --cut the build stops
-// at the cut point, so only the prefix up to sim/flows_physical.mlir runs here.
-// RUN: %aiecc --get-aiesim --xchesscc --xbridge --tmpdir=%t/cut.prj --cut='sim/flows_physical.mlir' --checkpoint=%t/cut.ckpt %s
+// Cut at the per-device IR edge and snapshot it. With --cut the build stops at
+// the cut point, so only the prefix up to perDevice_{0}.mlir runs here.
+// RUN: %aiecc --get-aiesim --xchesscc --xbridge --tmpdir=%t/cut.prj --cut='perDevice_{0}.mlir' --checkpoint=%t/cut.ckpt %s
 
 // The captured frontier is textual MLIR, not a binary artifact.
-// RUN: cat %t/cut.ckpt/*/flows_physical.mlir | FileCheck --check-prefix=IR %s
+// RUN: cat %t/cut.ckpt/*/*.mlir | FileCheck --check-prefix=IR %s
 // IR: aie.device
 
-// Resume rebuilds the graph from the checkpoint's argv, reloads the flows IR,
-// and completes the sim/ folder in %t/cut.prj.
+// Resume rebuilds the graph from the checkpoint's argv, reloads the per-device
+// IR, and completes the sim/ folder in %t/cut.prj.
 // RUN: %aiecc --resume=%t/cut.ckpt/manifest.json
 
 // The resumed descriptors match the straight-through reference bit for bit.
 // RUN: cmp %t/ref.prj/sim/reports/graph.xpe %t/cut.prj/sim/reports/graph.xpe
 // RUN: cmp %t/ref.prj/sim/arch/aieshim_solution.aiesol %t/cut.prj/sim/arch/aieshim_solution.aiesol
 // RUN: cmp %t/ref.prj/sim/config/scsim_config.json %t/cut.prj/sim/config/scsim_config.json
-// RUN: cmp %t/ref.prj/sim/flows_physical.json %t/cut.prj/sim/flows_physical.json
 
 module @checkpoint_resume_aiesim {
   aie.device(xcvc1902) {

--- a/test/aiecc/cpp_aiesim.mlir
+++ b/test/aiecc/cpp_aiesim.mlir
@@ -24,7 +24,6 @@
 // CHECK-DAG: graph.xpe
 // CHECK-DAG: aieshim_solution.aiesol
 // CHECK-DAG: scsim_config.json
-// CHECK-DAG: flows_physical.json
 // CHECK-DAG: -D__AIESIM__
 // CHECK-DAG: genwrapper_for_ps.cpp
 // CHECK-DAG: {{.*}}ps.so

--- a/test/create-flows/broadcast.mlir
+++ b/test/create-flows/broadcast.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/find_flows_packet_mask.mlir
+++ b/test/create-flows/find_flows_packet_mask.mlir
@@ -1,0 +1,45 @@
+//===- find_flows_packet_mask.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A packet rule states a (mask, id) pair, and a lifted flow carries that pair.
+//
+// The rules a routed design holds are the only record of which ids reach a
+// port, because a core may build a packet header at run time. Recovering the
+// id alone would narrow the first flow from 0x8..0xb down to 0x8, so routing
+// the recovered design would drop the other three ids.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | FileCheck %s --check-prefix=LIFTED
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// The first flow states the rule it came from. The second matches one id, and
+// an id states that on its own, so it carries no mask.
+// LIFTED-DAG: aie.packet_flow(8 mask 28)
+// LIFTED-DAG: aie.packet_flow(0)
+
+// Routing the recovered design rebuilds the same two rules.
+// ROUTED: aie.switchbox(%{{.*}}tile_0_2)
+// ROUTED:   aie.packet_rules(DMA : 0)
+// ROUTED-DAG:     aie.rule(28, 8, %{{.*}})
+// ROUTED-DAG:     aie.rule(31, 0, %{{.*}})
+
+module {
+  aie.device(npu1_1col) {
+    %t00 = aie.tile(0, 0)
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+
+    aie.packet_flow(8 mask 28) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t00, DMA : 0>
+    }
+
+    aie.packet_flow(0) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+  }
+}

--- a/test/create-flows/find_flows_packet_merge.mlir
+++ b/test/create-flows/find_flows_packet_merge.mlir
@@ -1,0 +1,52 @@
+//===- find_flows_packet_merge.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Routing gives one rule to several ids that travel together, and narrow rules
+// where they part. Ids 9 and 10 share a route up column 0 and separate at
+// tile(0,4), so the switchboxes below it carry the enclosing cube of the pair,
+// (mask 0x1c, id 0x8).
+//
+// A recovered flow matching one id must therefore carry no mask: stating the
+// full-width mask would make each flow claim its own rule, and the shared
+// switchboxes would need two rules where routing used one.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | FileCheck %s --check-prefix=LIFTED
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// LIFTED-DAG: aie.packet_flow(9)
+// LIFTED-DAG: aie.packet_flow(10)
+// LIFTED-NOT: mask
+
+// The rules come back as routing first wrote them: merged below the split,
+// narrow above it.
+// ROUTED: aie.switchbox(%{{.*}}tile_0_2)
+// ROUTED:   aie.rule(28, 8, %{{.*}})
+// ROUTED: aie.switchbox(%{{.*}}tile_0_4)
+// ROUTED-DAG:   aie.rule(31, 9, %{{.*}})
+// ROUTED-DAG:   aie.rule(31, 10, %{{.*}})
+// ROUTED: aie.switchbox(%{{.*}}tile_0_5)
+// ROUTED:   aie.rule(31, 10, %{{.*}})
+// ROUTED: aie.switchbox(%{{.*}}tile_0_3)
+// ROUTED:   aie.rule(28, 8, %{{.*}})
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    %t04 = aie.tile(0, 4)
+    %t05 = aie.tile(0, 5)
+
+    aie.packet_flow(9) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t04, DMA : 0>
+    }
+
+    aie.packet_flow(10) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t05, DMA : 0>
+    }
+  }
+}

--- a/test/create-flows/find_flows_remove_lifted.mlir
+++ b/test/create-flows/find_flows_remove_lifted.mlir
@@ -1,0 +1,37 @@
+//===- find_flows_remove_lifted.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// By default --aie-find-flows removes the interconnect configuration it lifts
+// into flows, so its output is a purely logical, re-routable design.  With
+// remove-lifted=false the switchboxes are kept alongside the recovered flows.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | FileCheck %s --check-prefix=LIFTED --implicit-check-not=aie.switchbox
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows=remove-lifted=false | FileCheck %s --check-prefix=KEPT
+// RUN: aie-opt --aie-create-pathfinder-flows %s | aie-opt --aie-find-flows | aie-opt --aie-create-pathfinder-flows | FileCheck %s --check-prefix=ROUTED
+
+// Lifted: the flow is recovered and every switchbox/wire is gone.
+// LIFTED: %[[T02:.*]] = aie.tile(0, 2)
+// LIFTED: %[[T03:.*]] = aie.tile(0, 3)
+// LIFTED: aie.flow(%[[T02]], DMA : 0, %[[T03]], DMA : 0)
+
+// Kept: switchboxes remain when removal is disabled.
+// KEPT: aie.switchbox
+
+// Round-trippable: re-routing the lifted flow reproduces the switchbox config.
+// ROUTED: %[[R02:.*]] = aie.tile(0, 2)
+// ROUTED: %[[R03:.*]] = aie.tile(0, 3)
+// ROUTED: aie.switchbox(%[[R02]]) {
+// ROUTED:   aie.connect<DMA : 0, North : {{[0-9]+}}>
+// ROUTED: aie.switchbox(%[[R03]]) {
+// ROUTED:   aie.connect<South : {{[0-9]+}}, DMA : 0>
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    aie.flow(%t02, DMA : 0, %t03, DMA : 0)
+  }
+}

--- a/test/create-flows/find_partial_flows.mlir
+++ b/test/create-flows/find_partial_flows.mlir
@@ -1,0 +1,80 @@
+//===- find_partial_flows.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// --aie-find-flows lifts every configured connection into a flow, including
+// partial flows whose source or destination is a directional switchbox port
+// rather than a core or DMA (array edges, off-fabric consumers, PLIO/edge
+// entries, or packet routes a running design steers by packet id).  With
+// keep-partial-flows=false only flows that begin and end on a core/DMA are
+// recovered.
+
+// RUN: aie-opt --aie-find-flows --split-input-file %s | FileCheck %s
+// RUN: aie-opt --aie-find-flows=keep-partial-flows=false --split-input-file %s | FileCheck %s --check-prefix=NONE
+
+// A circuit-switched connection driven out an edge port (North:0 has no wire).
+// NONE-NOT: aie.flow
+// CHECK-LABEL: aie.device
+// CHECK: %[[T02:.*]] = aie.tile(0, 2)
+// CHECK: aie.flow(%[[T02]], DMA : 0, %[[T02]], North : 0)
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %sb02 = aie.switchbox(%t02) {
+      aie.connect<DMA : 0, North : 0>
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+  }
+}
+
+// -----
+
+// Time-multiplexed packet routing: one source fans out to different edge ports
+// by packet id.  Each id recovers a partial packet flow to its output port.
+// NONE-NOT: aie.packet_flow
+// CHECK-LABEL: aie.device
+// CHECK: %[[T12:.*]] = aie.tile(0, 2)
+// CHECK: aie.packet_flow(0)
+// CHECK:   aie.packet_source<%[[T12]], DMA : 0>
+// CHECK:   aie.packet_dest<%[[T12]], North : 0>
+// CHECK: aie.packet_flow(1)
+// CHECK:   aie.packet_source<%[[T12]], DMA : 0>
+// CHECK:   aie.packet_dest<%[[T12]], East : 0>
+module {
+  aie.device(xcvc1902) {
+    %t02 = aie.tile(0, 2)
+    %sb02 = aie.switchbox(%t02) {
+      %a0 = aie.amsel<0> (0)
+      %a1 = aie.amsel<0> (1)
+      aie.masterset(North : 0, %a0)
+      aie.masterset(East : 0, %a1)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %a0)
+        aie.rule(31, 1, %a1)
+      }
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+  }
+}
+
+// -----
+
+// Pure transit: a switchbox forwards West:0 -> East:0 with neither endpoint on
+// a core or DMA.  The source side seeds from the (undriven) West:0 input and
+// the destination side from the (unwired) East:0 output, lifting the whole
+// segment into one partial flow so the switchbox can be dropped.
+// NONE-NOT: aie.flow
+// CHECK-LABEL: aie.device
+// CHECK: %[[T22:.*]] = aie.tile(2, 2)
+// CHECK: aie.flow(%[[T22]], West : 0, %[[T22]], East : 0)
+module {
+  aie.device(xcvc1902) {
+    %t22 = aie.tile(2, 2)
+    %sb22 = aie.switchbox(%t22) {
+      aie.connect<West : 0, East : 0>
+    }
+  }
+}

--- a/test/create-flows/fixed_connection_broadcast.mlir
+++ b/test/create-flows/fixed_connection_broadcast.mlir
@@ -1,0 +1,54 @@
+//===- fixed_connection_broadcast.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test for ingesting a pre-lowered broadcast switchbox alongside a
+// freshly added flow.  addFixedConnection() must accept a broadcast -- one
+// source port fanning out to several destination ports -- rather than rejecting
+// the sibling connects.
+//
+// Setup
+// -----
+//   tile(2,2) already contains a lowered broadcast: source North:0 drives both
+//   South:0 and East:0.  (This is what --aie-create-pathfinder-flows emits for
+//   several aie.flows sharing one source.)
+//
+//   An independent flow tile(2,3) DMA:0 -> tile(2,1) DMA:1 is added at the
+//   physical level, without lifting the switchbox back to flows.
+//
+// Before the fix addFixedConnection() invalidated the whole North:0 source row
+// when it recorded the first fan-out connect, so the second (North:0 -> East:0)
+// failed its AVAILABLE check and the pass aborted with
+// "Unable to add fixed connections".  The broadcast is now ingested and the new
+// flow routes around the reserved ports.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// CHECK: %[[T22:.*]] = aie.tile(2, 2)
+
+// The broadcast is preserved intact: both fan-out connects survive.
+// CHECK:      aie.switchbox(%[[T22]]) {
+// CHECK-DAG:    aie.connect<North : 0, South : 0>
+// CHECK-DAG:    aie.connect<North : 0, East : 0>
+// CHECK:      }
+
+module {
+  aie.device(xcvc1902) {
+    %t21 = aie.tile(2, 1)
+    %t22 = aie.tile(2, 2)
+    %t23 = aie.tile(2, 3)
+    %t32 = aie.tile(3, 2)
+
+    // Pre-lowered broadcast at tile(2,2): North:0 -> {South:0, East:0}.
+    %sb22 = aie.switchbox(%t22) {
+      aie.connect<North : 0, South : 0>
+      aie.connect<North : 0, East : 0>
+    }
+
+    // New flow added alongside the fixed broadcast switchbox.
+    aie.flow(%t23, DMA : 0, %t21, DMA : 1)
+  }
+}

--- a/test/create-flows/fixed_connection_egress_conflict.mlir
+++ b/test/create-flows/fixed_connection_egress_conflict.mlir
@@ -1,0 +1,57 @@
+//===- fixed_connection_egress_conflict.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test for the egress side of addFixedConnection(): a circuit
+// ConnectOp monopolizes its destination (output) port, not just its source
+// port.  addFixedConnection() must mark all connectivity[*][dst] cells INVALID
+// so the pathfinder cannot drive a second stream onto an occupied output.
+//
+// Setup
+// -----
+//   tile(2,2) has a pre-existing circuit connection: North:1 -> South:0.
+//   This occupies output port South:0 (and the wire to tile(2,1)).
+//
+//   A flow is requested from tile(2,3) DMA:0 to tile(2,1) DMA:0.  The
+//   straight-line path goes down column 2 through tile(2,2), entering from the
+//   North and exiting to the South.
+//
+// Without the egress reservation the pathfinder is free to route the flow
+// through tile(2,2) as North:0 -> South:0, colliding with the pre-existing
+// ConnectOp on output South:0; the verifier then rejects the switchbox
+// ("different destinations") and aie-opt exits non-zero.
+//
+// With the egress reservation output South:0 is unavailable, so the flow exits
+// tile(2,2) on a different south channel and the pre-existing connect is
+// preserved untouched.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// CHECK: %[[T22:.*]] = aie.tile(2, 2)
+
+// tile(2,2) keeps its original output connection and gains no second connect
+// driving South:0.
+// CHECK:      aie.switchbox(%[[T22]]) {
+// CHECK:        aie.connect<North : 1, South : 0>
+// CHECK-NOT:    South : 0>
+// CHECK:      }
+
+module {
+  aie.device(xcvc1902) {
+    %tile_2_1 = aie.tile(2, 1)
+    %tile_2_2 = aie.tile(2, 2)
+    %tile_2_3 = aie.tile(2, 3)
+
+    // Fixed circuit connection at tile(2,2): occupies output port South:0.
+    %switchbox_2_2 = aie.switchbox(%tile_2_2) {
+      aie.connect<North : 1, South : 0>
+    }
+
+    // Straight-line flow down column 2 through tile(2,2).  Must not reuse the
+    // occupied South:0 output port.
+    aie.flow(%tile_2_3, DMA : 0, %tile_2_1, DMA : 0)
+  }
+}

--- a/test/create-flows/flow_test_1.mlir
+++ b/test/create-flows/flow_test_1.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/flow_test_2.mlir
+++ b/test/create-flows/flow_test_2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/flow_test_3.mlir
+++ b/test/create-flows/flow_test_3.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/many_flows.mlir
+++ b/test/create-flows/many_flows.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/many_flows2.mlir
+++ b/test/create-flows/many_flows2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/memtile.mlir
+++ b/test/create-flows/memtile.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/memtile_routing_constraints.mlir
+++ b/test/create-flows/memtile_routing_constraints.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/mmult.mlir
+++ b/test/create-flows/mmult.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/over_flows.mlir
+++ b/test/create-flows/over_flows.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/routed_herd_3x1.mlir
+++ b/test/create-flows/routed_herd_3x1.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/routed_herd_3x2.mlir
+++ b/test/create-flows/routed_herd_3x2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple.mlir
+++ b/test/create-flows/simple.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple2.mlir
+++ b/test/create-flows/simple2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple_flows.mlir
+++ b/test/create-flows/simple_flows.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/simple_flows2.mlir
+++ b/test/create-flows/simple_flows2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-flows/vecmul_4x4_slow_test.mlir
+++ b/test/create-flows/vecmul_4x4_slow_test.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-packet-flows/aie2_memtile_connection.mlir
+++ b/test/create-packet-flows/aie2_memtile_connection.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-packet-flows/packet_flow_mask.mlir
+++ b/test/create-packet-flows/packet_flow_mask.mlir
@@ -1,0 +1,48 @@
+//===- packet_flow_mask.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A packet flow states the rule it wants with `mask`, and routing keeps that
+// rule instead of deriving one from the ids.
+//
+// A core may build a packet header at run time, so a design can send ids that
+// appear nowhere in the IR. Here one flow claims 0x8 through 0xb by masking off
+// the low two bits, and routing must leave that claim to it: the rules the
+// other two flows get may not match any id in that range.
+
+// RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
+
+// The stated rule reaches the slave port unchanged.
+// CHECK: aie.switchbox(%{{.*}}tile_0_2)
+// CHECK:   aie.packet_rules(DMA : 0)
+// CHECK-DAG:     aie.rule(28, 8, %{{.*}})
+// The derived rules match one id each, so none of them reaches into 0x8..0xb.
+// CHECK-DAG:     aie.rule(31, 0, %{{.*}})
+// CHECK-DAG:     aie.rule(31, 15, %{{.*}})
+
+module {
+  aie.device(npu1_1col) {
+    %t00 = aie.tile(0, 0)
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+
+    // Claims every id that agrees with 0x8 on the bits 0x1c selects.
+    aie.packet_flow(8 mask 28) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t00, DMA : 0>
+    }
+
+    aie.packet_flow(0) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+
+    aie.packet_flow(15) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+  }
+}

--- a/test/create-packet-flows/packet_flow_mask_conflict.mlir
+++ b/test/create-packet-flows/packet_flow_mask_conflict.mlir
@@ -1,0 +1,35 @@
+//===- packet_flow_mask_conflict.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Two claims on one slave port that share an id.
+//
+// The first flow claims 0x8 through 0xb. The second carries 0x9, which sits
+// inside that range, so the port would need two routes for one id. Routing
+// reports the pair rather than handing the id to whichever rule the arbiter
+// checks first.
+
+// RUN: not aie-opt --aie-create-pathfinder-flows %s 2>&1 | FileCheck %s
+
+// CHECK: error: packet flows through DMA0 claim rule (mask 0x1F, id 0x9) and rule (mask 0x1C, id 0x8), which both match id 0x9
+
+module {
+  aie.device(npu1_1col) {
+    %t00 = aie.tile(0, 0)
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+
+    aie.packet_flow(8 mask 28) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t00, DMA : 0>
+    }
+
+    aie.packet_flow(9) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t03, DMA : 0>
+    }
+  }
+}

--- a/test/create-packet-flows/packet_routing_keep_pkt_header.mlir
+++ b/test/create-packet-flows/packet_routing_keep_pkt_header.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
@@ -14,11 +14,9 @@
 // CHECK1:    %[[VAL_2:.*]] = aie.tile(0, 3)
 // CHECK1:    %[[VAL_3:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[VAL_4:.*]] = aie.tile(0, 5)
-// The flows below are the ones --aie-find-flows recovers from the routing, in
-// the order it walks the tiles and their packet rules; the flows this file
-// declares up front are replaced by them rather than kept alongside. Both
-// flows out of tile (0, 2) share a source port, so their relative order comes
-// from the routed switchbox rather than from this file.
+// The pathfinder now removes the lowered packet flows; --aie-find-flows
+// re-derives them from the switchbox routing, emitting the two fan-out
+// destinations of tile(0,2) DMA:0 in discovery order (flow 4 before flow 0).
 // CHECK1:    aie.packet_flow(4) {
 // CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 4>

--- a/test/create-packet-flows/test_congestion1.mlir
+++ b/test/create-packet-flows/test_congestion1.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
+// RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows=remove-lifted=false %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
@@ -16,9 +16,8 @@
 // CHECK1:    %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK1:    %[[TILE_1_0:.*]] = aie.tile(1, 0)
-// The flows below are the ones --aie-find-flows recovers from the routing, in
-// the order it walks the tiles; the flows this file declares up front are
-// replaced by them rather than kept alongside.
+// The pathfinder now removes the lowered flows; --aie-find-flows re-derives
+// them from the switchbox routing, emitting circuit flows before packet flows.
 // CHECK1:    aie.flow(%[[TILE_0_1]], DMA : 0, %[[TILE_0_0]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_2]], DMA : 0, %[[TILE_0_1]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_3]], DMA : 0, %[[TILE_0_1]], DMA : 1)

--- a/test/create-packet-flows/test_create_packet_flows7.mlir
+++ b/test/create-packet-flows/test_create_packet_flows7.mlir
@@ -28,10 +28,9 @@
 // CHECK:            aie.rule(31, 1, %[[VAL1]])
 // CHECK:          }
 // CHECK:        }
-// CHECK:        aie.packet_flow(1) {
-// CHECK:          aie.packet_source<%[[TILE_1_2]], Trace : 0>
-// CHECK:          aie.packet_dest<%[[TILE_0_0]], DMA : 1>
-// CHECK:        } {keep_pkt_header = true}
+// The pathfinder removes the packet_flow op once it has been lowered into
+// switchbox masterset/packet_rules, so it must not reappear in the output.
+// CHECK-NOT:     aie.packet_flow
 // CHECK:        %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:        %{{.*}} = aie.switchbox(%[[TILE_1_0]]) {
 // CHECK:          %[[VAL2:.*]] = aie.amsel<0> (0)

--- a/test/dialect/AIE/duplicate_flow.mlir
+++ b/test/dialect/AIE/duplicate_flow.mlir
@@ -58,7 +58,7 @@ module @flow_dup_logical {
 // -----
 
 // The same packet flow declared twice, as reported in issue #3706.
-// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 0 is already declared between the same sources and destinations
+// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 0 under mask 0x1F is already declared between the same sources and destinations
 // CHECK: note:{{.*}}the other packet flow is here
 module @packet_flow_dup {
   aie.device(npu2) {
@@ -81,7 +81,7 @@ module @packet_flow_dup {
 // same endpoints in a different order is still the same flow. Disagreeing
 // keep_pkt_header attributes make the redeclaration contradictory, not merely
 // redundant, so the attributes are deliberately not part of the key.
-// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 3 is already declared between the same sources and destinations
+// CHECK: error{{.*}}'aie.packet_flow' op duplicates an earlier packet flow; ID 3 under mask 0x1F is already declared between the same sources and destinations
 module @packet_flow_dup_reordered {
   aie.device(npu2) {
     %shim = aie.tile(2, 0)
@@ -158,6 +158,27 @@ module @packet_flow_no_false_positives {
     aie.packet_flow(0) {
       aie.packet_source<%u0, DMA : 0>
       aie.packet_dest<%u1, DMA : 0>
+    }
+  }
+}
+
+// -----
+
+// Two flows carrying one ID between one pair of endpoints under different
+// masks claim different sets of packets, so neither duplicates the other.
+// The first claims 0x0 through 0x3, the second 0x0 alone.
+// CHECK-LABEL: @packet_flow_distinct_masks
+module @packet_flow_distinct_masks {
+  aie.device(npu2) {
+    %shim = aie.tile(2, 0)
+    %core = aie.tile(2, 2)
+    aie.packet_flow(0 mask 28) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
+    }
+    aie.packet_flow(0) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
     }
   }
 }

--- a/test/dialect/AIE/packet_flow_mask_bad_id.mlir
+++ b/test/dialect/AIE/packet_flow_mask_bad_id.mlir
@@ -1,0 +1,23 @@
+//===- packet_flow_mask_bad_id.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A slave port accepts a packet when `incoming & mask == ID`. ID 0x3 sets a bit
+// the mask 0x1 clears, so the test never holds and the flow carries nothing.
+
+// RUN: not aie-opt %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'aie.packet_flow' op has ID 0x3 outside mask 0x1, which no packet can match
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    aie.packet_flow(3 mask 1) {
+      aie.packet_source<%t02, DMA : 0>
+      aie.packet_dest<%t02, DMA : 0>
+    }
+  }
+}

--- a/test/find-flows/id_check.mlir
+++ b/test/find-flows/id_check.mlir
@@ -9,7 +9,7 @@
 // RUN: aie-opt -aie-find-flows %s | FileCheck %s
 // CHECK: %[[T23:.*]] = aie.tile(2, 3)
 // CHECK: %[[T22:.*]] = aie.tile(2, 2)
-// CHECK: aie.packet_flow(15) {
+// CHECK: aie.packet_flow(15 mask 15) {
 // CHECK:   aie.packet_source<%[[T22]], DMA : 0>
 // CHECK:   aie.packet_dest<%[[T23]], DMA : 1>
 // CHECK: }

--- a/test/find-flows/id_check2.mlir
+++ b/test/find-flows/id_check2.mlir
@@ -9,7 +9,7 @@
 // RUN: aie-opt -aie-find-flows %s | FileCheck %s
 // CHECK: %[[T23:.*]] = aie.tile(2, 3)
 // CHECK: %[[T22:.*]] = aie.tile(2, 2)
-// CHECK: aie.packet_flow(13) {
+// CHECK: aie.packet_flow(13 mask 15) {
 // CHECK:   aie.packet_source<%[[T22]], DMA : 0>
 // CHECK:   aie.packet_dest<%[[T23]], DMA : 1>
 // CHECK: }

--- a/test/find-flows/packet_mask_hops.mlir
+++ b/test/find-flows/packet_mask_hops.mlir
@@ -1,0 +1,77 @@
+//===- packet_mask_hops.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The rules along one path may state different masks. Each hop narrows the set
+// of ids that reach the end, so a lifted flow claims what every hop on its path
+// accepts.
+
+// RUN: aie-opt --aie-find-flows --split-input-file %s | FileCheck %s
+
+// The first hop accepts 0x8 through 0xb and the second only 0x9, so the path
+// carries 0x9. A full-width mask selects one id, which the id states alone.
+// CHECK: aie.packet_flow(9)
+// CHECK-NOT: mask
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    %sb02 = aie.switchbox(%t02) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(North : 0, %a)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(28, 8, %a)
+      }
+    }
+    %sb03 = aie.switchbox(%t03) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(DMA : 0, %a)
+      aie.packet_rules(South : 0) {
+        aie.rule(31, 9, %a)
+      }
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+    aie.wire(%sb02 : North, %sb03 : South)
+    aie.wire(%t03 : DMA, %sb03 : DMA)
+  }
+}
+
+// -----
+
+// The two hops accept disjoint sets, so nothing reaches the end. The pass
+// recovers no flow and leaves both switchboxes in place, rather than lifting a
+// route that carries nothing.
+
+// CHECK-NOT: aie.packet_flow
+// CHECK: aie.switchbox
+// CHECK:   aie.rule(28, 8
+// CHECK: aie.switchbox
+// CHECK:   aie.rule(31, 4
+
+module {
+  aie.device(npu1_1col) {
+    %t02 = aie.tile(0, 2)
+    %t03 = aie.tile(0, 3)
+    %sb02 = aie.switchbox(%t02) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(North : 0, %a)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(28, 8, %a)
+      }
+    }
+    %sb03 = aie.switchbox(%t03) {
+      %a = aie.amsel<0> (0)
+      %m = aie.masterset(DMA : 0, %a)
+      aie.packet_rules(South : 0) {
+        aie.rule(31, 4, %a)
+      }
+    }
+    aie.wire(%t02 : DMA, %sb02 : DMA)
+    aie.wire(%sb02 : North, %sb03 : South)
+    aie.wire(%t03 : DMA, %sb03 : DMA)
+  }
+}

--- a/test/find-flows/shim.mlir
+++ b/test/find-flows/shim.mlir
@@ -11,7 +11,8 @@
 // CHECK:           %[[VAL_0:.*]] = aie.tile(2, 1)
 // CHECK:           %[[VAL_1:.*]] = aie.tile(2, 0)
 // CHECK:           %[[VAL_6:.*]] = aie.shim_dma(%[[VAL_1]])
-// CHECK:           aie.flow(%[[VAL_0]], Core : 0, %[[VAL_6]], DMA : 0)
+// aie.flow names tiles, so the shim DMA endpoint resolves to its tile.
+// CHECK:           aie.flow(%[[VAL_0]], Core : 0, %[[VAL_1]], DMA : 0)
 module {
   aie.device(xcvc1902) {
     %t21 = aie.tile(2, 1)
@@ -42,30 +43,20 @@ module {
 
 // -----
 
+// The route is now carried by the flow, so remove-lifted (on by default) drops
+// the switchboxes, the shim-mux and the wires it lifted.
 // CHECK:  %{{.*}}tile_2_1 = aie.tile(2, 1)
 // CHECK:  %{{.*}}tile_2_0 = aie.tile(2, 0)
 // CHECK:  %core_2_1 = aie.core(%tile_2_1) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  %switchbox_2_1 = aie.switchbox(%{{.*}}tile_2_1) {
-// CHECK:    aie.connect<Core : 0, South : 0>
-// CHECK:  }
-// CHECK:  %switchbox_2_0 = aie.switchbox(%{{.*}}tile_2_0) {
-// CHECK:    aie.connect<North : 0, South : 2>
-// CHECK:  }
-// CHECK:  %shim_mux_2_0 = aie.shim_mux(%{{.*}}tile_2_0) {
-// CHECK:    aie.connect<North : 2, DMA : 0>
-// CHECK:  }
 // CHECK:  %shim_dma_2_0 = aie.shim_dma(%{{.*}}tile_2_0) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  aie.wire(%switchbox_2_1 : South, %switchbox_2_0 : North)
-// CHECK:  aie.wire(%switchbox_2_0 : South, %shim_mux_2_0 : North)
-// CHECK:  aie.wire(%shim_mux_2_0 : DMA, %shim_dma_2_0 : DMA)
-// CHECK:  aie.wire(%shim_mux_2_0 : South, %{{.*}}tile_2_0 : DMA)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %core_2_1 : Core)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %{{.*}}tile_2_1 : Core)
-// CHECK:  aie.flow(%{{.*}}tile_2_1, Core : 0, %shim_dma_2_0, DMA : 0)
+// CHECK:  aie.flow(%{{.*}}tile_2_1, Core : 0, %{{.*}}tile_2_0, DMA : 0)
+// CHECK-NOT: aie.switchbox
+// CHECK-NOT: aie.shim_mux
+// CHECK-NOT: aie.wire
 
 module {
   aie.device(xcvc1902) {

--- a/tools/aie-routing-command-line/mlir2json.sh
+++ b/tools/aie-routing-command-line/mlir2json.sh
@@ -2,4 +2,9 @@
 # Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-aie-opt --aie-create-pathfinder-flows --aie-find-flows $1 | aie-translate --aie-flows-to-json > $2.json
+# aie-translate traces each flow through the switchbox that configures it, so
+# --aie-find-flows has to keep the interconnect configuration it recovers from.
+# It also expects every flow to start on a core or DMA.
+aie-opt --aie-create-pathfinder-flows \
+        --aie-find-flows='keep-partial-flows=false remove-lifted=false' $1 \
+  | aie-translate --aie-flows-to-json > $2.json

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -389,8 +389,8 @@ buildHostExeSubgraph(EdgeWithTypedOutput<std::string> &aieInc,
 }
 
 // AIE-simulator work-folder subgraph. Emits the `sim/` folder the aiesimulator
-// consumes: the graph/shim/scsim descriptors, the routed flows, the ps.so
-// co-simulation model, the `.target` marker, and the `aiesim.sh` launcher.
+// consumes: the graph/shim/scsim descriptors, the ps.so co-simulation model,
+// the `.target` marker, and the `aiesim.sh` launcher.
 //
 // Each artifact is its own edge/Item. They are declared with work-dir-relative
 // names, so as intermediates they land in the `.prj` (aiesim.sh derives
@@ -406,7 +406,6 @@ buildAiesimSubgraph(mlir::MLIRContext &context,
                     EdgeWithTypedOutput<std::string> &aieInc) {
   std::string installDir = getInstallDir();
   std::string aietoolsRoot = discoverAietoolsDir(aietoolsDir.getValue());
-  const std::string &devFilter = deviceName.getValue();
 
   // graph.xpe / aieshim_solution.aiesol / scsim_config.json: in-process
   // translations of the per-device module.
@@ -438,27 +437,10 @@ buildAiesimSubgraph(mlir::MLIRContext &context,
                                                     d.getSymName());
       });
 
-  // Routed flows: run `aie-find-flows` to annotate the module, emit it as
-  // flows_physical.mlir, then serialize the flows to JSON.
-  auto findFlowsPM = std::make_unique<mlir::PassManager>(&context);
-  findFlowsPM->nest<DeviceOp>().addPass(xilinx::AIE::createAIEFindFlowsPass());
-  auto &flows = staticPerDevice.map<ModRef>(
-      "sim/flows_physical.mlir", PassPipeline{std::move(findFlowsPM)});
-  auto &flowsJson = flows.map<std::string>(
-      "sim/flows_physical.json",
-      [devFilter](const Item<ModRef> &item,
-                  Item<std::string> &out) -> mlir::LogicalResult {
-        mlir::ModuleOp mod = item.get().get();
-        std::string devName = devFilter;
-        if (devName.empty()) {
-          for (auto d : mod.getOps<DeviceOp>()) {
-            devName = d.getSymName().str();
-            break;
-          }
-        }
-        llvm::raw_string_ostream os(out.value.emplace());
-        return xilinx::AIE::AIEFlowsToJSON(mod, os, devName);
-      });
+  // The routing description `aie-translate --aie-flows-to-json` produces
+  // belongs to the route visualizer, not to aiesimulator, which reads only the
+  // graph/shim/scsim descriptors and ps.so. Run
+  // tools/aie-routing-command-line/mlir2json.sh to obtain it.
 
   // ps.so: the SystemC co-simulation model. clang++ links the toolchain's
   // `genwrapper_for_ps.cpp` (which #includes aie_inc.cpp from the work dir)
@@ -582,26 +564,24 @@ aiesimulator --pkg-dir=${prj_name}/sim --dump-vcd ${vcd_filename}
   // materializes them -- via asFile(), the Item abstraction's "I need this on
   // disk" request -- into the `.prj`. Produces no file of its own.
   auto &aiesim =
-      bundle(xpe.out, shim.out, scsim.out, flows.out, flowsJson.out, ps.out,
-             target.out, script.out)
-          .join<File>(
-              "aiesim.stamp",
-              [](const Node<std::string> &xpe, const Node<std::string> &shim,
-                 const Node<std::string> &scsim, const Node<ModRef> &flows,
-                 const Node<std::string> &flowsJson, const Node<File> &ps,
-                 const Node<std::string> &target,
-                 const Node<std::string> &script,
-                 Item<File> &out) -> mlir::LogicalResult {
-                const NodeBase *nodes[] = {&xpe,       &shim, &scsim,  &flows,
-                                           &flowsJson, &ps,   &target, &script};
-                for (const NodeBase *n : nodes) {
-                  for (const ItemBase *it : n->itemRefs()) {
-                    (void)it->asFile();
-                  }
-                }
-                out.value = File{};
-                return mlir::success();
-              });
+      bundle(xpe.out, shim.out, scsim.out, ps.out, target.out, script.out)
+          .join<File>("aiesim.stamp",
+                      [](const Node<std::string> &xpe,
+                         const Node<std::string> &shim,
+                         const Node<std::string> &scsim, const Node<File> &ps,
+                         const Node<std::string> &target,
+                         const Node<std::string> &script,
+                         Item<File> &out) -> mlir::LogicalResult {
+                        const NodeBase *nodes[] = {&xpe, &shim,   &scsim,
+                                                   &ps,  &target, &script};
+                        for (const NodeBase *n : nodes) {
+                          for (const ItemBase *it : n->itemRefs()) {
+                            (void)it->asFile();
+                          }
+                        }
+                        out.value = File{};
+                        return mlir::success();
+                      });
   aiesim.producesFiles = false;
   return aiesim;
 }


### PR DESCRIPTION
More minimal change factored out from #3421

The following two limitations (related to idempotency of passes) make debugging routing problems hard, and this PR fixes both:
1. Routing cannot run on its own output.
2. You cannot pass the output of --aie-find-flows back into the router (no round-tripping).

## Issue 1:
--aie-create-pathfinder-flows leaves state behind on every run. For certain broadcast flows, the original `aie.flow` op survives into the routed IR (which should be only switchboxes and wires). runOnPacketFlow keeps the `aie.packet_flow` ops it lowers. A second run lowers them again and emits a duplicate masterset on a port the first run claimed. 

This is annoying for debugging or incremental development. Say you want to route a flow, then use the produced IR and add more flows to route. The router will try to re-route the original flows that have already been routed and this will cause collisions in switchboxes, wires, etc. It would also just be nice to be able to pass an already-routed IR into aiecc without errors for debugging, without having to instruct aiecc to skip the routing phase.

## Issue 2:
--aie-find-flows leaves the switchbox configuration behind for the flows it lifts. This leaves the IR representing the flow in two forms, once as an `aie.flow` and once as a set of switchbox configurations. When you go to re-lower the flow, the router rejects it, because it collides with the existing switchbox configurations. This makes debugging hard.

It also does not recover all flows. It seeds a traversal only from the Core and DMA ports of a tile. A stream that enters the fabric elsewhere yields no flow. This means no partial flows are recovered, even though this would be useful. 

## Solution:

--aie-create-pathfinder-flows now erases the original `aie.flow` for broadcast flows as well after lowering to switchboxes, so there is only one set of IR ops representing the flow. It marks aie.packet_flow illegal after lowering, ensuring they don't remain, and removes each op it lowers. It keys the wires already present and emits only the missing ones. --aie-generate-column-control-overlay reads the is_ctrl_pkt_overlay marker and skips a device that already carries an overlay.

--aie-find-flows records the interconnect ops that implement each hop. It seeds a traversal from every interconnect source port that no upstream connection drives, which recovers PLIO entries, transit connections and runtime-steered packet routes. It reports a driven output port without an onward wire as an endpoint. It then erases the connects, packet rules, mastersets, amsels and wires it lifted, and drops each interconnect left empty. 

Two options control the recovery. keep-partial-flows=false restricts it to flows that begin and end on a core or DMA. remove-lifted=false keeps the configuration the pass lifted, which is the earlier behavior. The existing tests pass remove-lifted=false and check the same output as before.

The `aie.packet_flow` also gets a new `mask` attribute. This is needed to recover packet flows that might claim multiple IDs. We don't know exactly which IDs they were meant for after lowering, so a proper recovery now just expresses the packet flow with the mask that the lowering chose.

## Summary

> **With the new default options, a route is now either an aie.flow or switchbox configs with aie.connect ops, never both at the same time in IR.**