### PR TITLE
[AIEX] Carry address_patch's arg_plus at its real 64-bit width [HIGH]

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1045,7 +1045,7 @@ def AIE_NpuAddressPatchOp
     : AIEX_Op<"npu.address_patch", [AttrSizedOperandSegments]> {
   let summary = "address patch operator";
   let arguments = (ins UI32Attr:$addr, Optional<I32>:$addr_val,
-      OptionalAttr<I32Attr>:$arg_idx, I32:$arg_plus,
+      OptionalAttr<I32Attr>:$arg_idx, AnyTypeOf<[I32, I64]>:$arg_plus,
       Optional<AnyMemRef>:$buffer);
   let results = (outs );
   let assemblyFormat = [{
@@ -1068,9 +1068,10 @@ def AIE_NpuAddressPatchOp
     precedence. Only the EmitC (C++ TXN) target supports a runtime `addr_val`;
     the static binary target requires the constant `addr`.
 
-    `arg_plus` is an SSA value; use arith.constant for
+    `arg_plus` is an SSA value of type `i32` or `i64`; use arith.constant for
     a compile-time-known offset or pass a runtime sequence value for a
-    runtime-parameterized buffer offset.
+    runtime-parameterized buffer offset. It reaches the device as a 64-bit
+    field, so an offset past 4 GiB needs an `i64` constant.
 
     `arg_idx` or `buffer` specify which runtime sequence argument holds the 
     host buffer whose address you want to patch. You must set exactly one of

--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -74,6 +74,12 @@ std::optional<uint64_t> getConstantInt64Operand(mlir::Value v);
 mlir::Value createConstantI32(mlir::OpBuilder &builder, mlir::Location loc,
                               uint32_t value);
 
+// Materializes an address_patch `arg_plus` offset as the narrowest constant
+// that holds it: i32 while the value fits, i64 beyond that. aie-rt carries the
+// field as u64, so truncating a wider offset mis-addresses the buffer.
+mlir::Value createConstantArgPlus(mlir::OpBuilder &builder, mlir::Location loc,
+                                  uint64_t value);
+
 } // namespace AIEX
 } // namespace xilinx
 

--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -65,6 +65,7 @@ bool isContiguousTransfer(llvm::ArrayRef<int64_t> sizes,
 // otherwise returns nullopt. Used by ops whose operands carry
 // compile-time-known values in the static lowering path.
 std::optional<uint32_t> getConstantIntOperand(mlir::Value v);
+std::optional<uint64_t> getConstantInt64Operand(mlir::Value v);
 
 // Materializes a 32-bit integer constant. The inverse of getConstantIntOperand:
 // used when lowering passes feed a compile-time-known value into an npu op

--- a/include/aie/Dialect/AIEX/Utils/BdLowering.h
+++ b/include/aie/Dialect/AIEX/Utils/BdLowering.h
@@ -221,8 +221,8 @@ struct SsaStridePolicy {
 mlir::Value getAsValue(mlir::OpBuilder &builder, mlir::Location loc,
                        mlir::OpFoldResult ofr, mlir::Type intType);
 
-// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value, or
-// i64 when a constant offset exceeds 32 bits:
+// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value, i64
+// when it does not fit:
 // sum(elementOffsets[i] * strides[i]) * elemWidthBytes + baseByteOffset, where
 // any entry may be runtime (a fully-constant set folds to one arith.constant).
 mlir::Value buildArgPlusValue(mlir::OpBuilder &builder, mlir::Location loc,

--- a/include/aie/Dialect/AIEX/Utils/BdLowering.h
+++ b/include/aie/Dialect/AIEX/Utils/BdLowering.h
@@ -221,7 +221,8 @@ struct SsaStridePolicy {
 mlir::Value getAsValue(mlir::OpBuilder &builder, mlir::Location loc,
                        mlir::OpFoldResult ofr, mlir::Type intType);
 
-// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value:
+// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value, or
+// i64 when a constant offset exceeds 32 bits:
 // sum(elementOffsets[i] * strides[i]) * elemWidthBytes + baseByteOffset, where
 // any entry may be runtime (a fully-constant set folds to one arith.constant).
 mlir::Value buildArgPlusValue(mlir::OpBuilder &builder, mlir::Location loc,

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -213,7 +213,7 @@ inline void txn_append_address_patch(std::vector<uint32_t> &txn, uint32_t addr,
   txn[pos + 0] = TXN_OPC_DDR_PATCH;     // opcode
   txn[pos + 1] = 12 * sizeof(uint32_t); // operation size
   // pos+2..4 are reserved (zero)
-  txn[pos + 5] = 0; // action; the struct puts it at word 4, inert while zero
+  txn[pos + 5] = 0;    // action; the struct puts it at word 4, inert while zero
   txn[pos + 6] = addr; // register address to patch
   // pos+7 is reserved (zero)
   txn[pos + 8] = static_cast<uint32_t>(arg_idx); // buffer argument index

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -202,20 +202,10 @@ inline void txn_append_blockwrite(std::vector<uint32_t> &txn, uint32_t addr,
 // Append a 12-word address_patch (DDR_PATCH) instruction.
 //
 // The consumer casts this byte range to aie-rt's `XAie_CustomOpHdr` followed by
-// `patch_op_t` (xaie_txn.h), so the word offsets are that struct pair's layout
-// under natural alignment, not a free choice:
-//
-//   XAie_CustomOpHdr { XAie_OpHdr{u8 Op,Col,Row}; u32 Size; }   words 0-1
-//   patch_op_t { op_base{enum,u32}; u32 action; <4 B pad>;      words 2-5
-//                u64 regaddr; u64 argidx; u64 argplus; }        words 6-11
-//
-// regaddr, argidx and argplus therefore each occupy a word pair, low half
-// first. aiebu's stringify_patchop reads `op->argplus` as one u64.
-//
-// `action` sits at word 4 per the struct while the store below targets word 5,
-// the alignment pad. Both are zero for every op emitted here (action 0 =
-// patch), so the disagreement is inert; op_base's size field (word 3) is
-// likewise never populated.
+// `patch_op_t` (xaie_txn.h), so the layout is that struct pair's under natural
+// alignment: an 8-byte header at words 0-1, op_base and action at 2-5, then
+// regaddr, argidx and argplus as u64 word pairs at 6-7, 8-9 and 10-11, low half
+// first.
 inline void txn_append_address_patch(std::vector<uint32_t> &txn, uint32_t addr,
                                      int32_t arg_idx, uint64_t arg_plus) {
   size_t pos = txn.size();
@@ -223,7 +213,7 @@ inline void txn_append_address_patch(std::vector<uint32_t> &txn, uint32_t addr,
   txn[pos + 0] = TXN_OPC_DDR_PATCH;     // opcode
   txn[pos + 1] = 12 * sizeof(uint32_t); // operation size
   // pos+2..4 are reserved (zero)
-  txn[pos + 5] = 0;    // action (0 = patch)
+  txn[pos + 5] = 0; // action; the struct puts it at word 4, inert while zero
   txn[pos + 6] = addr; // register address to patch
   // pos+7 is reserved (zero)
   txn[pos + 8] = static_cast<uint32_t>(arg_idx); // buffer argument index

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -200,8 +200,24 @@ inline void txn_append_blockwrite(std::vector<uint32_t> &txn, uint32_t addr,
 }
 
 // Append a 12-word address_patch (DDR_PATCH) instruction.
+//
+// The consumer casts this byte range to aie-rt's `XAie_CustomOpHdr` followed by
+// `patch_op_t` (xaie_txn.h), so the word offsets are that struct pair's layout
+// under natural alignment, not a free choice:
+//
+//   XAie_CustomOpHdr { XAie_OpHdr{u8 Op,Col,Row}; u32 Size; }   words 0-1
+//   patch_op_t { op_base{enum,u32}; u32 action; <4 B pad>;      words 2-5
+//                u64 regaddr; u64 argidx; u64 argplus; }        words 6-11
+//
+// regaddr, argidx and argplus therefore each occupy a word pair, low half
+// first. aiebu's stringify_patchop reads `op->argplus` as one u64.
+//
+// `action` sits at word 4 per the struct while the store below targets word 5,
+// the alignment pad. Both are zero for every op emitted here (action 0 =
+// patch), so the disagreement is inert; op_base's size field (word 3) is
+// likewise never populated.
 inline void txn_append_address_patch(std::vector<uint32_t> &txn, uint32_t addr,
-                                     int32_t arg_idx, uint32_t arg_plus) {
+                                     int32_t arg_idx, uint64_t arg_plus) {
   size_t pos = txn.size();
   txn.resize(pos + 12, 0);
   txn[pos + 0] = TXN_OPC_DDR_PATCH;     // opcode
@@ -212,8 +228,8 @@ inline void txn_append_address_patch(std::vector<uint32_t> &txn, uint32_t addr,
   // pos+7 is reserved (zero)
   txn[pos + 8] = static_cast<uint32_t>(arg_idx); // buffer argument index
   // pos+9 is reserved (zero)
-  txn[pos + 10] = arg_plus; // byte offset into buffer
-  // pos+11 is reserved (zero)
+  txn[pos + 10] = static_cast<uint32_t>(arg_plus & 0xFFFFFFFFull);
+  txn[pos + 11] = static_cast<uint32_t>(arg_plus >> 32);
 }
 
 // Append a 4-word loadpdi instruction.

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -69,7 +69,8 @@ struct TransactionBinaryOperation {
     uint32_t action;
     uint32_t addr;
     int32_t argIdx;
-    int32_t argPlus;
+    // Words 10-11 of the op; see txn_append_address_patch.
+    uint64_t argPlus;
   };
 
   std::optional<SyncPayload> sync;
@@ -278,7 +279,8 @@ parseTransactionBinary(const std::vector<uint8_t> &data,
         uint32_t action = read32(i + 20);
         uint32_t addr = read32(i + 24);
         int32_t argIdx = static_cast<int32_t>(read32(i + 32));
-        int32_t argPlus = static_cast<int32_t>(read32(i + 40));
+        uint64_t argPlus = static_cast<uint64_t>(read32(i + 40)) |
+                           (static_cast<uint64_t>(read32(i + 44)) << 32);
         TransactionBinaryOperation::AddressPatchPayload payload{
             action, addr, argIdx, argPlus};
         op.addressPatch = payload;
@@ -402,7 +404,8 @@ parseTransactionBinary(const std::vector<uint8_t> &data,
         uint32_t action = read32(i + 20);
         uint32_t addr = read32(i + 24);
         int32_t argIdx = static_cast<int32_t>(read32(i + 32));
-        int32_t argPlus = static_cast<int32_t>(read32(i + 40));
+        uint64_t argPlus = static_cast<uint64_t>(read32(i + 40)) |
+                           (static_cast<uint64_t>(read32(i + 44)) << 32);
         TransactionBinaryOperation::AddressPatchPayload payload{
             action, addr, argIdx, argPlus};
         op.addressPatch = payload;
@@ -530,7 +533,7 @@ emitTransactionOps(OpBuilder &builder, Location fallbackLoc,
       AIEX::NpuAddressPatchOp::create(
           builder, loc, patch.addr,
           /*addr_val=*/mlir::Value(), static_cast<int32_t>(patch.argIdx),
-          AIEX::createConstantI32(builder, loc, patch.argPlus));
+          AIEX::createConstantArgPlus(builder, loc, patch.argPlus));
     } else if (op.cmd.Opcode == 0x6 /*  XAie_TxnOpcode::XAIE_IO_PREEMPT */) {
       auto ui8Ty =
           IntegerType::get(builder.getContext(), 8, IntegerType::Unsigned);

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -853,9 +853,8 @@ std::optional<uint32_t> AIEX::getConstantIntOperand(mlir::Value v) {
   return static_cast<uint32_t>(cst.getZExtValue());
 }
 
-// `address_patch`'s arg_plus is a buffer OFFSET and aie-rt carries it as u64;
-// truncating it to 32 bits mis-addresses any buffer past 4 GiB. Operands whose
-// field is genuinely 32-bit use getConstantIntOperand.
+// Widthwise counterpart of getConstantIntOperand, for fields aie-rt carries as
+// u64: `address_patch`'s arg_plus offset truncates past 4 GiB otherwise.
 std::optional<uint64_t> AIEX::getConstantInt64Operand(mlir::Value v) {
   mlir::APInt cst;
   if (!mlir::matchPattern(v, mlir::m_ConstantInt(&cst)))

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -853,6 +853,16 @@ std::optional<uint32_t> AIEX::getConstantIntOperand(mlir::Value v) {
   return static_cast<uint32_t>(cst.getZExtValue());
 }
 
+// `address_patch`'s arg_plus is a buffer OFFSET and aie-rt carries it as u64;
+// truncating it to 32 bits mis-addresses any buffer past 4 GiB. Operands whose
+// field is genuinely 32-bit use getConstantIntOperand.
+std::optional<uint64_t> AIEX::getConstantInt64Operand(mlir::Value v) {
+  mlir::APInt cst;
+  if (!mlir::matchPattern(v, mlir::m_ConstantInt(&cst)))
+    return std::nullopt;
+  return cst.getZExtValue();
+}
+
 mlir::Value AIEX::createConstantI32(mlir::OpBuilder &builder,
                                     mlir::Location loc, uint32_t value) {
   return arith::ConstantOp::create(

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -854,8 +854,7 @@ std::optional<uint32_t> AIEX::getConstantIntOperand(mlir::Value v) {
   return static_cast<uint32_t>(cst.getZExtValue());
 }
 
-// Widthwise counterpart of getConstantIntOperand, for fields aie-rt carries as
-// u64: `address_patch`'s arg_plus offset truncates past 4 GiB otherwise.
+// Widthwise counterpart of getConstantIntOperand; see createConstantArgPlus.
 std::optional<uint64_t> AIEX::getConstantInt64Operand(mlir::Value v) {
   mlir::APInt cst;
   if (!mlir::matchPattern(v, mlir::m_ConstantInt(&cst)))

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/TypeSize.h"
 
 #include <cstdint>
+#include <limits>
 #include <numeric>
 
 using namespace mlir;
@@ -866,6 +867,16 @@ mlir::Value AIEX::createConstantI32(mlir::OpBuilder &builder,
                                     mlir::Location loc, uint32_t value) {
   return arith::ConstantOp::create(
       builder, loc, builder.getI32IntegerAttr(static_cast<int32_t>(value)));
+}
+
+mlir::Value AIEX::createConstantArgPlus(mlir::OpBuilder &builder,
+                                        mlir::Location loc, uint64_t value) {
+  if (value <= std::numeric_limits<uint32_t>::max())
+    return createConstantI32(builder, loc, static_cast<uint32_t>(value));
+  return arith::ConstantOp::create(
+      builder, loc,
+      IntegerAttr::get(builder.getIntegerType(64),
+                       static_cast<int64_t>(value)));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/AIEX/Transforms/AIEResolveAddressPatchBuffers.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEResolveAddressPatchBuffers.cpp
@@ -55,13 +55,22 @@ struct ResolveBufferOperand : OpRewritePattern<NpuAddressPatchOp> {
 
     Value argPlus = op.getArgPlus();
     if (traced->offsetInBytes != 0) {
-      std::optional<uint32_t> base = getConstantIntOperand(argPlus);
-      if (base) {
-        argPlus = createConstantI32(rewriter, op.getLoc(),
-                                    *base + traced->offsetInBytes);
+      // Sum at 64 bits; see createConstantArgPlus for the width choice.
+      if (std::optional<uint64_t> base = getConstantInt64Operand(argPlus)) {
+        argPlus = createConstantArgPlus(
+            rewriter, op.getLoc(),
+            *base + static_cast<uint64_t>(traced->offsetInBytes));
       } else {
-        Value shift =
-            createConstantI32(rewriter, op.getLoc(), traced->offsetInBytes);
+        // Widen the runtime value only when the offset outgrows its width.
+        Type ty = argPlus.getType();
+        if (ty.getIntOrFloatBitWidth() < 64 &&
+            traced->offsetInBytes > std::numeric_limits<uint32_t>::max()) {
+          ty = rewriter.getIntegerType(64);
+          argPlus = arith::ExtUIOp::create(rewriter, op.getLoc(), ty, argPlus);
+        }
+        Value shift = arith::ConstantOp::create(
+            rewriter, op.getLoc(),
+            IntegerAttr::get(ty, static_cast<int64_t>(traced->offsetInBytes)));
         argPlus = arith::AddIOp::create(rewriter, op.getLoc(), argPlus, shift);
       }
     }

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -113,9 +113,7 @@ Value buildArgPlusValue(OpBuilder &builder, Location loc,
       assert(oc && sc && "allConst already verified these are constant");
       bytes += (*oc) * (*sc) * elemWidthBytes;
     }
-    // aie-rt carries argplus as u64, so an offset past UINT32_MAX needs an i64
-    // constant. Reachable only for a constant offset; the runtime path below
-    // stays i32.
+    // Reachable only for a constant offset; the runtime path below stays i32.
     if (bytes > std::numeric_limits<uint32_t>::max() || bytes < 0)
       return arith::ConstantOp::create(
           builder, loc, IntegerAttr::get(builder.getIntegerType(64), bytes));

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -14,6 +14,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
+#include <limits>
+
 using namespace mlir;
 
 namespace xilinx::AIEX {
@@ -111,6 +113,16 @@ Value buildArgPlusValue(OpBuilder &builder, Location loc,
       assert(oc && sc && "allConst already verified these are constant");
       bytes += (*oc) * (*sc) * elemWidthBytes;
     }
+    // aie-rt carries argplus as u64 (patch_op_t::argplus) and the TXN op has a
+    // high word for it, so an offset past UINT32_MAX needs an i64 constant.
+    //
+    // Constant path only: the runtime path below is i32 throughout, since a
+    // value not known here cannot be range-checked here. The static TXN target
+    // refuses a non-constant arg_plus outright, so a dynamic sequence on the
+    // C++ TXN builder is the one path that truncates.
+    if (bytes > std::numeric_limits<uint32_t>::max() || bytes < 0)
+      return arith::ConstantOp::create(
+          builder, loc, IntegerAttr::get(builder.getIntegerType(64), bytes));
     return arith::ConstantOp::create(builder, loc,
                                      IntegerAttr::get(i32ty, bytes));
   }

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -113,13 +113,9 @@ Value buildArgPlusValue(OpBuilder &builder, Location loc,
       assert(oc && sc && "allConst already verified these are constant");
       bytes += (*oc) * (*sc) * elemWidthBytes;
     }
-    // aie-rt carries argplus as u64 (patch_op_t::argplus) and the TXN op has a
-    // high word for it, so an offset past UINT32_MAX needs an i64 constant.
-    //
-    // Constant path only: the runtime path below is i32 throughout, since a
-    // value not known here cannot be range-checked here. The static TXN target
-    // refuses a non-constant arg_plus outright, so a dynamic sequence on the
-    // C++ TXN builder is the one path that truncates.
+    // aie-rt carries argplus as u64, so an offset past UINT32_MAX needs an i64
+    // constant. Reachable only for a constant offset; the runtime path below
+    // stays i32.
     if (bytes > std::numeric_limits<uint32_t>::max() || bytes < 0)
       return arith::ConstantOp::create(
           builder, loc, IntegerAttr::get(builder.getIntegerType(64), bytes));

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -134,8 +134,8 @@ LogicalResult appendAddressPatch(std::vector<uint32_t> &instructions,
                           "register address (addr_val) to a static TXN binary; "
                           "the runtime-bd_id pool path targets the C++ TXN "
                           "target only");
-  std::optional<uint32_t> argPlus =
-      AIEX::getConstantIntOperand(op.getArgPlus());
+  std::optional<uint64_t> argPlus =
+      AIEX::getConstantInt64Operand(op.getArgPlus());
   if (!argPlus)
     return op.emitOpError("Cannot translate address_patch with non-constant "
                           "arg_plus to a static TXN binary");
@@ -144,7 +144,7 @@ LogicalResult appendAddressPatch(std::vector<uint32_t> &instructions,
     return op.emitOpError("address_patch still names its host buffer by SSA "
                           "value; run -aie-resolve-address-patch-buffers");
   uint32_t argIdx = *argIdxAttr;
-  uint32_t patchedArgPlus = *argPlus;
+  uint64_t patchedArgPlus = *argPlus;
   if (foldDDRAddrOffset && argIdx >= kNumFirmwareTranslatedArgs)
     patchedArgPlus += kDDRAIEAddrOffset;
   aie_runtime::txn_append_address_patch(instructions, op.getAddr(), argIdx,

--- a/test/Targets/NPU/npu_address_patch_arg_plus_64bit.mlir
+++ b/test/Targets/NPU/npu_address_patch_arg_plus_64bit.mlir
@@ -1,0 +1,64 @@
+//===- npu_address_patch_arg_plus_64bit.mlir ------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// arg_plus is a 64-bit field on the wire: aie-rt's patch_op_t declares
+// `u64 argplus`, and the 12-word DDR_PATCH op carries it in words 10 AND 11,
+// low half first, exactly as regaddr and argidx occupy 6-7 and 8-9. These
+// checks pin both halves.
+//
+// Each check anchors on the register address (word 6, 0x12340 = 74560) and
+// counts forward: w7 pad, w8 arg_idx, w9 pad, then the two arg_plus halves.
+// arg_idx is 0 -- inside the firmware-translated set -- so no DDR aperture
+// offset is folded in and the checked words are the offset itself.
+
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false %s | FileCheck %s
+
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence(%a0: memref<8xi32>) {
+      // Largest offset that still fits the low word: high word stays zero.
+      // CHECK:      00012340
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: FFFFFFFF
+      // CHECK-NEXT: 00000000
+      %max32 = arith.constant 4294967295 : i64
+      aiex.npu.address_patch(%max32 : i64) {addr = 74560 : ui32, arg_idx = 0 : i32}
+
+      // 2^32 exactly: the low word is zero and the whole offset sits high.
+      // CHECK:      00012340
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000001
+      %four_gib = arith.constant 4294967296 : i64
+      aiex.npu.address_patch(%four_gib : i64) {addr = 74560 : ui32, arg_idx = 0 : i32}
+
+      // 8 GiB + 0x100: both halves non-zero, so neither is being dropped.
+      // CHECK:      00012340
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000100
+      // CHECK-NEXT: 00000002
+      %eight_gib = arith.constant 8589934848 : i64
+      aiex.npu.address_patch(%eight_gib : i64) {addr = 74560 : ui32, arg_idx = 0 : i32}
+
+      // An i32 arg_plus is accepted and fills the low word, high word zero.
+      // CHECK:      00012340
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000000
+      // CHECK-NEXT: 00000100
+      // CHECK-NEXT: 00000000
+      %small = arith.constant 256 : i32
+      aiex.npu.address_patch(%small : i32) {addr = 74560 : ui32, arg_idx = 0 : i32}
+    }
+  }
+}

--- a/test/dialect/AIEX/resolve_address_patch_buffers_64bit.mlir
+++ b/test/dialect/AIEX/resolve_address_patch_buffers_64bit.mlir
@@ -1,0 +1,64 @@
+//===- resolve_address_patch_buffers_64bit.mlir ----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Resolving a buffer adds its traced byte offset to arg_plus. aie-rt carries
+// that field as u64, so the sum is computed at 64 bits and narrowed back only
+// when it fits, and a runtime arg_plus is widened to match its addend.
+
+// RUN: aie-opt %s -aie-resolve-address-patch-buffers --split-input-file | FileCheck %s
+
+// A sum that fits keeps the i32 form.
+// CHECK-LABEL: @fits
+// CHECK: %[[C:.*]] = arith.constant 32 : i32
+// CHECK: aiex.npu.address_patch(%[[C]] : i32) {addr = 119300 : ui32, arg_idx = 0 : i32}
+module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence @fits(%arg0: memref<8xi32>) {
+      %plus = arith.constant 16 : i32
+      %view = memref.subview %arg0[4][4][1]
+          : memref<8xi32> to memref<4xi32, strided<[1], offset: 4>>
+      aiex.npu.address_patch(%plus : i32) buffer %view
+          : memref<4xi32, strided<[1], offset: 4>> {addr = 119300 : ui32}
+    }
+  }
+}
+
+// -----
+
+// A base already past 32 bits stays i64 across the addition.
+// CHECK-LABEL: @wide
+// CHECK: %[[C:.*]] = arith.constant 8589934608 : i64
+// CHECK: aiex.npu.address_patch(%[[C]] : i64) {addr = 119300 : ui32, arg_idx = 0 : i32}
+module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence @wide(%arg0: memref<8xi32>) {
+      %plus = arith.constant 8589934592 : i64
+      %view = memref.subview %arg0[4][4][1]
+          : memref<8xi32> to memref<4xi32, strided<[1], offset: 4>>
+      aiex.npu.address_patch(%plus : i64) buffer %view
+          : memref<4xi32, strided<[1], offset: 4>> {addr = 119300 : ui32}
+    }
+  }
+}
+
+// -----
+
+// A runtime i64 arg_plus takes an i64 addend, so the arith.addi is well-typed.
+// CHECK-LABEL: @runtime_i64
+// CHECK: %[[S:.*]] = arith.constant 16 : i64
+// CHECK: %[[A:.*]] = arith.addi %{{.*}}, %[[S]] : i64
+// CHECK: aiex.npu.address_patch(%[[A]] : i64) {addr = 119300 : ui32, arg_idx = 0 : i32}
+module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence @runtime_i64(%arg0: memref<8xi32>, %plus: i64) {
+      %view = memref.subview %arg0[4][4][1]
+          : memref<8xi32> to memref<4xi32, strided<[1], offset: 4>>
+      aiex.npu.address_patch(%plus : i64) buffer %view
+          : memref<4xi32, strided<[1], offset: 4>> {addr = 119300 : ui32}
+    }
+  }
+}

--- a/test/txn2mlir/roundtrip_address_patch_arg_plus_64bit.mlir
+++ b/test/txn2mlir/roundtrip_address_patch_arg_plus_64bit.mlir
@@ -1,0 +1,27 @@
+//===- roundtrip_address_patch_arg_plus_64bit.mlir -------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// arg_plus occupies words 10-11 of the DDR_PATCH op, so re-import has to read
+// both to round-trip an offset past 4 GiB. An offset that fits stays i32.
+
+// RUN: aie-translate -aie-npu-to-binary %s -o %t.cfg
+// RUN: %python txn2mlir.py -f %t.cfg | FileCheck %s
+
+// CHECK: %[[SMALL:.*]] = arith.constant 256 : i32
+// CHECK: aiex.npu.address_patch(%[[SMALL]] : i32) {addr = 74560 : ui32, arg_idx = 0 : i32}
+// CHECK: %[[BIG:.*]] = arith.constant 8589934848 : i64
+// CHECK: aiex.npu.address_patch(%[[BIG]] : i64) {addr = 74560 : ui32, arg_idx = 0 : i32}
+module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence() {
+      %small = arith.constant 256 : i32
+      aiex.npu.address_patch(%small : i32) {addr = 74560 : ui32, arg_idx = 0 : i32}
+      %big = arith.constant 8589934848 : i64
+      aiex.npu.address_patch(%big : i64) {addr = 74560 : ui32, arg_idx = 0 : i32}
+    }
+  }
+}


### PR DESCRIPTION
## Description

`aiex.npu.address_patch` declares `arg_plus` as `I32`, but the field is 64-bit on
the wire. The consumer casts the 12-word DDR_PATCH op to aie-rt's
`XAie_CustomOpHdr` followed by `patch_op_t`, whose `argplus` is a `u64` at words
10-11 -- the same word-pair form as `regaddr` at 6-7 and `argidx` at 8-9. Word 11
was commented "reserved" and hardcoded to zero.

So a buffer offset at or past 2^32 was truncated and the BD patched with a wrong
address, with no diagnostic at any layer. I hit this on a 48-layer decode design
with a 9.8 GB arena: every buffer below 2^32 was written, and every buffer above
it read back exactly zero. Bisecting by layer count brackets the boundary to
78 MB below and 82 MB above 4,294,967,296.

The op now takes `AnyTypeOf<[I32, I64]>`, `getConstantInt64Operand` matches
without narrowing, and `txn_append_address_patch` writes both halves.
`buildArgPlusValue` widens only when the offset does not fit, so a design that
fits in 32 bits emits the identical `i32` constant and no existing IR or test
moves. The new test pins both words at `0xFFFFFFFF`, 2^32 and 8 GiB + 0x100,
plus an `i32` operand for the narrow path.

Buffer resolution and TXN re-import narrowed the widened value back to 32 bits, so
`createConstantArgPlus` now picks the narrowest width that holds the offset on
every path; tests cover the resolve-buffers and round-trip paths.

## Known limitations

`buildArgPlusValue`'s runtime path is `i32` throughout. A value not known at
build time cannot be range-checked there, and the static TXN target already
refuses a non-constant `arg_plus`, so a dynamic sequence on the C++ TXN builder
is the one path that still truncates.

Deriving the word offsets also exposes that `action` is written to word 5 where
the struct puts it at word 4, the alignment pad. Both are zero for every op
emitted here, so it is inert, and I left it alone.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))

On clang-tidy: this change adds no findings -- the same 10 `misc-static-assert`
hits appear on unpatched `main` in my setup (9 in `AIEXDialect.cpp`, 1 in
`BdLowering.cpp`), all on `assert()` calls the change does not touch, so I could
not get a clean local run to tick that box against.

