### PR TITLE
ci: stop saving ccache from PRs and re-running what the merge queue ran [MED]

### DIFF
--- a/.github/actions/setup_ccache/action.yml
+++ b/.github/actions/setup_ccache/action.yml
@@ -31,6 +31,11 @@ runs:
         key: ${{ inputs.MATRIX_OS }}-${{ inputs.MATRIX_ARCH }}-${{ inputs.EXTRA_KEY }}
         max-size: "1G"
         verbose: 2
+        # Restore always; save only off a PR. A cache written on
+        # refs/pull/N/merge is readable by that PR alone, so saving from a PR
+        # spends the repo-wide 10 GB budget on entries no other PR can use, and
+        # evicts the refs/heads/main entries that every PR does restore from.
+        save: ${{ github.event_name != 'pull_request' }}
 
     - name: Configure ccache dir on host ubuntu
       if: contains(inputs.MATRIX_OS, 'ubuntu')

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -7,9 +7,8 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
+  # No push trigger for main: the merge queue runs this workflow on the
+  # commit that lands, so a push run repeats it.
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -101,6 +101,8 @@ jobs:
           # run, and only the newest is ever restored.
           key: ${{ matrix.build_type }}-${{ runner.os }}-${{ matrix.ubuntu_version }}-${{ matrix.python_version }}
           max-size: 1G
+          # Restore always, save only off a PR -- see .github/actions/setup_ccache.
+          save: ${{ github.event_name != 'pull_request' }}
 
       # ccache defaults to comparing the compiler by mtime. GitHub-hosted
       # runners reinstall the compiler every run with a fresh mtime, so every

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -8,9 +8,8 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
+  # No push trigger for main: the merge queue runs this workflow on the
+  # commit that lands, so a push run repeats it.
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/utils/build-mlir-aie-from-wheels.sh
+++ b/utils/build-mlir-aie-from-wheels.sh
@@ -143,6 +143,11 @@ fi
 if [ -x "$(command -v ccache)" ]; then
   CMAKE_CONFIGS+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache)
   CMAKE_CONFIGS+=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+  echo "ccache: using $(command -v ccache)"
+else
+  # Say so. A runner missing ccache recompiles every object on every build and
+  # nothing in the log distinguishes that from a cold cache.
+  echo "ccache: not found on PATH, building without a compiler cache"
 fi
 
 # Do not use LLVM_PARALLEL_{COMPILE,LINK}_JOBS: HandleLLVMOptions is included


### PR DESCRIPTION
## Description

Three cases where CI pays for work it already did, or hides why it was slow.

**ccache saves from pull requests.** A cache written on `refs/pull/N/merge` is
readable only by that PR, so every PR spends the repo-wide 10 GB budget on an
entry no other job can restore, and evicts the `refs/heads/main` entries that
every PR does restore from. Restore stays unconditional; save is now gated on not
being a pull request.

**`buildAndTestMulti` and `buildAndTestPythons` run twice on what lands.** Both
carry a `push: branches: [main]` trigger while the merge queue already runs them
on the commit that merges, so the push run repeats a result the queue just
produced.

**A runner without ccache is silent about it.** It recompiles every object and
nothing in the log distinguishes that from a cold cache, so the build script now
says which it is.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
