### PR TITLE
[python] Skip a kernel compile per kernel_dir, not per ExternalFunction [MED]

### DIFF
--- a/python/iron/kernel.py
+++ b/python/iron/kernel.py
@@ -451,7 +451,6 @@ class ExternalFunction(Kernel):
         self._compile_flags = compile_flags if compile_flags is not None else []
         self._use_chess = use_chess
         self._compiled = False
-        # Which kernel_dir that compile wrote into; see _compiled_into().
         self._compiled_dir = None
         self._cached_digest: str | None = None
 

--- a/python/iron/kernel.py
+++ b/python/iron/kernel.py
@@ -451,6 +451,8 @@ class ExternalFunction(Kernel):
         self._compile_flags = compile_flags if compile_flags is not None else []
         self._use_chess = use_chess
         self._compiled = False
+        # Which kernel_dir that compile wrote into; see _compiled_into().
+        self._compiled_dir = None
         self._cached_digest: str | None = None
 
         # Two same-name EFs with default object_file_name would collide on the

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -630,6 +630,23 @@ def _copy_source(dest: str, src: str) -> None:
         shutil.copy2(src, tmp)
 
 
+def _compiled_into(func, kernel_dir) -> bool:
+    """Report whether ``func``'s object was already built into this ``kernel_dir``.
+
+    ``_compiled`` alone cannot answer it.  One ExternalFunction can be compiled
+    by several designs -- the module-scope kernel of
+    ``programming_examples/algorithms/README.md`` is the documented shape -- and
+    each design compiles into its own ``kernel_dir`` with its own ``-I`` paths.
+    A flag that only remembers *whether* a compile happened makes every design
+    after the first skip its own, leaving that design's directory with no object
+    for aiecc's linker to find.
+    """
+    compiled_dir = getattr(func, "_compiled_dir", None)
+    if not getattr(func, "_compiled", False) or compiled_dir is None:
+        return False
+    return os.path.abspath(compiled_dir) == os.path.abspath(kernel_dir)
+
+
 def compile_external_kernels(funcs, kernel_dir, target_arch, include_dirs=None):
     """Compile every ExternalFunction in ``funcs`` into ``kernel_dir``.
 
@@ -652,7 +669,7 @@ def compile_external_kernels(funcs, kernel_dir, target_arch, include_dirs=None):
     without the intrinsics PCH), so the bound is cores rather than memory on an
     ordinary box.  Set AIE_KERNEL_COMPILE_JOBS to override.
     """
-    pending = [f for f in funcs if not f._compiled]
+    pending = [f for f in funcs if not _compiled_into(f, kernel_dir)]
     if not pending:
         return
 
@@ -707,8 +724,8 @@ def compile_external_kernel(func, kernel_dir, target_arch, include_dirs=None):
         include_dirs: Design-wide include directories appended after the
             ExternalFunction's own include directories.
     """
-    # Skip if already compiled in this session.
-    if func._compiled:
+    # Skip only if this session already built it into this same directory.
+    if _compiled_into(func, kernel_dir):
         return
 
     # inline + symbol_prefix is unsupported: the MLIR func.call uses the
@@ -799,6 +816,7 @@ def compile_external_kernel(func, kernel_dir, target_arch, include_dirs=None):
         _rename_symbol_in_object(output_file, original, prefixed)
 
     func._compiled = True
+    func._compiled_dir = os.path.abspath(kernel_dir)
 
 
 def _cleanup_failed_compilation(cache_dir):

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -633,13 +633,9 @@ def _copy_source(dest: str, src: str) -> None:
 def _compiled_into(func, kernel_dir) -> bool:
     """Report whether ``func``'s object was already built into this ``kernel_dir``.
 
-    ``_compiled`` alone cannot answer it.  One ExternalFunction can be compiled
-    by several designs -- the module-scope kernel of
-    ``programming_examples/algorithms/README.md`` is the documented shape -- and
-    each design compiles into its own ``kernel_dir`` with its own ``-I`` paths.
-    A flag that only remembers *whether* a compile happened makes every design
-    after the first skip its own, leaving that design's directory with no object
-    for aiecc's linker to find.
+    One ExternalFunction can be compiled by several designs, each into its own
+    directory, so ``_compiled`` on its own would deny every design after the
+    first an object.
     """
     compiled_dir = getattr(func, "_compiled_dir", None)
     if not getattr(func, "_compiled", False) or compiled_dir is None:
@@ -724,7 +720,6 @@ def compile_external_kernel(func, kernel_dir, target_arch, include_dirs=None):
         include_dirs: Design-wide include directories appended after the
             ExternalFunction's own include directories.
     """
-    # Skip only if this session already built it into this same directory.
     if _compiled_into(func, kernel_dir):
         return
 

--- a/test/python/npu/test_jit_utils.py
+++ b/test/python/npu/test_jit_utils.py
@@ -236,16 +236,25 @@ def test_compile_external_kernel_marks_compiled(npu_target_arch):
         assert func._compiled
 
 
-def test_compile_external_kernel_skip_if_already_compiled(npu_target_arch):
-    """compile_external_kernel must be a no-op when func._compiled is already True."""
+def test_compile_external_kernel_skip_is_per_kernel_dir(npu_target_arch):
+    """The skip covers the directory already built into, not the function.
+
+    Skipping on the flag alone denies a second design its own object, so the
+    same func compiled into a fresh directory must compile again.
+    """
     func = ExternalFunction(
         "add_one",
         source_string='extern "C" void add_one() {}',
     )
-    func._compiled = True
     with tempfile.TemporaryDirectory() as kernel_dir:
