### PR TITLE
Track transitive .td includes of TableGen outputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,11 @@ if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
 
+# LLVM's tablegen() macro emits a depfile only under CMP0116 NEW. The depfile
+# lists the transitive .td includes, so a generated file rebuilds whenever any
+# .td it includes changes.
 if(POLICY CMP0116)
-  cmake_policy(SET CMP0116 OLD)
+  cmake_policy(SET CMP0116 NEW)
 endif()
 
 if(POLICY CMP0144)


### PR DESCRIPTION
# In André's Words

I kept getting stale Python bindings (`_aie_ops_gen.py`) after making changes to the tablegen after rebuilding the compiler. Our CMake was not configured to properly track the dependencies, so Ninja didn't know to regenerate the bindings. This fixes that. 

# In Claude's Words

Set CMP0116 to NEW so LLVM's tablegen() macro passes -d and DEPFILE to add_custom_command. Ninja then reads the list of .td files that TableGen opened and rebuilds the output when any of them changes.

Under CMP0116 OLD the macro falls back to a glob of *.td in the top level of each include directory. That glob covers the dialect .td files for the .inc targets in include/aie/Dialect/**, because those live next to their own .td file. It covers nothing for the Python bindings: the include directories of python/CMakeLists.txt hold no .td file at their top level, so python/dialects/AIEBinding.td was the only dependency of _aie_ops_gen.py. Editing AIEOps.td left the bindings stale until the generated file was deleted by hand. _aiex_ops_gen.py and _aievec_ops_gen.py had the same gap.

The project sets CMP0116 OLD since commit 12eddf18f40 (January 2022), when CMake could not parse the depfiles LLVM generates. cmake_minimum_required now demands 3.30, and the macro itself refuses the depfile path below CMake 3.23, so the fallback no longer serves a purpose.

Verified with `ninja -t deps python/dialects/_aie_ops_gen.py`, which now lists AIEOps.td, AIEAttrs.td, AIETypes.td and the generated AIEEvents includes.