### PR TITLE
[python] Materialize a kernel's source atomically

### DIFF
--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -6,6 +6,7 @@
 """Low-level helpers for compiling MLIR modules and external C++ kernels to NPU artifacts."""
 
 import concurrent.futures
+import contextlib
 import logging
 import os
 import re
@@ -23,6 +24,12 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+# What open(path, "w") would have produced.  Probed once at import because
+# reading the umask means setting it, which is process-wide.
+_UMASK = os.umask(0o022)
+os.umask(_UMASK)
+_DEFAULT_FILE_MODE = 0o666 & ~_UMASK
 
 
 def resolve_target_arch(device=None) -> str:
@@ -574,13 +581,52 @@ def _rename_symbol_in_object(object_path: str, old_name: str, new_name: str) -> 
         raise RuntimeError(f"Symbol rename failed: {result.stderr.decode()}")
 
 
+def _materialize_source(
+    dest: str, *, text: str | None = None, copy_from: str | None = None
+):
+    """Put a kernel's source at ``dest`` without ever truncating it in place.
+
+    Kernels are grouped by ``_original_name``, but a source file is named after
+    its own basename, so the several ExternalFunctions that share one .cc (only
+    their -D flags differ) land in different groups and materialize the same
+    path concurrently.  Writing in place truncates that file under a sibling
+    compile: the reader either takes SIGBUS when the mapping shrinks beneath it,
+    or sees a short prefix, compiles it clean because the missing part was
+    behind an #ifdef, and emits an object with no symbol in it.
+
+    Every writer stages identical bytes, so it does not matter which one lands.
+    Staging in a sibling temp file and renaming makes the swap atomic, and a
+    compile already holding the old inode keeps reading it until it unmaps.
+    """
+    directory = os.path.dirname(dest) or "."
+    fd, tmp = tempfile.mkstemp(
+        dir=directory, prefix=os.path.basename(dest) + ".", suffix=".tmp"
+    )
+    try:
+        if text is not None:
+            with os.fdopen(fd, "w") as f:
+                f.write(text)
+            # mkstemp opens at 0600; the in-place open() this replaces left the
+            # file at the process umask.  copy2 carries the mode over on the
+            # other branch, so only the written-from-string one has to.
+            os.chmod(tmp, _DEFAULT_FILE_MODE)
+        else:
+            os.close(fd)
+            shutil.copy2(copy_from, tmp)
+        os.replace(tmp, dest)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
 def compile_external_kernels(funcs, kernel_dir, target_arch):
     """Compile every ExternalFunction in ``funcs`` into ``kernel_dir``.
 
-    Kernels are separate translation units with separate outputs, so they compile
-    concurrently.  The exception is the source path: ``compile_external_kernel``
-    writes the source as ``<_original_name>.cc``, so ExternalFunctions sharing an
-    original name write the same file and are ordered against each other.
+    Kernels are separate translation units with separate outputs, so they
+    compile concurrently.  Their source files are not always separate --
+    several ExternalFunctions can share one .cc -- so ``_materialize_source``
+    makes each write atomic rather than ordering the compiles behind it.
 
     Each compile is single-threaded and peaks near 205 MB of RSS on aie2p (250 MB
     without the intrinsics PCH), so the bound is cores rather than memory on an
@@ -668,8 +714,7 @@ def compile_external_kernel(func, kernel_dir, target_arch):
     if func._source_string is not None:
         original_name = getattr(func, "_original_name", func._name)
         source_file = os.path.join(kernel_dir, f"{original_name}.cc")
-        with open(source_file, "w") as f:
-            f.write(func._source_string)
+        _materialize_source(source_file, text=func._source_string)
         compile_cxx_core_function(
             source_path=source_file,
             target_arch=target_arch,
@@ -696,11 +741,11 @@ def compile_external_kernel(func, kernel_dir, target_arch):
             raise FileNotFoundError(
                 f"ExternalFunction '{func._name}': source file not found: {func._source_file}"
             )
-        if os.path.abspath(source_file) != os.path.abspath(func._source_file):
-            try:
-                shutil.copy2(func._source_file, source_file)
-            except shutil.SameFileError:
-                pass
+        # realpath, not abspath: the rename in _materialize_source would happily
+        # overwrite the kernel's own source with a copy of itself if kernel_dir
+        # reaches it through a symlink, where copy2 used to raise SameFileError.
+        if os.path.realpath(source_file) != os.path.realpath(func._source_file):
+            _materialize_source(source_file, copy_from=func._source_file)
         # Include the original source file's directory so relative includes
         # (e.g. "../aie_kernel_utils.h") still resolve after the file is
         # copied into kernel_dir.

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -581,10 +581,9 @@ def _rename_symbol_in_object(object_path: str, old_name: str, new_name: str) -> 
         raise RuntimeError(f"Symbol rename failed: {result.stderr.decode()}")
 
 
-def _materialize_source(
-    dest: str, *, text: str | None = None, copy_from: str | None = None
-):
-    """Put a kernel's source at ``dest`` without ever truncating it in place.
+@contextlib.contextmanager
+def _staged(dest: str):
+    """Yield a sibling temp path that replaces ``dest`` atomically on success.
 
     Kernels are grouped by ``_original_name``, but a source file is named after
     its own basename, so the several ExternalFunctions that share one .cc (only
@@ -595,24 +594,16 @@ def _materialize_source(
     behind an #ifdef, and emits an object with no symbol in it.
 
     Every writer stages identical bytes, so it does not matter which one lands.
-    Staging in a sibling temp file and renaming makes the swap atomic, and a
-    compile already holding the old inode keeps reading it until it unmaps.
+    Renaming makes the swap atomic, and a compile already holding the old inode
+    keeps reading it until it unmaps.
     """
     directory = os.path.dirname(dest) or "."
     fd, tmp = tempfile.mkstemp(
         dir=directory, prefix=os.path.basename(dest) + ".", suffix=".tmp"
     )
