### PR TITLE
[hrx-xclbinutil] an empty ptree path means the node itself [MED]

### DIFF
--- a/third_party/hrx-xclbinutil/util/hrx_util.h
+++ b/third_party/hrx-xclbinutil/util/hrx_util.h
@@ -751,6 +751,10 @@ private:
   container m_children;
 
   static void splitPath(const std::string &path, std::list<std::string> &out) {
+    // An empty path denotes the node itself, as in boost. Otherwise the loop below pushes
+    // an empty segment and put("", v) lands one level deeper than as_vector_simple reads.
+    if (path.empty())
+      return;
     size_t start = 0, dot;
     while ((dot = path.find('.', start)) != std::string::npos) {
       out.push_back(path.substr(start, dot - start));


### PR DESCRIPTION
## Description

`splitPath("")` pushed one empty segment instead of returning no segments, so
`put("", v)` wrote one level deeper than `as_vector_simple` reads it back. An
empty path denotes the node itself, matching boost's property_tree, which this
class stands in for.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [ ] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] `ruff check` and `pyright` pass locally for any touched Python file in their covered paths (see [CONTRIBUTING](../CONTRIBUTING.md#linting-python))
- [x] `clang-tidy` passes locally for any touched file on the enabled list (see [CONTRIBUTING](../CONTRIBUTING.md#static-analysis-for-c-clang-tidy))
