### PR TITLE
[python] ExternalFunction: key the digest on include content, not directory mtime [HIGH]

### DIFF
--- a/python/iron/kernel.py
+++ b/python/iron/kernel.py
@@ -83,6 +83,32 @@ def _maybe_collapse_to_match(arg, expected_ty):
     return memref.collapse_shape(exp_mr, arg, reassociation)
 
 
+_DIGEST_CHUNK = 1 << 20  # streamed read bound for _hash_dir_contents
+
+
+def _hash_dir_contents(d: str) -> str:
+    """Recursive content digest of every regular file under ``d``.
+
+    Replaces a directory mtime, which moves on create/delete/rename but not
+    on an in-place rewrite (e.g. an editor that truncates-and-rewrites a
+    header) -- the common case a cache key needs to catch.
+    """
+    h = hashlib.sha256()
+    try:
+        paths = sorted(p for p in Path(d).rglob("*") if p.is_file())
+    except OSError:
+        return "<missing>"
+    for p in paths:
+        h.update(str(p.relative_to(d)).encode())
+        try:
+            with open(p, "rb") as fh:
+                while chunk := fh.read(_DIGEST_CHUNK):
+                    h.update(chunk)
+        except OSError as exc:
+            h.update(f"<unreadable:{type(exc).__name__}>".encode())
+    return h.hexdigest()
+
+
 class BaseKernel(Resolvable):
     """Base class for AIE core functions that resolve to a func.func declaration.
 
@@ -528,20 +554,23 @@ class ExternalFunction(Kernel):
         if self._cached_digest is not None:
             return self._cached_digest
 
-        from pathlib import Path as _Path
-
-        include_dir_mtimes = []
-        for d in sorted(self._include_dirs):
-            try:
-                mtime = str(_Path(d).stat().st_mtime)
-            except (FileNotFoundError, OSError):
-                mtime = "missing"
-            include_dir_mtimes.append(f"{d}:{mtime}")
+        include_dirs = list(self._include_dirs)
+        if self._source_file is not None:
+            # Mirrors compile_external_kernel()'s own src_dir append: a
+            # same-directory sibling #include (e.g. aie_kernels/aie2p/mm.cc
+            # including zero.cc) is otherwise never in any hashed directory
+            # unless the caller separately declares it via include_dirs=.
+            src_dir = str(Path(self._source_file).resolve().parent)
+            if src_dir not in include_dirs:
+                include_dirs.append(src_dir)
+        include_dir_hashes = [
+            f"{d}:{_hash_dir_contents(d)}" for d in sorted(include_dirs)
+        ]
 
         parts = [
             self._name,
             str(self._arg_types),
-            str(include_dir_mtimes),
+            str(include_dir_hashes),
             str(sorted(self._compile_flags)),
             # Toolchain choice (peano vs chess) changes the resulting .o
             # contents even when name + arg_types + flags + source are

--- a/test/python/test_kernels_memoization.py
+++ b/test/python/test_kernels_memoization.py
@@ -331,3 +331,86 @@ def test_kernels_mm_object_file_name_is_order_independent():
     reuses by name is identical regardless of registration order."""
     ef = kernels.mm(dim_m=64, dim_k=64, dim_n=32, c_col_maj=True)
     assert ef._object_file_name == f"matmul_i16_i16_{ef._symbol_prefix}.o"
+
+
+# ---------------------------------------------------------------------------
+# _content_digest must react to included source, not just the top-level
+# file, and to the source file's OWN directory even when the caller never
+# passes it via include_dirs= — the aie_kernels/aie2p/mm.cc + zero.cc shape
+# (a quoted #include of a same-directory sibling). A directory mtime misses
+# an in-place rewrite (an editor's truncate-and-rewrite save, cp -p, git
+# checkout); content hashing does not.
+# ---------------------------------------------------------------------------
+
+
+def test_content_digest_changes_on_declared_include_header_edit(tmp_path):
+    """Editing a header under a declared include_dirs= entry moves the digest."""
+    inc_dir = tmp_path / "inc"
+    inc_dir.mkdir()
+    header = inc_dir / "declared.h"
+    header.write_text("#define DIGEST_TEST_VAL 1\n")
+    src = tmp_path / "main_declared.cc"
+    src.write_text(
+        '#include "declared.h"\n'
+        'extern "C" int digest_test_declared() { return DIGEST_TEST_VAL; }\n'
+    )
+
+    def make():
+        return ExternalFunction(
+            name="digest_test_declared_fn",
+            source_file=str(src),
+            include_dirs=[str(inc_dir)],
+            arg_types=[],
+        )._content_digest()
+
+    before = make()
+    header.write_text("#define DIGEST_TEST_VAL 2\n")  # in-place rewrite, same file
+    after = make()
+    assert before != after
+
+
+def test_content_digest_changes_on_undeclared_sibling_edit(tmp_path):
+    """A sibling reached only via the source file's own directory -- no
+    matching include_dirs= entry -- still moves the digest when edited."""
+    sibling = tmp_path / "sibling.cc"
+    sibling.write_text("static int digest_test_sibling_val() { return 1; }\n")
+    src = tmp_path / "main_sibling.cc"
+    src.write_text(
+        '#include "sibling.cc"\n'
+        'extern "C" int digest_test_sibling() { return digest_test_sibling_val(); }\n'
+    )
+
+    def make():
+        return ExternalFunction(
+            name="digest_test_sibling_fn",
+            source_file=str(src),
+            arg_types=[],
+        )._content_digest()
+
+    before = make()
+    sibling.write_text("static int digest_test_sibling_val() { return 2; }\n")
+    after = make()
+    assert before != after
+
+
+def test_content_digest_stable_when_nothing_changes(tmp_path):
+    """Two EFs over byte-identical source + includes get the same digest --
+    the control case: the digest must not move on its own."""
+    inc_dir = tmp_path / "inc"
+    inc_dir.mkdir()
+    (inc_dir / "declared.h").write_text("#define DIGEST_TEST_STABLE 1\n")
+    src = tmp_path / "main_stable.cc"
+    src.write_text(
+        '#include "declared.h"\n'
+        'extern "C" int digest_test_stable() { return DIGEST_TEST_STABLE; }\n'
+    )
+
+    def make():
+        return ExternalFunction(
+            name="digest_test_stable_fn",
+            source_file=str(src),
+            include_dirs=[str(inc_dir)],
+            arg_types=[],
+        )._content_digest()
+
+    assert make() == make()


### PR DESCRIPTION
## Description

`ExternalFunction`'s memoization digest keyed each include directory on the
directory's own mtime. That mtime moves when an entry is created, deleted or
renamed, but not when a file under it is rewritten in place — which is the common
case a cache key has to catch, and what an editor that truncates-and-rewrites a
header does. An edited header therefore left the digest unchanged and the cached
kernel object was reused against stale source.

The digest now hashes the contents of every regular file under each include
directory, read in chunks so a large header set does not sit in memory. It also
adds the source file's own directory, which `compile_external_kernel()` already
appends to the include path — so a same-directory sibling include (for example
`aie_kernels/aie2p/mm.cc` including `zero.cc`) was previously covered by no
hashed directory at all unless the caller declared it separately.

Unreadable or missing paths hash to a marker rather than raising, so a permission
error degrades to a cache miss instead of failing the build.

`test/python/test_kernels_memoization.py` covers the in-place rewrite, the
sibling-include case, and that an unchanged tree still hits.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
