### PR TITLE
Add AI comment-slop check to pre-commit/CI

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -427,10 +427,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # HEAD in a merge_group carries commits from every PR ahead of this one in the
-    # queue, so the diff would compare comments across several independently
-    # reviewed PRs and could fail this one for wording introduced by another.
-    if: github.event_name != 'merge_group'
+    # Scoped to actual PR commits only. merge_group's HEAD carries commits from
+    # every PR ahead of this one in the queue, so the diff would compare comments
+    # across several independently reviewed PRs; schedule/workflow_dispatch run
+    # against main with no PR base, which would just diff main against itself.
+    if: github.event_name == 'pull_request'
 
     permissions:
       contents: read
@@ -454,9 +455,8 @@ jobs:
         # Scoped to the PR's actual target branch (not always main), so a PR onto a
         # release branch is diffed against that branch instead.
         env:
-          BASE_REF: ${{ github.base_ref || github.event.repository.default_branch }}
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |
-          BASE_BRANCH="${BASE_REF#refs/heads/}"
           git fetch --no-tags origin "$BASE_BRANCH"
           BASE=$(git merge-base "origin/$BASE_BRANCH" HEAD)
           pre-commit run comment-slop --from-ref "$BASE" --to-ref HEAD --show-diff-on-failure

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -421,6 +421,46 @@ jobs:
           level: error
           fail_level: any
 
+  comment-slop:
+
+    name: Check for AI comment slop
+
+    runs-on: ubuntu-latest
+
+    # HEAD in a merge_group carries commits from every PR ahead of this one in the
+    # queue, so the diff would compare comments across several independently
+    # reviewed PRs and could fail this one for wording introduced by another.
+    if: github.event_name != 'merge_group'
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Run the comment-slop unit tests
+        run: python utils/test_check_comment_slop.py -v
+
+      - name: Install pre-commit
+        run: python -m pip install --require-hashes -r python/requirements_dev.lock
+
+      - name: Check for AI comment slop in changed files
+        # Scoped to the PR's actual target branch (not always main), so a PR onto a
+        # release branch is diffed against that branch instead.
+        env:
+          BASE_REF: ${{ github.base_ref || github.event.repository.default_branch }}
+        run: |
+          BASE_BRANCH="${BASE_REF#refs/heads/}"
+          git fetch --no-tags origin "$BASE_BRANCH"
+          BASE=$(git merge-base "origin/$BASE_BRANCH" HEAD)
+          pre-commit run comment-slop --from-ref "$BASE" --to-ref HEAD --show-diff-on-failure
+
   license-compliance:
     name: License Compliance Check
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -275,3 +275,14 @@ repos:
         )$
       pass_filenames: true
       stages: [pre-push]
+
+    # Flags AI comment slop: the same concept re-explained at 3+ sites, oversized
+    # comment blocks, and high comment density. Reads the diff, not whole files, so
+    # it never complains about a comment the contributor did not write.
+    - id: comment-slop
+      name: Check for AI comment slop (repeated explanations, oversized blocks)
+      language: python
+      entry: python utils/check_comment_slop.py
+      pass_filenames: false
+      require_serial: true
+      types_or: [c, c++, python]

