### PR TITLE
gemm-atb: set smaller stack sizes

### DIFF
--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/n32_core.py
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config1/n32_core.py
@@ -179,13 +179,7 @@ def n32_core_gemm(
                 zero_kernel,
                 matmul_kernel,
             ],
-            # Peano drops the chess_storage(exN/dmN) placements above, so those
-            # block_vectors spill to the stack: with converted_A sized correctly
-            # the frame is 0x1640 (disassembled `paddxm [sp], #0x1640`), which
-            # 0xD00 silently underprovisioned. 0x1800 overflows the core's data
-            # region by 4 B; 0x1700 is the largest round value that links.
-            # Chess pins these vectors off-stack and likely needs less; untested.
-            stack_size=0x1700,
+            stack_size=0xA00,
         ),
     )
 

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/n32_core.py
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config2/n32_core.py
@@ -154,7 +154,7 @@ def n32_core_gemm(
                 zero_kernel,
                 matmul_kernel,
             ],
-            stack_size=0xD00,
+            stack_size=0x400,
         ),
     )
 

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/n32_core.py
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/config3/n32_core.py
@@ -150,11 +150,11 @@ def n32_core_gemm(
                 zero_kernel,
                 matmul_kernel,
             ],
-            stack_size=0xF00,
+            stack_size=0x400,
             # Reserve the kernel's static data explicitly: mm_bfp_mixed.cc
             # holds the bf16 C staging buffer (c_bf16_2nd_half, 16384 B) plus
-            # two counters in .bss. Buffer allocation leaves < 14 KB
-            # contiguous on each core, so the link fails without this.
+            # two counters in .bss. Without this, buffer allocation leaves
+            # < 14 KB contiguous and the core-ELF link fails.
             data_size=m * n // 2 * 2 + 8,
         ),
     )


### PR DESCRIPTION
The stack_size in #3658 for config1 was calculated for Chess kernel that was compiled with Peano and had a huge stack spill. New kernel is zero-spill (the loop part), and setting `stack_size=0x1700` is just unreasonable.

New sizes are measured from `paddxm`. But even if peano regresses and starts to spill, this change is safe anyways (i. e. it will fail loudly): aiecc's StackSizeAnalysis errors if `stack_size` is underprovisioned.

<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->

## Description

<!-- What does this PR change, and why? Link any related issue with "Fixes #123". -->

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [ ] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
