### PR TITLE
aie_kernels: set the rounding mode in two kernels whose siblings already do [MED]

### DIFF
--- a/aie_kernels/aie2p/softmax.cc
+++ b/aie_kernels/aie2p/softmax.cc
@@ -18,6 +18,7 @@ void softmax_simple_bf16(bfloat16 *restrict input_vector,
                          bfloat16 *restrict output_vector,
                          const int32_t vector_size) {
   event0();
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
 
   // VJUNG: We do 3 passes on the vector:
   // 1. Find the max value scaled by log2e in the vector

--- a/aie_kernels/generic/mv.cc
+++ b/aie_kernels/generic/mv.cc
@@ -25,6 +25,7 @@
 
 void matvec_scalar(uint32_t m, uint32_t k, const bfloat16 *__restrict a,
                    const bfloat16 *__restrict b, bfloat16 *__restrict c) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
   for (uint32_t row = 0; row < m; row++) {
     float acc = 0;
     for (uint32_t i = 0; i < k; i++) {


### PR DESCRIPTION
## Description

`softmax_simple_bf16` and `matvec_scalar` convert to `bfloat16` without setting
the rounding register. In both cases the neighbouring function in the same file
already sets it — `partial_softmax_alias_bf16` in `softmax.cc`,
`matvec_vectorized` in `mv.cc` — so this is a consistency fix within each file.

`aie_api` never writes the register itself, so the mode is whatever the core was
last left in; its documented reset value is truncation, which biases every
conversion toward zero rather than round-to-nearest-even.

One question for maintainers rather than something this PR changes: the same
grep says 17 kernels under `aie_kernels/` convert to `bfloat16` and never set the
mode, against 7 that do. If the intended contract is that a kernel sets it, most
are missing it; if the intent is that the runtime establishes it once, then the 7
are redundant and these two are fine as they were. I picked the two where the
file contradicts itself, which is true either way.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