--- a/utils/check_comment_slop.py
+++ b/utils/check_comment_slop.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Flag comment slop in a diff: repeated explanations, oversized blocks, density.
+
+Runs as a pre-commit hook (staged diff) or in CI (base..head). It reads a diff
+rather than whole files, so it never complains about comments a contributor did
+not write.
+
+It flags; it never rewrites. Choosing which of several duplicate explanations to
+keep needs judgement about where a confused reader lands, and that is not
+mechanisable.
+
+Usage:
+    python utils/check_comment_slop.py                    # staged diff (pre-commit)
+    python utils/check_comment_slop.py --from-ref origin/main --to-ref HEAD
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# A concept re-explained at N sites is the dominant failure: the model restates it at
+# every site it touches, having no memory of the last one. Those restatements are
+# reworded, not copy-pasted, so prose similarity misses them -- what they share is
+# distinctive vocabulary.
+SHARED_TERMS_THRESHOLD = 4
+MIN_TERM_LEN = 5
+MAX_BLOCK_LINES = 12
+DENSITY_WARN_PCT = 20
+
+# Stating a contract at the declaration and the reason at the implementation is the
+# idiomatic pair, not slop. Three sites is where a concept starts being re-explained.
+MIN_SITES = 3
+
+# A comment that points at the canonical explanation is a cross-reference, not a
+# repeat of it -- which is exactly the shape a cut should leave behind.
+POINTER_RE = re.compile(r"\bsee\s+\S", re.IGNORECASE)
+
+# A test comment naming the invariant under test is the spec, even when the source
+# explains the same mechanism.
+TEST_PATH_RE = re.compile(r"(^|/)tests?(/|_|\.)|(^|/)testing(/|_)|_tests?\.|(^|/)test_")
+
+STOPWORDS = {
+    "about",
+    "after",
+    "again",
+    "against",
+    "already",
+    "always",
+    "another",
+    "because",
+    "before",
+    "being",
+    "below",
+    "between",
+    "cannot",
+    "could",
+    "doing",
+    "during",
+    "either",
+    "every",
+    "first",
+    "found",
+    "from",
+    "given",
+    "hence",
+    "however",
+    "instead",
+    "into",
+    "itself",
+    "later",
+    "least",
+    "leave",
+    "makes",
+    "might",
+    "must",
+    "never",
+    "other",
+    "rather",
+    "same",
+    "should",
+    "since",
+    "still",
+    "such",
+    "than",
+    "that",
+    "their",
+    "them",
+    "then",
+    "there",
+    "these",
+    "they",
+    "this",
+    "those",
+    "through",
+    "under",
+    "until",
+    "using",
+    "value",
+    "when",
+    "where",
+    "which",
+    "while",
+    "with",
+    "would",
+    "your",
+}
+
+# In C and C++ a leading `#` opens a preprocessor directive, not a comment, and a
+# leading `*` is a block-comment continuation only when nothing follows it -- `*ptr`
+# is a dereference. Classifying either as a comment counts an ordinary include block
+# as prose, which is how an alphabetised #include added to three files gets reported
+# as a repeated explanation.
+COMMENT_RE_PY = re.compile(r"^\s*#")
+COMMENT_RE_CISH = re.compile(r"^\s*(//|/\*|\*/|\*(?=\s|$))")
+SOURCE_SUFFIXES = (
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".py",
+    ".pyi",
+)
+
+
+def is_comment_line(path, text):
+    pattern = COMMENT_RE_PY if path.endswith((".py", ".pyi")) else COMMENT_RE_CISH
+    return bool(pattern.match(text))
+
+
+@dataclass
+class Block:
+    path: str
+    line: int
+    lines: list = field(default_factory=list)
+
+    @property
+    def text(self):
+        return " ".join(self.lines)
+
+    @property
+    def terms(self):
+        """Distinctive vocabulary. Identifiers are split (has_enforce_eager,
+        --enforce-eager and VLLMServer::load all contribute their parts) so the same
+        concept is recognised however it is spelled at each site."""
+        parts = re.split(r"[^A-Za-z]+", self.text)
+        words = []
+        for part in parts:
+            words += re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])", part)
+        return {
+            w.lower()
+            for w in words
+            if len(w) >= MIN_TERM_LEN and w.lower() not in STOPWORDS
+        }
+
+
+class GitError(RuntimeError):
+    pass
+
+
+def run(cmd, allow_missing=False):
+    """Run a git command, or raise.
+
+    A failed command that returned "" would be indistinguishable from one that
+    succeeded and found nothing, so the verification would report a clean result for a
+    comparison that never ran. `allow_missing` covers the one legitimate failure: a
+    path absent from one side of the comparison.
+    """
+    # Decode losslessly. `errors="replace"` collapses every invalid byte to one U+FFFD,
+    # so `\xff` and `\xfe` inside a string compare equal -- a change certified as no
+    # change. `surrogateescape` maps each invalid byte to a distinct surrogate, so the
+    # difference survives. And we do NOT translate newlines (no text=True), because a raw
+    # CR inside a string literal (an HTTP template, say) is content, and `\r\n`->`\n`
+    # would hide a CRLF change as comments-only.
+    p = subprocess.run(cmd, capture_output=True, check=False)
+    if p.returncode != 0:
+        if allow_missing:
+            return None
+        msg = p.stderr.decode("utf-8", "replace").strip()
+        raise GitError(f"{' '.join(cmd)} failed ({p.returncode}): {msg}")
+    return p.stdout.decode("utf-8", "surrogateescape")
+
+
+HUNK_RE = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def added_lines(diff):
+    """Yield (path, lineno, text, is_comment) for every added line.
+
+    The @@ header declares how many lines the hunk body holds, and we consume exactly
+    that many. Telling body from header by prefix instead cannot be made correct: an
+    added `++iter;` arrives as `+++iter;` and a removed `-- x` as `--- x`.
+    """
+    path, lineno, old_left, new_left = None, 0, 0, 0
+    for raw in diff.splitlines():
+        # Every body line carries a +/-/space/\ prefix, so a bare @@ or `diff --git` can
+        # only be a header. Resyncing on one bounds the damage of a hunk whose declared
+        # counts do not match its body to that hunk, instead of letting the shortfall eat
+        # the headers that follow and silently swallow the next hunk's added lines.
+        if HUNK_RE.match(raw) or raw.startswith("diff --git "):
+            old_left = new_left = 0
+
+        if old_left <= 0 and new_left <= 0:
+            if raw.startswith("+++ b/"):
+                path = raw[6:]
+            elif m := HUNK_RE.match(raw):
+                old_left = int(m.group(1) or 1)
+                lineno = int(m.group(2))
+                new_left = int(m.group(3) or 1)
+            continue
+
+        if raw.startswith("\\"):  # "\ No newline at end of file"
+            continue
+        if raw.startswith("+"):
+            body = raw[1:]
+            if path:
+                yield path, lineno, body, is_comment_line(path, body)
+            lineno += 1
+            new_left -= 1
+        elif raw.startswith("-"):
+            old_left -= 1
+        else:  # context
+            lineno += 1
+            old_left -= 1
+            new_left -= 1
+
+
+def strip_comment_markers(text):
+    return re.sub(r"^\s*(//+|#+|/\*+|\*+/?)\s?", "", text).strip()
+
+
+def _scan_line(text, was_open):
+    """Read one line and return (block still open after, any code outside comments).
+
+    `has_code` is what makes `/* note */ x = 1;` a code line rather than prose: the
+    prefix `/*` opens and closes on the same line, and the `x = 1;` after it is code.
+    String and char literals are content (code); a raw string holds `"` and `/*` as
+    ordinary content and is consumed whole, so the quote tracker does not leave it early.
+    """
+    i, open_, quote, has_code = 0, was_open, "", False
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            has_code = True
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = ""
+        elif open_:
+            if text.startswith("*/", i):
+                open_ = False
+                i += 2
+                continue
+        elif (raw := _raw_string_at(text, i)) is not None:
+            has_code = True
+            i += len(raw)
+            continue
+        elif ch in ('"', "'"):
+            has_code = True
+            quote = ch
+        elif text.startswith("//", i):
+            break
+        elif text.startswith("/*", i):
+            open_ = True
+            i += 2
+            continue
+        elif not ch.isspace():
+            has_code = True
+        i += 1
+    return open_, has_code
+
+
+def collect(diff):
+    """Group added comment lines into contiguous blocks; count added code lines."""
+    blocks, current, code = [], None, 0
+    in_block, expected = False, None
+    for path, lineno, text, is_comment in added_lines(diff):
+        if not path.endswith(SOURCE_SUFFIXES):
+            continue
+
+        # The body of a /* */ block need not start its lines with a star, so whether a
+        # line is prose depends on the lines before it. Carrying that state is only sound
+        # across contiguous added lines -- over a gap, the lines we cannot see may have
+        # closed the comment.
+        if expected != (path, lineno):
+            in_block = False
+        expected = (path, lineno + 1)
+        if not path.endswith((".py", ".pyi")):
+            in_block, has_code = _scan_line(text, in_block)
+            is_comment = not has_code
+
+        if is_comment:
+            stripped = strip_comment_markers(text)
+            if (
+                current
+                and current.path == path
+                and current.line + len(current.lines) == lineno
+            ):
+                current.lines.append(stripped)
+            else:
+                current = Block(path, lineno, [stripped])
+                blocks.append(current)
+        else:
+            current = None
+            if text.strip():
+                code += 1
+    return blocks, code
+
+
+def find_duplicates(blocks):
+    """Group blocks that explain the same concept at different sites.
+
+    A block joins a group only if it shares enough vocabulary with what the WHOLE
+    group already has in common, not merely with one member. Matching against a
+    single member chains unrelated blocks together (A-B, B-C, so A and C group
+    despite sharing nothing) and reports a group with no common terms at all.
+
+    Copy-pasted prose needs no separate check: identical text shares all its terms.
+    """
+    candidates = [
+        b
+        for b in blocks
+        if len(b.terms) >= SHARED_TERMS_THRESHOLD
+        and not TEST_PATH_RE.search(b.path)
+        and not POINTER_RE.search(b.text)
+    ]
+
+    groups = []  # [members, terms common to every member]
+    for block in candidates:
+        terms = block.terms
+        for group in groups:
+            shared = group[1] & terms
+            if len(shared) >= SHARED_TERMS_THRESHOLD:
+                group[0].append(block)
+                group[1] = shared  # stays >= threshold, so it can never empty out
+                break
+        else:
+            groups.append([[block], set(terms)])
+    return [(g, sorted(terms)) for g, terms in groups if len(g) >= MIN_SITES]
+
+
+def _raw_string_at(text, i):
+    """The raw string literal starting at i, or None.
+
+    R"delim( ... )delim" takes no escapes and may hold bare quotes, so the ordinary
+    string scanner would leave it early and read its contents as code.
+    """
+    if text[i] != "R" or not text[i + 1 : i + 2] == '"':
+        return None
+    open_paren = text.find("(", i + 2)
+    if open_paren == -1:
+        return None
+    delim = text[i + 2 : open_paren]
+    if len(delim) > 16 or re.search(r'[\s()\\"]', delim):
+        return None
+    close = ")" + delim + '"'
+    end = text.find(close, open_paren)
+    if end == -1:
+        return None
+    return text[i : end + len(close)]
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--from-ref")
+    p.add_argument("--to-ref", default="HEAD")
+    p.add_argument("filenames", nargs="*", help="ignored; pre-commit passes these")
+    args = p.parse_args()
+
+    # pre-commit exports these when invoked with --from-ref/--to-ref, which is how CI
+    # runs it; a plain `git commit` has neither and we read the staged diff instead.
+    from_ref = args.from_ref or os.environ.get("PRE_COMMIT_FROM_REF")
+    to_ref = os.environ.get("PRE_COMMIT_TO_REF") or args.to_ref
+
+    if from_ref:
+        diff = run(["git", "diff", "--unified=0", f"{from_ref}..{to_ref}"])
+    else:
+        diff = run(["git", "diff", "--cached", "--unified=0"])
+
+    blocks, code = collect(diff)
+    comment_lines = sum(len(b.lines) for b in blocks)
+    problems = 0
+
+    for group, shared in find_duplicates(blocks):
+        problems += 1
+        print(
+            f"This concept is explained at {len(group)} sites ({', '.join(shared[:5])}):"
+        )
+        for b in group:
+            print(f"    {b.path}:{b.line}: {b.text[:70]}")
+        print(
+            "    Explain it once, where the surprising thing happens; "
+            "point at that site from the others."
+        )
+
+    for b in blocks:
+        if len(b.lines) > MAX_BLOCK_LINES:
+            problems += 1
+            print(
+                f"{b.path}:{b.line}: {len(b.lines)}-line comment block "
+                f"(limit {MAX_BLOCK_LINES})."
+            )
+            print("    Design notes belong in the PR description, not the source.")
+
+    if code and comment_lines:
+        density = comment_lines * 100 // (comment_lines + code)
+        if density > DENSITY_WARN_PCT:
+            print(
+                f"note: {comment_lines} added comment lines to {code} of code ({density}%)."
+            )
+
+    if problems:
+        print(f"\n{problems} issue(s). Comment the non-obvious WHY, never the WHAT.")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/test_check_comment_slop.py
+++ b/utils/test_check_comment_slop.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for utils/check_comment_slop.py."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import check_comment_slop as slop  # noqa: E402
+
+
+def diff(*hunks):
+    """Build a unified diff (-U0) from (path, start_line, lines) triples."""
+    out = []
+    for path, start, lines in hunks:
+        out.append(f"--- a/{path}")
+        out.append(f"+++ b/{path}")
+        out.append(f"@@ -{start},0 +{start},{len(lines)} @@")
+        out += [f"+{line}" for line in lines]
+    return "\n".join(out)
+
+
+class CollectTests(unittest.TestCase):
+    def test_contiguous_comment_lines_form_one_block(self):
+        blocks, code = slop.collect(
+            diff(("a.cpp", 10, ["// one", "// two", "int x = 1;"]))
+        )
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0].lines, ["one", "two"])
+        self.assertEqual(code, 1)
+
+    def test_code_between_comments_splits_the_block(self):
+        blocks, _ = slop.collect(diff(("a.cpp", 1, ["// one", "int x = 1;", "// two"])))
+        self.assertEqual(len(blocks), 2)
+
+    def test_non_source_files_are_ignored(self):
+        blocks, code = slop.collect(diff(("README.md", 1, ["# heading", "text"])))
+        self.assertEqual(blocks, [])
+        self.assertEqual(code, 0)
+
+
+class TermTests(unittest.TestCase):
+    def test_identifiers_are_split_into_words(self):
+        block = slop.Block("a.cpp", 1, ["has_enforce_eager and VLLMServer::load"])
+        self.assertIn("enforce", block.terms)
+        self.assertIn("server", block.terms)
+
+    def test_short_words_and_stopwords_are_dropped(self):
+        block = slop.Block("a.cpp", 1, ["the cat sat on that mat"])
+        self.assertEqual(block.terms, set())
+
+
+class DuplicateTests(unittest.TestCase):
+    def _blocks(self, *texts, path="a.cpp"):
+        return [slop.Block(path, i * 10, [t]) for i, t in enumerate(texts)]
+
+    def test_reworded_explanations_at_three_sites_are_flagged(self):
+        # The real failure: the same concept, differently worded at each site.
+        blocks = self._blocks(
+            "enforce eager is stripped from args because load re-emits it from policy",
+            "enforce eager is a managed intent, not passthrough: load re-emits policy",
+            "policy re-emits enforce eager, so args must strip the managed intent",
+        )
+        found = slop.find_duplicates(blocks)
+        self.assertEqual(len(found), 1)
+        self.assertEqual(len(found[0][0]), 3)
+
+    def test_two_sites_are_not_flagged(self):
+        # Contract at the declaration + reason at the implementation is idiomatic.
+        blocks = self._blocks(
+            "enforce eager is stripped from args because load re-emits from policy",
+            "enforce eager stripped here since load re-emits it from the policy",
+        )
+        self.assertEqual(slop.find_duplicates(blocks), [])
+
+    def test_unrelated_blocks_are_not_grouped(self):
+        blocks = self._blocks(
+            "enforce eager stripped because load re-emits from launch policy",
+            "speculative config is structured json that cannot ride the args string",
+            "gfx covers every cdna generation plus vega, all discrete hbm parts",
+        )
+        self.assertEqual(slop.find_duplicates(blocks), [])
+
+    def test_a_pointer_comment_is_not_a_duplicate(self):
+        # "see X" is a cross-reference, which is what a cut should leave behind.
+        blocks = self._blocks(
+            "enforce eager is stripped from args because load re-emits from policy",
+            "enforce eager is a managed intent, not passthrough: load re-emits policy",
+            "enforce eager is absent here; see resolve_vllm_args, which manages policy",
+        )
+        self.assertEqual(slop.find_duplicates(blocks), [])
+
+    def test_test_files_may_restate_the_invariant(self):
+        blocks = self._blocks(
+            "enforce eager is stripped from args because load re-emits from policy",
+            "enforce eager is a managed intent, not passthrough: load re-emits policy",
+        ) + self._blocks(
+            "enforce eager must survive the resolver: load re-emits it from policy",
+            path="test/cpp/test_thing.cpp",
+        )
+        self.assertEqual(slop.find_duplicates(blocks), [])
+
+    def test_unrelated_blocks_never_chain_together(self):
+        # A joins B and B joins C must not put A and C in one group when A and C
+        # share nothing; that reports a "duplicate" with no common terms at all.
+        # The bridge has to clear the threshold against B (4 terms) while sharing
+        # nothing with A, or the chain never forms and the test proves nothing.
+        blocks = self._blocks(
+            "apple banana cherry delta eagle",
+            "apple banana cherry delta flamingo gorilla hyena iguana",
+            "flamingo gorilla hyena iguana jackfruit kangaroo leopard mongoose",
+        )
+        self.assertEqual(
+            blocks[0].terms & blocks[1].terms, {"apple", "banana", "cherry", "delta"}
+        )
+        self.assertEqual(
+            blocks[1].terms & blocks[2].terms,
+            {"flamingo", "gorilla", "hyena", "iguana"},
+        )
+        self.assertEqual(blocks[0].terms & blocks[2].terms, set())
+        self.assertEqual(slop.find_duplicates(blocks), [])
+
+
+class CommentClassificationTests(unittest.TestCase):
+    def test_preprocessor_directives_are_code_not_comments(self):
+        # An alphabetised #include block is the most routine C++ diff there is. Read
+        # as prose it becomes a "repeated explanation" the moment three files add one.
+        self.assertFalse(slop.is_comment_line("a.cpp", "#include <lemon/router.h>"))
+        self.assertFalse(slop.is_comment_line("a.cpp", "#define LEMON_MAX 4"))
+
+    def test_hash_is_still_a_comment_in_python(self):
+        self.assertTrue(slop.is_comment_line("a.py", "# why this is not obvious"))
+
+    def test_block_comment_delimiters_are_comments(self):
+        self.assertTrue(slop.is_comment_line("a.cpp", " */"))
+        self.assertTrue(slop.is_comment_line("a.cpp", " * continued"))
+
+    def test_leading_star_dereference_is_code(self):
+        self.assertFalse(slop.is_comment_line("a.cpp", "    *result = compute();"))
+
+    def test_a_block_comment_body_need_not_start_its_lines_with_a_star(self):
+        blocks, code = slop.collect(
+            diff(
+                (
+                    "a.cpp",
+                    1,
+                    [
+                        "/* This is a long comment",
+                        "   that continues without stars",
+                        "   on each line",
+                        "*/",
+                    ],
+                )
+            )
+        )
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(len(blocks[0].lines), 4)
+        self.assertEqual(code, 0)
+
+    def test_a_block_comment_closing_hands_the_next_line_back_to_code(self):
+        blocks, code = slop.collect(
+            diff(("a.cpp", 1, ["/* why", "   because", "*/", "int x = 1;"]))
+        )
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(code, 1)
+
+    def test_a_slashslash_comment_mentioning_a_block_opener_does_not_open_one(self):
+        blocks, code = slop.collect(
+            diff(("a.cpp", 1, ["// beware of /* in here", "int x = 1;"]))
+        )
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(code, 1)
+
+    def test_an_inline_block_comment_before_code_is_a_code_line(self):
+        # `/* note */ x = 1;` starts with `/*` but the code after the close is not prose.
+        for line in ("/* note */ int evil = 1;", "*/ int x = 1;"):
+            blocks, code = slop.collect(diff(("a.cpp", 1, [line])))
+            self.assertEqual(blocks, [], line)
+            self.assertEqual(code, 1, line)
+
+    def test_a_string_containing_a_block_opener_does_not_open_one(self):
+        # Reading `"/*"` as an open comment hands the NEXT line of ordinary code to the
+        # slop detector as prose.
+        blocks, code = slop.collect(
+            diff(("a.cpp", 1, ['char s[] = "/*";', "int x = 1;"]))
+        )
+        self.assertEqual(blocks, [])
+        self.assertEqual(code, 2)
+
+    def test_a_raw_string_containing_a_block_opener_does_not_open_one(self):
+        # A raw string holds `"` and `/*` as content; the quote tracker would leave it
+        # early at the inner `"` and read the `/*` as a comment opener.
+        blocks, code = slop.collect(
+            diff(("a.cpp", 1, ['R"({"/*":"b"})"', "int evil();"]))
+        )
+        self.assertEqual(blocks, [])
+        self.assertEqual(code, 2)
+
+    def test_routine_include_block_is_not_slop(self):
+        includes = [
+            "#include <lemon/backends/wrapped_server.h>",
+            "#include <lemon/server/model_manager.h>",
+            "#include <lemon/server/router_capabilities.h>",
+            "#include <lemon/server/wrapped_registry.h>",
+        ]
+        blocks, code = slop.collect(
+            diff(
+                ("alpha.cpp", 1, includes),
+                ("bravo.cpp", 1, includes),
+                ("charlie.cpp", 1, includes),
+            )
+        )
+        self.assertEqual(blocks, [])
+        self.assertEqual(code, 12)
+        self.assertEqual(slop.find_duplicates(blocks), [])
+
+
+class AddedLinesTests(unittest.TestCase):
+    def _added(self, body):
+        head = "diff --git a/x.cpp b/x.cpp\n--- a/x.cpp\n+++ b/x.cpp\n"
+        return [t for _, _, t, _ in slop.added_lines(head + body)]
+
+    def test_added_line_starting_with_plus_plus_survives(self):
+        # "++iter;" reaches the parser as "+++iter;" -- a "+++" prefix test drops it.
+        self.assertEqual(
+            self._added("@@ -1,0 +1,2 @@\n+++iter;\n+int y = 1;\n"),
+            ["++iter;", "int y = 1;"],
+        )
+
+    def test_removed_line_starting_with_dashes_does_not_derail(self):
+        self.assertEqual(
+            self._added("@@ -1,1 +1,1 @@\n--- x;\n+int y = 1;\n"), ["int y = 1;"]
+        )
+
+    def test_no_newline_marker_is_skipped(self):
+        self.assertEqual(
+            self._added("@@ -1,0 +1,1 @@\n+int y = 1;\n\\ No newline at end of file\n"),
+            ["int y = 1;"],
+        )
+
+    def test_a_hunk_whose_counts_undershoot_cannot_swallow_the_next(self):
+        # A hunk declaring more lines than it holds leaves the counter positive, and the
+        # following @@ would be eaten as a body line -- taking the hunk after it with it.
+        self.assertEqual(
+            self._added("@@ -1 +1 @@\n+foo\n@@ -3 +3 @@\n+bar\n@@ -5 +5 @@\n+baz\n"),
+            ["foo", "bar", "baz"],
+        )
+
+    def test_multi_file_diff_attributes_lines_to_each_file(self):
+        d = (
+            "diff --git a/a.cpp b/a.cpp\n--- a/a.cpp\n+++ b/a.cpp\n"
+            "@@ -1,0 +1,1 @@\n+int a = 1;\n"
+            "diff --git a/b.cpp b/b.cpp\n--- a/b.cpp\n+++ b/b.cpp\n"
+            "@@ -1,0 +1,1 @@\n+int b = 2;\n"
+        )
+        self.assertEqual(
+            [(p, t) for p, _, t, _ in slop.added_lines(d)],
+            [("a.cpp", "int a = 1;"), ("b.cpp", "int b = 2;")],
+        )
+
+    def test_an_empty_diff_yields_nothing(self):
+        self.assertEqual(list(slop.added_lines("")), [])
+
+
+class TestPathTests(unittest.TestCase):
+    def test_test_files_are_recognised(self):
+        for path in ("test/a.py", "tests/a.py", "src/unit_tests.py", "testing/a.py"):
+            self.assertTrue(slop.TEST_PATH_RE.search(path), path)
+
+    def test_a_word_merely_containing_test_is_not_a_test_file(self):
+        self.assertFalse(slop.TEST_PATH_RE.search("src/latest_version.py"))
+        self.assertFalse(slop.TEST_PATH_RE.search("contest.py"))
+
+    def test_a_root_level_test_file_is_recognised(self):
+        for path in ("test.cpp", "tests.py", "test.py"):
+            self.assertTrue(slop.TEST_PATH_RE.search(path), path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Ports lemonade-sdk's `check_comment_slop.py`/`test_comment_slop.py` diff-based heuristic to flag likely AI-generated comment slop: the same concept re-explained across 3+ sites, oversized comment blocks (>12 lines), and high comment density.
- Wires it up as a new `comment-slop` local pre-commit hook (`types_or: [c, c++, python]`, no `stages:` override so it runs at both commit and push time, matching the other cheap diff-only validators).
- Adds a `comment-slop` job to `.github/workflows/lintAndFormat.yml` that runs the ported unit tests and then `pre-commit run comment-slop` scoped to the PR's actual merge-base against its target branch. Skipped on `merge_group` since queued HEAD there mixes commits from multiple independently-reviewed PRs.

## Test plan
- [x] `python utils/test_check_comment_slop.py -v` — all 31 ported unit tests pass unmodified
- [x] Manual smoke test: a synthetic 3-site reworded-duplicate diff is correctly flagged; an ordinary 2-site declaration/impl comment pair passes clean
- [x] `pre-commit run comment-slop --from-ref <base> --to-ref HEAD` verified locally
- [x] Ran against this PR's own diff with zero false positives
- [x] `.github/workflows/lintAndFormat.yml` YAML parses cleanly; full local pre-commit/pre-push hook suite passes on this branch, including the new hook