+        func._compiled = True
+        func._compiled_dir = kernel_dir
         compile_external_kernel(func, kernel_dir, target_arch=npu_target_arch)
         assert not os.path.exists(os.path.join(kernel_dir, "add_one.o"))
+
+    with tempfile.TemporaryDirectory() as other_dir:
+        compile_external_kernel(func, other_dir, target_arch=npu_target_arch)
+        assert os.path.exists(os.path.join(other_dir, "add_one.o"))
 
 
 def test_compile_external_kernel_skip_if_object_file_exists(npu_target_arch):

--- a/test/python/npu/test_jit_utils.py
+++ b/test/python/npu/test_jit_utils.py
@@ -237,11 +237,7 @@ def test_compile_external_kernel_marks_compiled(npu_target_arch):
 
 
 def test_compile_external_kernel_skip_is_per_kernel_dir(npu_target_arch):
-    """The skip covers the directory already built into, not the function.
-
-    Skipping on the flag alone denies a second design its own object, so the
-    same func compiled into a fresh directory must compile again.
-    """
+    """The skip covers the directory already built into, not the function."""
     func = ExternalFunction(
         "add_one",
         source_string='extern "C" void add_one() {}',

--- a/test/python/test_kernel_source_materialization.py
+++ b/test/python/test_kernel_source_materialization.py
@@ -152,6 +152,34 @@ def test_source_string_design_include_dirs_follow_kernel_dirs(tmp_path, stub_com
     assert func._include_dirs == ["kernel/include"]
 
 
+def test_reused_kernel_compiles_into_each_design_directory(stub_compiler, tmp_path):
+    """One ExternalFunction compiled by two designs must land in both directories.
+
+    A kernel built at module scope outlives the design that compiled it, so the
+    record of "already compiled" has to name the directory it wrote into.  Keyed
+    on a bare flag, the second design skips its own compile and its kernel_dir
+    holds no object for aiecc's linker -- and never sees its own -I paths.
+    """
+    src = tmp_path / "k.cc"
+    src.write_text(SOURCE)
+    func = _stub_func("k", src)
+    dir_a = tmp_path / "design_a"
+    dir_a.mkdir()
+    dir_b = tmp_path / "design_b"
+    dir_b.mkdir()
+
+    compile_external_kernels(
+        [func], str(dir_a), "aie2p", include_dirs=[tmp_path / "inc_a"]
+    )
+    compile_external_kernels(
+        [func], str(dir_b), "aie2p", include_dirs=[tmp_path / "inc_b"]
+    )
+
+    assert (dir_a / "k.o").exists()
+    assert (dir_b / "k.o").exists()
+    assert stub_compiler[1]["include_dirs"][-1] == tmp_path / "inc_b"
+
+
 def test_materialized_source_keeps_umask_permissions(tmp_path):
     """Staging through mkstemp must not narrow the source to 0600."""
     written = tmp_path / "from_string.cc"

--- a/test/python/test_kernel_source_materialization.py
+++ b/test/python/test_kernel_source_materialization.py
@@ -153,13 +153,7 @@ def test_source_string_design_include_dirs_follow_kernel_dirs(tmp_path, stub_com
 
 
 def test_reused_kernel_compiles_into_each_design_directory(stub_compiler, tmp_path):
-    """One ExternalFunction compiled by two designs must land in both directories.
-
-    A kernel built at module scope outlives the design that compiled it, so the
-    record of "already compiled" has to name the directory it wrote into.  Keyed
-    on a bare flag, the second design skips its own compile and its kernel_dir
-    holds no object for aiecc's linker -- and never sees its own -I paths.
-    """
+    """One ExternalFunction compiled by two designs must land in both directories."""
     src = tmp_path / "k.cc"
     src.write_text(SOURCE)
     func = _stub_func("k", src)


### PR DESCRIPTION
## Description

Based on #3721 and targets its branch, because it is that PR's new argument this bug
makes inert.

`func._compiled` is a per-instance latch: set in `compile_external_kernel`,
initialised `False` only in `ExternalFunction.__init__`, never reset. It records
*whether* a kernel was compiled, not *where*. An `ExternalFunction` built at module
scope -- the shape documented in `programming_examples/algorithms/README.md`, where
`my_kernel = ExternalFunction(...)` is then handed to `iron.jit(transform)(...)` --
outlives the design that compiles it, so every later design in the process skips its
own compile and its `kernel_dir` is left with no object for aiecc to link.

With the compiler stubbed and one kernel compiled by two designs:

```
design A -I: [['/tmp/x', '/tmp/x/headers_A']]  objects in A: ['my_kernel.cc', 'my_kernel.o']
design B -I: []                                objects in B: []
```

That reproduces on `main` too, so the latch predates this branch. What this branch
changes is the stakes: once `include_paths` decides which headers a kernel resolves, a
reused kernel keeps whichever design compiled it first, and the new argument silently
does nothing.

The fix keys the skip on the directory. `_compiled_dir` records the `kernel_dir` the
object was written into, and `_compiled_into()` skips only a repeat of that same
directory. A func marked compiled with no recorded directory counts as not built here,
so there is no state meaning "compiled, location unknown".

Tests: `test_reused_kernel_compiles_into_each_design_directory` fails on this branch
without the fix (design B's `kernel_dir` has no `.o`) and passes with it.
`test_compile_external_kernel_skip_if_already_compiled` asserted the old behaviour, so
it becomes `..._skip_is_per_kernel_dir` and covers both halves: the same directory
skips, a fresh one compiles.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [ ] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy)) — no C++ touched
