### PR TITLE
[AIE] Name the shortfall and the cores-per-col budget in placement failures [LOW]

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -354,6 +354,17 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                        ? " (compute-peer DMA budget unsatisfiable)"
                        : "");
         }
+        // A cores-per-col budget leaves no trace in the message above: the
+        // tiles it removed are simply absent from `availability.compTiles`.
+        if (coresPerCol.has_value() && deviceCoresPerCol > 0) {
+          int columns = targetModel->columns();
+          diag.attachNote()
+              << "cores-per-col=" << *coresPerCol << " leaves "
+              << columns * *coresPerCol << " of this device's "
+              << columns * deviceCoresPerCol
+              << " compute tiles placeable; raise it, or reduce the design's "
+                 "core count";
+        }
         if (adjacencyWasCause)
           attachPeerNotes(diag, logicalTile, bufferAdjacency, bufferLabel);
         if (hasCascade)

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1283,9 +1283,20 @@ LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
            << diagnosis.outMax << " output channels used";
       diag.attachNote() << "this is the device's total " << tileTypeName
                         << " DMA budget, not a placement choice -- no column "
-                           "has spare capacity to pin to; fan traffic "
-                           "through a MemTile, or reduce the number of "
-                           "DMA-attached ObjectFIFOs feeding this tile";
+                           "has spare capacity to pin to";
+      int shortIn = numInputChannels - (diagnosis.inMax - diagnosis.inUsed);
+      int shortOut = numOutputChannels - (diagnosis.outMax - diagnosis.outUsed);
+      auto &remedy = diag.attachNote();
+      if (shortIn > 0 && shortOut > 0)
+        remedy << "short " << shortIn << " input/" << shortOut
+               << " output channel(s); ";
+      else if (shortIn > 0)
+        remedy << "short " << shortIn << " input channel(s); ";
+      else if (shortOut > 0)
+        remedy << "short " << shortOut << " output channel(s); ";
+      remedy << "fan traffic through a MemTile via aie.objectfifo.link, or "
+                "reduce the number of DMA-attached ObjectFIFOs feeding this "
+                "tile";
     } else {
       diag << "no " << tileTypeName << " has sufficient DMA capacity for "
            << numInputChannels << " input/" << numOutputChannels

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -63,7 +63,8 @@ module @memtile_exhaustion {
     // Global exhaustion: npu1_1col has exactly one MemTile, and it is
     // already fully booked, so no column pin could ever help.
     // CHECK: error: no MemTile on the device has {{[0-9]+ input/[0-9]+ output}} DMA channel(s) free: all 1 MemTile(s) are at {{[0-9]+/[0-9]+}} input, {{[0-9]+/[0-9]+}} output channels used
-    // CHECK: note: this is the device's total MemTile DMA budget
+    // CHECK: note: this is the device's total MemTile DMA budget, not a placement choice
+    // CHECK: note: short 1 output channel(s); fan traffic through a MemTile via aie.objectfifo.link
     %mem7 = aie.logical_tile<MemTile>(?, ?)
 
     aie.objectfifo @of1 (%mem1, {%core1}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
@@ -149,7 +150,8 @@ module @shimnoc_exhaustion {
     // Global exhaustion: npu1_1col has exactly one ShimNOCTile, and it is
     // already fully booked, so no column pin could ever help.
     // CHECK: error: no ShimNOCTile on the device has {{[0-9]+ input/[0-9]+ output}} DMA channel(s) free: all 1 ShimNOCTile(s) are at {{[0-9]+/[0-9]+}} input, {{[0-9]+/[0-9]+}} output channels used
-    // CHECK: note: this is the device's total ShimNOCTile DMA budget
+    // CHECK: note: this is the device's total ShimNOCTile DMA budget, not a placement choice
+    // CHECK: note: short 1 output channel(s); fan traffic through a MemTile via aie.objectfifo.link
     %shim3 = aie.logical_tile<ShimNOCTile>(?, ?)
 
     aie.objectfifo @of1 (%shim1, {%core1}, 2 : i32) : !aie.objectfifo<memref<16xi32>>

--- a/test/place-tiles/sequential_placer/test_place_options.mlir
+++ b/test/place-tiles/sequential_placer/test_place_options.mlir
@@ -8,6 +8,7 @@
 // RUN: aie-opt -split-input-file --aie-place-tiles='cores-per-col=2' %s | FileCheck %s
 // RUN: aie-opt -split-input-file --aie-place-tiles %s | FileCheck %s --check-prefix=NO-LIMIT
 // RUN: not aie-opt -split-input-file --aie-place-tiles='cores-per-col=99' %s 2>&1 | FileCheck %s --check-prefix=EXCEEDS
+// RUN: not aie-opt -split-input-file --aie-place-tiles='cores-per-col=1' %s 2>&1 | FileCheck %s --check-prefix=OVERSUB
 
 // cores-per-col=2 spreads 4 cores across 2 columns
 // CHECK-LABEL: @cores_per_col_limit
@@ -43,5 +44,25 @@ module @cores_per_col_exceeds_device {
   aie.device(npu1) {
     %c1 = aie.logical_tile<CoreTile>(?, ?)
     aie.core(%c1) { aie.end }
+  }
+}
+
+// -----
+
+// cores-per-col leaves fewer tiles than the design needs
+// OVERSUB: error: no available compute tiles for placement
+// OVERSUB: note: cores-per-col=1 leaves 4 of this device's 16 compute tiles placeable
+module @cores_per_col_oversubscribed {
+  aie.device(npu1) {
+    %c0 = aie.logical_tile<CoreTile>(?, ?)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+    %c4 = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%c0) { aie.end }
+    aie.core(%c1) { aie.end }
+    aie.core(%c2) { aie.end }
+    aie.core(%c3) { aie.end }
+    aie.core(%c4) { aie.end }
   }
 }


### PR DESCRIPTION
## Description

Two placement failures name a limit without naming what to do about it.

The DMA-exhaustion diagnostic said a tile "has spare capacity to pin to" and then
listed remedies, without saying how far short the tile actually was. It now
attaches the shortfall — how many input and/or output channels are missing — so
the reader knows whether this is one ObjectFIFO too many or ten.

A `cores-per-col` budget left no trace at all: the tiles it excluded are simply
absent from the availability set, so the message described a device that appeared
to have fewer compute tiles than it has. It now attaches a note giving the budget,
the placeable count it implies, and the device's real total.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