+    os.close(fd)
     try:
-        if text is not None:
-            with os.fdopen(fd, "w") as f:
-                f.write(text)
-            # mkstemp opens at 0600; the in-place open() this replaces left the
-            # file at the process umask.  copy2 carries the mode over on the
-            # other branch, so only the written-from-string one has to.
-            os.chmod(tmp, _DEFAULT_FILE_MODE)
-        else:
-            os.close(fd)
-            shutil.copy2(copy_from, tmp)
+        yield tmp
         os.replace(tmp, dest)
     except BaseException:
         with contextlib.suppress(OSError):
@@ -620,13 +611,30 @@ def _materialize_source(
         raise
 
 
+def _write_source(dest: str, text: str) -> None:
+    """Write ``text`` to ``dest`` without ever truncating it in place."""
+    with _staged(dest) as tmp:
+        with open(tmp, "w") as f:
+            f.write(text)
+        # mkstemp created the temp file at 0600; the in-place open() this
+        # replaces left the source at the process umask.  copy2 carries the mode
+        # over in _copy_source, so only this path has to restore it.
+        os.chmod(tmp, _DEFAULT_FILE_MODE)
+
+
+def _copy_source(dest: str, src: str) -> None:
+    """Copy ``src`` onto ``dest`` without ever truncating ``dest`` in place."""
+    with _staged(dest) as tmp:
+        shutil.copy2(src, tmp)
+
+
 def compile_external_kernels(funcs, kernel_dir, target_arch):
     """Compile every ExternalFunction in ``funcs`` into ``kernel_dir``.
 
     Kernels are separate translation units with separate outputs, so they
     compile concurrently.  Their source files are not always separate --
-    several ExternalFunctions can share one .cc -- so ``_materialize_source``
-    makes each write atomic rather than ordering the compiles behind it.
+    several ExternalFunctions can share one .cc -- so ``_staged`` makes each
+    write atomic rather than ordering the compiles behind it.
 
     Each compile is single-threaded and peaks near 205 MB of RSS on aie2p (250 MB
     without the intrinsics PCH), so the bound is cores rather than memory on an
@@ -714,7 +722,7 @@ def compile_external_kernel(func, kernel_dir, target_arch):
     if func._source_string is not None:
         original_name = getattr(func, "_original_name", func._name)
         source_file = os.path.join(kernel_dir, f"{original_name}.cc")
-        _materialize_source(source_file, text=func._source_string)
+        _write_source(source_file, func._source_string)
         compile_cxx_core_function(
             source_path=source_file,
             target_arch=target_arch,
@@ -741,11 +749,11 @@ def compile_external_kernel(func, kernel_dir, target_arch):
             raise FileNotFoundError(
                 f"ExternalFunction '{func._name}': source file not found: {func._source_file}"
             )
-        # realpath, not abspath: the rename in _materialize_source would happily
-        # overwrite the kernel's own source with a copy of itself if kernel_dir
-        # reaches it through a symlink, where copy2 used to raise SameFileError.
+        # realpath, not abspath: the rename in _staged would happily overwrite
+        # the kernel's own source with a copy of itself if kernel_dir reaches it
+        # through a symlink, where copy2 used to raise SameFileError.
         if os.path.realpath(source_file) != os.path.realpath(func._source_file):
-            _materialize_source(source_file, copy_from=func._source_file)
+            _copy_source(source_file, func._source_file)
         # Include the original source file's directory so relative includes
         # (e.g. "../aie_kernel_utils.h") still resolve after the file is
         # copied into kernel_dir.

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -593,9 +593,11 @@ def _staged(dest: str):
     or sees a short prefix, compiles it clean because the missing part was
     behind an #ifdef, and emits an object with no symbol in it.
 
-    Every writer stages identical bytes, so it does not matter which one lands.
-    Renaming makes the swap atomic, and a compile already holding the old inode
-    keeps reading it until it unmaps.
+    Safe while every writer to one ``dest`` stages identical bytes: renaming
+    makes the swap atomic, and a compile already holding the old inode keeps
+    reading it until it unmaps.  Writers whose bytes differ have to be ordered
+    instead; ``compile_external_kernels`` says which of those its grouping
+    covers.
     """
     directory = os.path.dirname(dest) or "."
     fd, tmp = tempfile.mkstemp(
@@ -635,6 +637,16 @@ def compile_external_kernels(funcs, kernel_dir, target_arch):
     compile concurrently.  Their source files are not always separate --
     several ExternalFunctions can share one .cc -- so ``_staged`` makes each
     write atomic rather than ordering the compiles behind it.
+
+    The ``_original_name`` grouping below is still load-bearing, for a case
+    ``_staged`` cannot cover: two ExternalFunctions can share an
+    ``_original_name`` while carrying different ``source_string``s, because
+    ``ExternalFunction.__init__`` auto-suffixes a defaulted ``object_file_name``
+    on collision but never the original name.  Both write ``<_original_name>.cc``
+    and the bytes differ, so an atomic swap is not enough and they have to run
+    one after the other.  Not covered either way: two ``source_file``s with the
+    same basename in different directories land on one path with different bytes
+    but different ``_original_name``s, so nothing orders them.
 
     Each compile is single-threaded and peaks near 205 MB of RSS on aie2p (250 MB
     without the intrinsics PCH), so the bound is cores rather than memory on an

--- a/test/python/test_kernel_source_materialization.py
+++ b/test/python/test_kernel_source_materialization.py
@@ -10,10 +10,13 @@
 import os
 import types
 
-import pytest
-
 import aie.utils.compile.utils as compile_utils
-from aie.utils.compile.utils import _materialize_source, compile_external_kernels
+import pytest
+from aie.utils.compile.utils import (
+    _copy_source,
+    _write_source,
+    compile_external_kernels,
+)
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="test/python/ has no Windows pytest job to run under"
@@ -23,7 +26,7 @@ SOURCE = "// kernel\nvoid k() {}\n" * 64
 
 
 def _stub_func(name, source_file):
-    """A stand-in for ExternalFunction carrying only what the compile path reads."""
+    """Build a stand-in for ExternalFunction carrying what the compile path reads."""
     return types.SimpleNamespace(
         _name=name,
         _original_name=name,
@@ -59,10 +62,10 @@ def test_rewrite_leaves_an_open_reader_on_its_own_file(tmp_path):
     which is what spares it the SIGBUS when the size drops under its mapping.
     """
     dest = tmp_path / "kernel.cc"
-    _materialize_source(str(dest), text=SOURCE)
+    _write_source(str(dest), SOURCE)
 
     with open(dest) as reader:
-        _materialize_source(str(dest), text="// replaced\n")
+        _write_source(str(dest), "// replaced\n")
         assert reader.read() == SOURCE
         assert os.fstat(reader.fileno()).st_ino != os.stat(dest).st_ino
 
@@ -112,10 +115,10 @@ def test_source_that_is_already_in_place_is_not_rewritten(tmp_path, stub_compile
 def test_materialized_source_keeps_umask_permissions(tmp_path):
     """Staging through mkstemp must not narrow the source to 0600."""
     written = tmp_path / "from_string.cc"
-    _materialize_source(str(written), text=SOURCE)
+    _write_source(str(written), SOURCE)
 
     copied = tmp_path / "from_file.cc"
-    _materialize_source(str(copied), copy_from=str(written))
+    _copy_source(str(copied), str(written))
 
     expected = 0o666 & ~compile_utils._UMASK
     assert os.stat(written).st_mode & 0o777 == expected
@@ -126,6 +129,6 @@ def test_failed_write_leaves_no_temp_files(tmp_path):
     """A raising write must not litter the kernel directory with .tmp sources."""
     dest = tmp_path / "kernel.cc"
     with pytest.raises(FileNotFoundError):
-        _materialize_source(str(dest), copy_from=str(tmp_path / "missing.cc"))
+        _copy_source(str(dest), str(tmp_path / "missing.cc"))
 
     assert list(tmp_path.iterdir()) == []

--- a/test/python/test_kernel_source_materialization.py
+++ b/test/python/test_kernel_source_materialization.py
@@ -1,0 +1,131 @@
+# test_kernel_source_materialization.py -*- Python -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# RUN: %pytest %s
+"""Unit tests for concurrent kernel source materialization — no NPU required."""
+
+import os
+import types
+
+import pytest
+
+import aie.utils.compile.utils as compile_utils
+from aie.utils.compile.utils import _materialize_source, compile_external_kernels
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="test/python/ has no Windows pytest job to run under"
+)
+
+SOURCE = "// kernel\nvoid k() {}\n" * 64
+
+
+def _stub_func(name, source_file):
+    """A stand-in for ExternalFunction carrying only what the compile path reads."""
+    return types.SimpleNamespace(
+        _name=name,
+        _original_name=name,
+        _source_file=str(source_file),
+        _source_string=None,
+        _include_dirs=[],
+        _compile_flags=[f"-D{name.upper()}"],
+        _inline=False,
+        _symbol_prefix=None,
+        _use_chess=False,
+        _compiled=False,
+        object_file_name=f"{name}.o",
+    )
+
+
+@pytest.fixture
+def stub_compiler(monkeypatch):
+    """Replace the Peano invocation with a no-op that just produces the object."""
+
+    def fake_compile(source_path, output_path, **kwargs):
+        with open(output_path, "w"):
+            pass
+
+    monkeypatch.setattr(compile_utils, "compile_cxx_core_function", fake_compile)
+
+
+def test_rewrite_leaves_an_open_reader_on_its_own_file(tmp_path):
+    """A compile that already opened the source is unaffected by a sibling's write.
+
+    Reading back the same bytes would prove nothing -- every writer stages
+    identical content, so an in-place truncate is invisible once it finishes.
+    What matters is that the reader is never looking at the file being written,
+    which is what spares it the SIGBUS when the size drops under its mapping.
+    """
+    dest = tmp_path / "kernel.cc"
+    _materialize_source(str(dest), text=SOURCE)
+
+    with open(dest) as reader:
+        _materialize_source(str(dest), text="// replaced\n")
+        assert reader.read() == SOURCE
+        assert os.fstat(reader.fileno()).st_ino != os.stat(dest).st_ino
+
+    assert dest.read_text() == "// replaced\n"
+
+
+def test_shared_source_kernels_do_not_clobber_each_other(tmp_path, stub_compiler):
+    """Kernels sharing one .cc write one destination, so those writes must be atomic."""
+    upstream = tmp_path / "shared.cc"
+    upstream.write_text(SOURCE)
+    kernel_dir = tmp_path / "work"
+    kernel_dir.mkdir()
+    dest = kernel_dir / "shared.cc"
+
+    # The copy is named after the .cc but the grouping key is the kernel name,
+    # so these two are not ordered against each other despite sharing a path.
+    put, get = (_stub_func(n, upstream) for n in ("kernel_put", "kernel_get"))
+
+    compile_external_kernels([put], str(kernel_dir), "aie2p")
+    first = os.stat(dest).st_ino
+    compile_external_kernels([get], str(kernel_dir), "aie2p")
+
+    assert (
+        os.stat(dest).st_ino != first
+    ), "second kernel rewrote the shared source in place"
+    assert dest.read_text() == SOURCE
+
+
+def test_source_that_is_already_in_place_is_not_rewritten(tmp_path, stub_compiler):
+    """A kernel_dir reaching its own source through a symlink must not overwrite it."""
+    kernel_dir = tmp_path / "work"
+    kernel_dir.mkdir()
+    upstream = kernel_dir / "shared.cc"
+    upstream.write_text(SOURCE)
+    link = tmp_path / "link"
+    link.symlink_to(kernel_dir)
+
+    before = os.stat(upstream).st_ino
+    compile_external_kernels(
+        [_stub_func("kernel_put", link / "shared.cc")], str(kernel_dir), "aie2p"
+    )
+
+    assert os.stat(upstream).st_ino == before
+    assert upstream.read_text() == SOURCE
+
+
+def test_materialized_source_keeps_umask_permissions(tmp_path):
+    """Staging through mkstemp must not narrow the source to 0600."""
+    written = tmp_path / "from_string.cc"
+    _materialize_source(str(written), text=SOURCE)
+
+    copied = tmp_path / "from_file.cc"
+    _materialize_source(str(copied), copy_from=str(written))
+
+    expected = 0o666 & ~compile_utils._UMASK
+    assert os.stat(written).st_mode & 0o777 == expected
+    assert os.stat(copied).st_mode & 0o777 == expected
+
+
+def test_failed_write_leaves_no_temp_files(tmp_path):
+    """A raising write must not litter the kernel directory with .tmp sources."""
+    dest = tmp_path / "kernel.cc"
+    with pytest.raises(FileNotFoundError):
+        _materialize_source(str(dest), copy_from=str(tmp_path / "missing.cc"))
+
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Problem

`compile_external_kernels` groups pending kernels by `_original_name` so that kernels sharing a source file are ordered against each other. But `compile_external_kernel` names a copied source after the *basename of the source file*, not the kernel. The several `ExternalFunction`s that share one `.cc` and differ only in their `-D` flags therefore land in **different** groups and `shutil.copy2` onto the **same** destination path concurrently:

| shared source | kernels sharing it |
|---|---|
| `bottleneck/bn_conv2dk1_relu.cc` | 4 |
| `bottleneck/bn_conv2dk1_i8.cc` | 3 |

`copy2` opens the destination `"w"`, which truncates it in place. A sibling `clang++` that already mapped that file then either

- takes **SIGBUS** when the file shrinks beneath its mapping (`exit 135` = 128 + 7), or
- reads a short prefix, compiles it **cleanly** because the missing remainder was behind an `#ifdef`, and emits an object with no symbol in it.

Both showed up on `aie2p-8col` in the CI run for #3708 — a clang crash on `bn_conv2dk1_relu.cc`, and an `ld.lld` undefined symbol for `bn14_1_conv2dk1_i8_ui8_partial_width_get_new`. Those are exactly the two files in the table.

This is nondeterministic and unrelated to #3708's own changes; it was introduced by #3685 (`1b8b1b89`), which landed shortly before that CI run. CI's transient-retry logic only matches `eio`, `hwctx` and `readrace`, so a compile-time crash is never retried.

## Fix

Stage the source in a sibling temp file and `os.replace` it into place — the same atomic-write convention already used by `jit/_manifest.py`. Every writer stages identical bytes, so whichever rename lands is correct, and a compile already holding the old inode keeps reading it until it unmaps. Kernels keep compiling concurrently rather than being serialized behind the file.

Two details:

- `mkstemp` opens at `0600`, narrower than the in-place `open()` it replaces, so the written-from-string branch restores the umask-default mode (`copy2` carries the mode over on the other branch).
- The self-copy guard moves from `abspath` to `realpath`: `copy2` used to raise `SameFileError`, but a rename would happily overwrite a kernel's own source with a copy of itself if `kernel_dir` reaches it through a symlink.

The `compile_external_kernels` docstring claimed sources are written as `<_original_name>.cc`, which is false for the `_source_file` branch — precisely the bug. Corrected.

## Testing

New `test/python/test_kernel_source_materialization.py` (5 tests, no NPU required) covering inode isolation for an open reader, the shared-source case, the symlink self-copy guard, umask permissions, and temp-file cleanup on failure.

Verified the tests actually catch the bug: reverting `python/utils/compile/utils.py` to its current `main` content fails 2 of them with `second kernel rewrote the shared source in place`. Full `test/python/` run on this branch: **157 passed, 7 skipped**. `black`, `ruff` and `utils/check_comment_slop.py` all clean.

Note that asserting on file *content* proves nothing here — every writer stages identical bytes, so an in-place truncate is invisible once it finishes. The tests assert on inode identity instead, which is what distinguishes an atomic swap from a rewrite.
